### PR TITLE
Remove Query Engine asyncio Overhead (and nest_asyncio)

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/composite_traversal_based_retriever.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/composite_traversal_based_retriever.py
@@ -5,7 +5,8 @@ import logging
 import math
 import concurrent.futures
 from dataclasses import dataclass
-from typing import List, Type, Optional, Union
+from itertools import repeat
+from typing import List, Type, Optional, Union, Iterator, cast
 
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
 from graphrag_toolkit.lexical_graph.storage.vector.vector_store import VectorStore
@@ -14,11 +15,9 @@ from graphrag_toolkit.lexical_graph.retrieval.utils.query_decomposition import Q
 from graphrag_toolkit.lexical_graph.retrieval.retrievers.entity_context_search import EntityContextSearch
 from graphrag_toolkit.lexical_graph.retrieval.retrievers.chunk_based_search import ChunkBasedSearch
 from graphrag_toolkit.lexical_graph.retrieval.retrievers.keyword_entity_search import KeywordEntitySearch
-from graphrag_toolkit.lexical_graph.retrieval.processors import *
 from graphrag_toolkit.lexical_graph.retrieval.model import SearchResultCollection, SearchResult, ScoredEntity, Entity
 
-from llama_index.core.schema import QueryBundle
-from llama_index.core.async_utils import run_async_tasks
+from llama_index.core.schema import QueryBundle, NodeWithScore
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +56,7 @@ class CompositeTraversalBasedRetriever(TraversalBasedBaseRetriever):
     def get_start_node_ids(self, query_bundle: QueryBundle) -> List[str]:
         return []
     
-    async def _get_search_results_for_query(self, query_bundle: QueryBundle) -> SearchResultCollection:
+    def _get_search_results_for_query(self, query_bundle: QueryBundle) -> SearchResultCollection:
 
         def weighted_arg(v, weight, factor):
             multiplier = min(1, weight * factor)
@@ -111,17 +110,13 @@ class CompositeTraversalBasedRetriever(TraversalBasedBaseRetriever):
         search_results = []
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.args.num_workers) as executor:
-            
-            futures = [
-                executor.submit(r.aretrieve, query_bundle)
-                for r in retrievers
-            ]
-            
-            executor.shutdown()
-
-            for future in futures:
-                for scored_node in await future.result():
-                    search_results.append(SearchResult.model_validate_json(scored_node.node.text))
+            scored_node_batches: Iterator[List[NodeWithScore]] = executor.map(
+                lambda r, query: r.retrieve(query),
+                retrievers,
+                repeat(query_bundle)
+            )
+            scored_nodes = sum(scored_node_batches, start=cast(List[NodeWithScore], []))
+            search_results = [SearchResult.model_validate_json(scored_node.node.text) for scored_node in scored_nodes]
         
         return SearchResultCollection(results=search_results, entities=entities)
             
@@ -135,12 +130,8 @@ class CompositeTraversalBasedRetriever(TraversalBasedBaseRetriever):
             else [query_bundle]
         )
 
-        tasks = [
-            self._get_search_results_for_query(subquery) 
-            for subquery in subqueries
-        ]
-            
-        task_results:List[SearchResultCollection] = run_async_tasks(tasks)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(subqueries)) as p:
+            task_results = list(p.map(self._get_search_results_for_query, subqueries))
 
         for task_result in task_results:
             for search_result in task_result.results:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/keyword_entity_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/keyword_entity_search.py
@@ -1,9 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
+import concurrent.futures
 import logging
 import asyncio
-from typing import List
+from itertools import repeat
+from typing import List, Iterator, cast
 
 from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
@@ -15,7 +16,6 @@ from graphrag_toolkit.lexical_graph.retrieval.prompts import SIMPLE_EXTRACT_KEYW
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
-from llama_index.core.async_utils import run_async_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -127,54 +127,47 @@ class KeywordEntitySearch(BaseRetriever):
 
         return scored_entities
         
-    async def _get_entities_for_keyword(self, keyword:str) -> List[ScoredEntity]:
+    def _get_entities_for_keyword(self, keyword:str) -> List[ScoredEntity]:
+        parts = keyword.split('|')
 
-        def blocking_query():
+        if len(parts) > 1:
 
-            parts = keyword.split('|')
+            cypher = f"""
+            // get entities for keywords
+            MATCH (entity:`__Entity__`)-[r:`__SUBJECT__`|`__OBJECT__`]->(:`__Fact__`)
+            WHERE entity.search_str = $keyword and entity.class STARTS WITH $classification
+            WITH entity, count(r) AS score ORDER BY score DESC
+            RETURN {{
+                {node_result('entity', self.graph_store.node_id('entity.entityId'), properties=['value', 'class'])},
+                score: score
+            }} AS result"""
 
