### PR TITLE
Add FalkorDB support for Traversal Based Retriever

### DIFF
--- a/lexical-graph-contrib/falkordb/src/graphrag_toolkit/lexical_graph/storage/graph/falkordb/falkordb_graph_store.py
+++ b/lexical-graph-contrib/falkordb/src/graphrag_toolkit/lexical_graph/storage/graph/falkordb/falkordb_graph_store.py
@@ -179,16 +179,7 @@ class FalkorDBDatabaseClient(GraphStore):
 
         end = time.time()
 
-        results = None
-
-        if response.header:
-            key = response.header[0][1]
-            results = [
-                {key: json.loads(json.dumps(n[0]))}
-                for n in response.result_set
-            ]
-        else:
-            results = response.result_set
+        results = [{h[1]: d[i] for i, h in enumerate(response.header)} for d in response.result_set]
 
         if logger.isEnabledFor(logging.DEBUG):
             response_log_entry_parameters = self.log_formatting.format_log_entry(

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/traversal_based_base_retriever.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/traversal_based_base_retriever.py
@@ -61,7 +61,7 @@ class TraversalBasedBaseRetriever(BaseRetriever):
         MATCH (l:`__Statement__`)-[:`__MENTIONED_IN__`]->(c:`__Chunk__`)-[:`__EXTRACTED_FROM__`]->(s:`__Source__`)
         OPTIONAL MATCH (f:`__Fact__`)-[:`__SUPPORTS__`]->(l:`__Statement__`)
         WITH {{ sourceId: {self.graph_store.node_id("s.sourceId")}, metadata: s{{.*}}}} AS source,
-            t,
+            t, l, c,
             {{ chunkId: {self.graph_store.node_id("c.chunkId")}, value: NULL }} AS cc, 
             {{ statementId: {self.graph_store.node_id("l.statementId")}, statement: l.value, facts: collect(distinct f.value), details: l.details, chunkId: {self.graph_store.node_id("c.chunkId")}, score: count(l) }} as ll
         WITH source, 
@@ -76,7 +76,7 @@ class TraversalBasedBaseRetriever(BaseRetriever):
             }} as topic
         RETURN {{
             score: sum(size(topic.statements)/size(topic.chunks)), 
-            source: source,
+            source: head(collect(source)),
             topics: collect(distinct topic)
         }} as result ORDER BY result.score DESC LIMIT $limit'''
 


### PR DESCRIPTION
This PR introduces preliminary support for using the **Traversal Based Retriever** with **FalkorDB**

### Description of changes

1. **Traversal Compatibility with FalkorDB**  
   Adjusted the query generation to enable traversal-based retrieval in FalkorDB.  
   ✅ **With this PR, it is now possible to query FalkorDB using the Traversal Based Retriever.**  
   ⚠️ Compatibility with other graph stores has *not* been verified and may require adjustments.

2. **Internal FalkorDB Response Fixes**  
   Improved the internal structuring of FalkorDB responses. Previously, some keys or values could be omitted in certain cases. This should now be more reliable and consistent.

3. **Amazon Neptune / Other Graph DBs Not Tested**  
   I do *not* have access to Amazon-hosted graph DBs, so these changes haven't been tested outside of FalkorDB.

> ⚠️ **Note:** This PR is **not** ready to be merged yet. The intention is to provide a tested implementation for FalkorDB and gather feedback regarding broader compatibility and stability across other graph databases.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
