### PR TITLE
Refactor lexical-graph Logging Utilities for Enhanced Flexibility and Maintainability

### DIFF
--- a/docs/lexical-graph/configuration.md
+++ b/docs/lexical-graph/configuration.md
@@ -102,30 +102,63 @@ The `cache` directory can grow very large, particularly if you are caching extra
 
 ### Logging configuration
 
-The graphrag_toolkit's `set_logging_config` method allows you to set the [logging level](https://docs.python.org/3/library/logging.html#logging-levels), and apply filters to `DEBUG` log lines. Besides the logging level, you can supply an array of prefixes to include when outputting debug information, and an array of prefixes to exclude.
+The `graphrag_toolkit` provides two methods for configuring logging in your application. These methods allow you to set logging levels, apply filters to include or exclude specific modules or messages, and customize logging behavior:
 
-The following example sets the logging level to `DEBUG`, but also applies a filter that specifies that only messages from the storage module are to be emitted:
+- `set_logging_config`
+- `set_advanced_logging_config`
 
-```python
-from graphrag_toolkit.lexical_graph import set_logging_config
+#### set_logging_config
 
-set_logging_config(
-  'DEBUG', 
-  ['graphrag_toolkit.lexical_graph.storage']
-)
-```
-
-The following example sets the logging level to `DEBUG`, together with a filter that specifies that only messages from the storage module are to be emitted, and another filter that excludes messages from the graph store factory within the storage module:
+The `set_logging_config` method allows you to configure logging with a basic set of options, such as logging level and module filters. Wildcards are supported for module names, and you can pass either a single string or a list of strings for included or excluded modules. For example:
 
 ```python
 from graphrag_toolkit.lexical_graph import set_logging_config
 
 set_logging_config(
-  'DEBUG', 
-  ['graphrag_toolkit.lexical_graph.storage'],
-  ['graphrag_toolkit.lexical_graph.storage.graph_store_factory']
+  logging_level='DEBUG',  # or logging.DEBUG
+  debug_include_modules='graphrag_toolkit.lexical_graph.storage',  # single string or list of strings
+  debug_exclude_modules=['opensearch', 'boto']  # single string or list of strings
 )
 ```
+
+#### set_advanced_logging_config
+
+The `set_advanced_logging_config` method provides more advanced logging configuration options, including the ability to specify filters for included and excluded modules or messages based on logging levels. Wildcards are supported only for module names, and you can pass either a single string or a list of strings for modules. This method offers greater flexibility and control over the logging behavior.
+
+##### Parameters
+
+| Parameter           | Type                          | Description                                                                          | Default Value  |
+|---------------------|-------------------------------|--------------------------------------------------------------------------------------|----------------|
+| `logging_level`     | `str` or `int`                | The logging level to apply (e.g., `'DEBUG'`, `'INFO'`, `logging.DEBUG`, etc.).       | `logging.INFO` |
+| `included_modules`  | `dict[int, str \| list[str]]` | Modules to include in logging, grouped by logging level. Wildcards are supported.    | `None`         |
+| `excluded_modules`  | `dict[int, str \| list[str]]` | Modules to exclude from logging, grouped by logging level. Wildcards are supported.  | `None`         |
+| `included_messages` | `dict[int, str \| list[str]]` | Specific messages to include in logging, grouped by logging level.                   | `None`         |
+| `excluded_messages` | `dict[int, str \| list[str]]` | Specific messages to exclude from logging, grouped by logging level.                 | `None`         |
+
+##### Example Usage
+
+Here is an example of how to use `set_advanced_logging_config`:
+
+```python
+import logging
+from graphrag_toolkit.lexical_graph import set_advanced_logging_config
+
+set_advanced_logging_config(
+    logging_level=logging.DEBUG,
+    included_modules={
+        logging.DEBUG: 'graphrag_toolkit',  # single string or list of strings
+        logging.INFO: '*',  # wildcard supported
+    },
+    excluded_modules={
+        logging.DEBUG: ['opensearch', 'boto', 'urllib'],  # single string or list of strings
+        logging.INFO: ['opensearch', 'boto', 'urllib'],  # wildcard supported
+    },
+    excluded_messages={
+        logging.WARNING: 'Removing unpickleable private attribute',  # single string or list of strings
+    }
+)
+```
+
 ### AWS profile configuration
 
 You can explicitly configure the AWS CLI profile and region to use when initializing Bedrock clients or other AWS service clients in `GraphRAGConfig`. This ensures compatibility across local development, EC2/ECS environments, or federated environments such as AWS SSO.

--- a/docs/lexical-graph/configuration.md
+++ b/docs/lexical-graph/configuration.md
@@ -127,13 +127,13 @@ The `set_advanced_logging_config` method provides more advanced logging configur
 
 ##### Parameters
 