-            if len(parts) > 1:
+            params = {
+                'keyword': search_string_from(parts[0]),
+                'classification': parts[1]
+            }
+        else:
+            cypher = f"""
+            // get entities for keywords
+            MATCH (entity:`__Entity__`)-[r:`__SUBJECT__`|`__OBJECT__`]->(:`__Fact__`)
+            WHERE entity.search_str = $keyword
+            WITH entity, count(r) AS score ORDER BY score DESC
+            RETURN {{
+                {node_result('entity', self.graph_store.node_id('entity.entityId'), properties=['value', 'class'])},
+                score: score
+            }} AS result"""
 
-                cypher = f"""
-                // get entities for keywords
-                MATCH (entity:`__Entity__`)-[r:`__SUBJECT__`|`__OBJECT__`]->(:`__Fact__`)
-                WHERE entity.search_str = $keyword and entity.class STARTS WITH $classification
-                WITH entity, count(r) AS score ORDER BY score DESC
-                RETURN {{
-                    {node_result('entity', self.graph_store.node_id('entity.entityId'), properties=['value', 'class'])},
-                    score: score
-                }} AS result"""
+            params = {
+                'keyword': search_string_from(parts[0])
+            }
 
-                params = {
-                    'keyword': search_string_from(parts[0]),
-                    'classification': parts[1]
-                }
-            else:
-                cypher = f"""
-                // get entities for keywords
-                MATCH (entity:`__Entity__`)-[r:`__SUBJECT__`|`__OBJECT__`]->(:`__Fact__`)
-                WHERE entity.search_str = $keyword
-                WITH entity, count(r) AS score ORDER BY score DESC
-                RETURN {{
-                    {node_result('entity', self.graph_store.node_id('entity.entityId'), properties=['value', 'class'])},
-                    score: score
-                }} AS result"""
+        results = self.graph_store.execute_query(cypher, params)
 
-                params = {
-                    'keyword': search_string_from(parts[0])
-                }
-
-            results = self.graph_store.execute_query(cypher, params)
-
-            return [
-                ScoredEntity.model_validate(result['result'])
-                for result in results
-                if result['result']['score'] != 0
-            ]
-
-        coro = asyncio.to_thread(blocking_query)
-        
-        return await coro
+        return [
+            ScoredEntity.model_validate(result['result'])
+            for result in results
+            if result['result']['score'] != 0
+        ]
                         
     def _get_entities_for_keywords(self, keywords:List[str])  -> List[ScoredEntity]:
         
@@ -184,17 +177,17 @@ class KeywordEntitySearch(BaseRetriever):
             if keyword
         ]
 
-        task_results:List[List[ScoredEntity]] = run_async_tasks(tasks)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(keywords)) as p:
+            scored_entity_batches:Iterator[List[ScoredEntity]] = p.map(self._get_entities_for_keyword, keywords)
+            scored_entities = sum(scored_entity_batches, start=cast(List[ScoredEntity], []))
 
         scored_entity_mappings = {}
-
-        for result in task_results:
-            for scored_entity in result:
-                entity_id = scored_entity.entity.entityId
-                if entity_id not in scored_entity_mappings:
-                    scored_entity_mappings[entity_id] = scored_entity
-                else:
-                    scored_entity_mappings[entity_id].score += scored_entity.score
+        for scored_entity in scored_entities:
+            entity_id = scored_entity.entity.entityId
+            if entity_id not in scored_entity_mappings:
+                scored_entity_mappings[entity_id] = scored_entity
+            else:
+                scored_entity_mappings[entity_id].score += scored_entity.score
 
         scored_entities = list(scored_entity_mappings.values())
 
@@ -236,29 +229,21 @@ class KeywordEntitySearch(BaseRetriever):
         return enriched_keywords
 
     def _get_keywords(self, query, max_keywords):
-        
-        def add_keyword(k):
-            if k not in keywords:
-                keywords.append(k)
-        
-        keywords = [] 
 
         num_keywords = max(int(max_keywords/2), 1)
 
-        tasks = [
-            self._get_simple_keywords(query, num_keywords),
-            self._get_enriched_keywords(query, num_keywords),
-        ]
+        with concurrent.futures.ThreadPoolExecutor() as p:
+            keyword_batches: Iterator[List[str]] = p.map(
+                lambda f, *args: f(*args),
+                (self._get_simple_keywords, self._get_enriched_keywords),
+                repeat(query, num_keywords)
+            )
+            keywords = sum(keyword_batches, start=cast(List[str], []))
+            unique_keywords = list(set(keywords))
 
-        task_results = run_async_tasks(tasks)
-
-        for result in task_results:
-            for keyword in result:
-                add_keyword(keyword)
-
-        logger.debug(f'Keywords: {keywords}')
+        logger.debug(f'Keywords: {unique_keywords}')
         
-        return keywords
+        return unique_keywords
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/semantic_guided_retriever.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/semantic_guided_retriever.py
@@ -4,9 +4,9 @@ import concurrent.futures
 import logging
 from collections import defaultdict
 from typing import List, Optional, Any, Union, Type
+from itertools import repeat
 
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
-from numpy.ma.core import repeat
 
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
 from graphrag_toolkit.lexical_graph.storage.vector import VectorStore
@@ -78,103 +78,98 @@ class SemanticGuidedRetriever(SemanticGuidedBaseRetriever):
             ]
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        try:
-            # 1. Get initial results in parallel
-            with concurrent.futures.ThreadPoolExecutor(max_workers=len(self.initial_retrievers)) as p:
-                initial_results = list(p.map(
-                    lambda r, query: r.retrieve(query), 
-                    self.initial_retrievers, 
-                    repeat(query_bundle)
-                ))
-            
-            logger.debug(f'initial_results: {initial_results}')
+        # 1. Get initial results in parallel
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(self.initial_retrievers)) as p:
+            initial_results = list(p.map(
+                lambda r, query: r.retrieve(query), 
+                self.initial_retrievers, 
+                repeat(query_bundle)
+            ))
+        
+        logger.debug(f'initial_results: {initial_results}')
 
-            # 2. Collect unique initial nodes
-            seen_statement_ids = set()
-            initial_nodes = []
-            for nodes in initial_results:
-                for node in nodes:
-                    statement_id = node.node.metadata['statement']['statementId']
-                    if statement_id not in seen_statement_ids:
-                        seen_statement_ids.add(statement_id)
-                        initial_nodes.append(node)
-
-            all_nodes = initial_nodes.copy()
-            
-            logger.debug(f'all_nodes (before expansion): {all_nodes}')
-
-            # 3. Graph expansion if enabled
-            if self.share_results and initial_nodes:
-                for retriever in self.graph_retrievers:
-                    try:
-                        retriever.shared_nodes = initial_nodes
-                        graph_nodes = retriever.retrieve(query_bundle)
-                        for node in graph_nodes:
-                            statement_id = node.node.metadata['statement']['statementId']
-                            if statement_id not in seen_statement_ids:
-                                seen_statement_ids.add(statement_id)
-                                all_nodes.append(node)
-                    except Exception as e:
-                        logger.error(f"Error in graph retriever {retriever.__class__.__name__}: {e}")
-                        continue
-                        
-            logger.debug(f'all_nodes (after expansion): {all_nodes}')
-
-            # 4. Fetch statements once
-            if not all_nodes:
-                return []
-
-            statement_ids = [
-                node.node.metadata['statement']['statementId'] 
-                for node in all_nodes
-            ]
-            statements = get_statements_query(self.graph_store, statement_ids)
-            
-            logger.debug(f'statements: {statements}')
-
-            # 5. Create final nodes with full data
-            final_nodes = []
-            statements_map = {
-                s['result']['statement']['statementId']: s['result'] 
-                for s in statements
-            }
-            
-            for node in all_nodes:
+        # 2. Collect unique initial nodes
+        seen_statement_ids = set()
+        initial_nodes = []
+        for nodes in initial_results:
+            for node in nodes:
                 statement_id = node.node.metadata['statement']['statementId']
-                if statement_id in statements_map:
-                    result = statements_map[statement_id]
-                    new_node = TextNode(
-                        text=result['statement']['value'],
-                        metadata={
-                            **node.node.metadata,  # Preserve retriever metadata
-                            'statement': result['statement'],
-                            'chunk': result['chunk'],
-                            'source': result['source']                     
-                        }
-                    )
-                    final_nodes.append(NodeWithScore(
-                        node=new_node,
-                        score=node.score
-                    ))
+                if statement_id not in seen_statement_ids:
+                    seen_statement_ids.add(statement_id)
+                    initial_nodes.append(node)
+
+        all_nodes = initial_nodes.copy()
+        
+        logger.debug(f'all_nodes (before expansion): {all_nodes}')
+
+        # 3. Graph expansion if enabled
+        if self.share_results and initial_nodes:
+            for retriever in self.graph_retrievers:
+                try:
+                    retriever.shared_nodes = initial_nodes
+                    graph_nodes = retriever.retrieve(query_bundle)
+                    for node in graph_nodes:
+                        statement_id = node.node.metadata['statement']['statementId']
+                        if statement_id not in seen_statement_ids:
+                            seen_statement_ids.add(statement_id)
+                            all_nodes.append(node)
+                except Exception as e:
+                    logger.error(f"Error in graph retriever {retriever.__class__.__name__}: {e}")
+                    continue
                     