-| Parameter           | Type                          | Description                                                                          | Default Value  |
-|---------------------|-------------------------------|--------------------------------------------------------------------------------------|----------------|
-| `logging_level`     | `str` or `int`                | The logging level to apply (e.g., `'DEBUG'`, `'INFO'`, `logging.DEBUG`, etc.).       | `logging.INFO` |
-| `included_modules`  | `dict[int, str \| list[str]]` | Modules to include in logging, grouped by logging level. Wildcards are supported.    | `None`         |
-| `excluded_modules`  | `dict[int, str \| list[str]]` | Modules to exclude from logging, grouped by logging level. Wildcards are supported.  | `None`         |
-| `included_messages` | `dict[int, str \| list[str]]` | Specific messages to include in logging, grouped by logging level.                   | `None`         |
-| `excluded_messages` | `dict[int, str \| list[str]]` | Specific messages to exclude from logging, grouped by logging level.                 | `None`         |
+| Parameter           | Type                          | Description                                                                                 | Default Value  |
+|---------------------|-------------------------------|---------------------------------------------------------------------------------------------|----------------|
+| `logging_level`     | `str` or `int`                | The logging level to apply (e.g., `'DEBUG'`, `'INFO'`, `logging.DEBUG`, etc.).              | `logging.INFO` |
+| `included_modules`  | `dict[int, str \| list[str]]` | Modules to include in logging, grouped by logging level. Wildcards are supported.           | `None`         |
+| `excluded_modules`  | `dict[int, str \| list[str]]` | Modules to exclude from logging, grouped by logging level. Wildcards are supported.         | `None`         |
+| `included_messages` | `dict[int, str \| list[str]]` | Specific messages to include in logging, grouped by logging level. Wildcards are supported. | `None`         |
+| `excluded_messages` | `dict[int, str \| list[str]]` | Specific messages to exclude from logging, grouped by logging level.                        | `None`         |
 
 ##### Example Usage
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/__init__.py
@@ -4,7 +4,7 @@
 from .tenant_id import TenantId, DEFAULT_TENANT_ID, TenantIdType, to_tenant_id
 from .config import GraphRAGConfig as GraphRAGConfig, LLMType, EmbeddingType
 from .errors import ModelError, BatchJobError, IndexError
-from .logging import set_logging_config as set_logging_config
+from .logging import set_logging_config, set_advanced_logging_config
 from .lexical_graph_query_engine import LexicalGraphQueryEngine
 from .lexical_graph_index import LexicalGraphIndex
 from .lexical_graph_index import ExtractionConfig, BuildConfig, IndexingConfig

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
@@ -11,7 +11,7 @@ EXCLUDED_WARNINGS = [
     'Removing unpickleable private attribute'
 ]
 
-class CustomFormatter(logging.Formatter):
+class CompactFormatter(logging.Formatter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
     def format(self, record):
@@ -89,7 +89,7 @@ LOGGING = {
     },
     'formatters': {
         'default': {
-            '()': CustomFormatter,
+            '()': CompactFormatter,
             'fmt': '%(asctime)s:%(levelname)s:%(name)-15s:%(message)s',
             'datefmt': '%Y-%m-%d %H:%M:%S'
         }

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
@@ -12,17 +12,20 @@ EXCLUDED_WARNINGS = [
 ]
 
 class CompactFormatter(logging.Formatter):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-    def format(self, record):
-        saved_name = record.name  
-        parts = saved_name.split('.')
-        record.name = parts[-1]
-        if len(parts) > 1:
-            record.name = f"{'.'.join(p[0] for p in parts[0:-1])}.{parts[-1]}"
+    def format(self, record:logging.LogRecord) -> str:
+        original_record_name = record.name
+        record.name = self._shorten_record_name(record.name)
         result = super().format(record)
-        record.name = saved_name
+        record.name = original_record_name
         return result
+
+    @staticmethod
+    def _shorten_record_name(name:str) -> str:
+        if '.' not in name:
+            return name
+
+        parts = name.split('.')
+        return f"{'.'.join(p[0] for p in parts[0:-1])}.{parts[-1]}"
 
 class ModuleFilter(logging.Filter):
     def __init__(

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
@@ -122,7 +122,7 @@ def set_logging_config(
     )
 
 def set_advanced_logging_config(
-    logging_level:str | LoggingLevel,
+    logging_level:Union[str, LoggingLevel],
     included_modules:Optional[Dict[LoggingLevel, Union[str, List[str]]]]=None,
     excluded_modules:Optional[Dict[LoggingLevel, Union[str, List[str]]]]=None,
     included_messages:Optional[Dict[LoggingLevel, Union[str, List[str]]]]=None,

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import logging
 import logging.config
 from typing import List, Dict, Optional

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/logging.py
@@ -143,10 +143,7 @@ def set_advanced_logging_config(
 
 def _is_valid_logging_level(level: Union[str, LoggingLevel]) -> bool:
     if isinstance(level, int):
-        return level in cast(dict[LoggingLevel, str], logging._levelToName)
+        return level in cast(dict[LoggingLevel, str], logging._levelToName)  # type: ignore
     elif isinstance(level, str):
-        return level.upper() in cast(dict[str, LoggingLevel], logging._nameToLevel)
+        return level.upper() in cast(dict[str, LoggingLevel], logging._nameToLevel)  # type: ignore
     return False
-
-
-


### PR DESCRIPTION
This pull request refactors the logging utilities in the `lexical-graph` module to enhance flexibility and maintainability. Key improvements include readability enhancement, a redesigned module filter with extended functionality, and a new advanced logging configuration function. Only `set_logging_config` is backwards compatible 

### Description of changes
- Replaced `CustomFormatter` with `CompactFormatter`, which includes a new `_shorten_record_name` method to simplify log record names.
- Refactored `ModuleFilter` to support additional filtering options, such as included and excluded messages, alongside modules. The filter logic has been streamlined for better readability and extensibility.
- Introduced `set_advanced_logging_config` to allow more granular logging configuration, including support for included/excluded modules and messages at specific logging levels.
- Replaced `LOGGING` with `BASE_LOGGING_CONFIG` to serve as a reusable template for logging configurations.

If you have suggestions for improving the logging interface, naming conventions, or configuration structure, feel free to share. I'm happy to iterate on this!

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