-            logger.debug(f'final_nodes: {final_nodes}')
+        logger.debug(f'all_nodes (after expansion): {all_nodes}')
 
-            # 6. Group by source for better context
-            source_nodes = defaultdict(list)
-            for node in final_nodes:
-                source_id = node.node.metadata['source']['sourceId']
-                source_nodes[source_id].append(node)
-
-            # 7. Create final ordered list
-            ordered_nodes = []
-            for source_id, nodes in source_nodes.items():
-                nodes.sort(key=lambda x: x.score or 0.0, reverse=True)
-                ordered_nodes.extend(nodes)
-                
-            logger.debug(f'ordered_nodes: {ordered_nodes}')
-
-            return ordered_nodes
-
-        except Exception as e:
-            logger.error(f"Error in StatementGraphRetriever: {e}")
+        # 4. Fetch statements once
+        if not all_nodes:
             return []
+
+        statement_ids = [
+            node.node.metadata['statement']['statementId'] 
+            for node in all_nodes
+        ]
+        statements = get_statements_query(self.graph_store, statement_ids)
+        
+        logger.debug(f'statements: {statements}')
+
+        # 5. Create final nodes with full data
+        final_nodes = []
+        statements_map = {
+            s['result']['statement']['statementId']: s['result'] 
+            for s in statements
+        }
+        
+        for node in all_nodes:
+            statement_id = node.node.metadata['statement']['statementId']
+            if statement_id in statements_map:
+                result = statements_map[statement_id]
+                new_node = TextNode(
+                    text=result['statement']['value'],
+                    metadata={
+                        **node.node.metadata,  # Preserve retriever metadata
+                        'statement': result['statement'],
+                        'chunk': result['chunk'],
+                        'source': result['source']                     
+                    }
+                )
+                final_nodes.append(NodeWithScore(
+                    node=new_node,
+                    score=node.score
+                ))
+                
+        logger.debug(f'final_nodes: {final_nodes}')
+
+        # 6. Group by source for better context
+        source_nodes = defaultdict(list)
+        for node in final_nodes:
+            source_id = node.node.metadata['source']['sourceId']
+            source_nodes[source_id].append(node)
+
+        # 7. Create final ordered list
+        ordered_nodes = []
+        for source_id, nodes in source_nodes.items():
+            nodes.sort(key=lambda x: x.score or 0.0, reverse=True)
+            ordered_nodes.extend(nodes)
+            
+        logger.debug(f'ordered_nodes: {ordered_nodes}')
+
+        return ordered_nodes


### PR DESCRIPTION
This pull request refactors several components of the `lexical-graph` retrieval system by removing asynchronous code and replacing it with synchronous, thread-based implementations using `concurrent.futures`. The changes aim to simplify the codebase, improve maintainability, and ensure better compatibility with environments where asynchronous execution is not ideal.
In particular this PR targets removal of `nest_asyncio` dependency.

### Description of changes
#### Transition from Asynchronous to Thread-Based Execution:

* **Statement Enhancement (`statement_enhancement.py`)**:
  - Replaced the `asyncio`-based `enhance_statement` method with a synchronous implementation using `ThreadPoolExecutor` for concurrent processing of nodes.

* **Composite Traversal-Based Retriever (`composite_traversal_based_retriever.py`)**:
  - Converted `_get_search_results_for_query` and `do_graph_search` methods to use `ThreadPoolExecutor` instead of `asyncio` tasks for parallel query execution.

* **Keyword Entity Search (`keyword_entity_search.py`)**:
  - Refactored `_get_entities_for_keywords` and `_extract_keywords` to use `ThreadPoolExecutor` for parallel keyword processing and LLM calls.

* **Keyword Ranking Search (`keyword_ranking_search.py`)**:
  - Updated `get_keywords` to use `ThreadPoolExecutor` for extracting keywords and synonyms concurrently.

* **Semantic Guided Retriever (`semantic_guided_retriever.py`)**:
  - Replaced `run_async_tasks` with `ThreadPoolExecutor` for parallel retrieval using initial retrievers.

#### Removal of Unused Imports and Simplification:

* **General Cleanup**:
  - Removed unused imports such as `asyncio` and `run_async_tasks` across multiple files. This reduces dependencies and improves readability.

These changes collectively simplify the codebase by removing asynchronous complexity, making it easier to maintain and debug. The use of `ThreadPoolExecutor` ensures that the system can still perform concurrent operations efficiently.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
