### PR TITLE
Resolve string formatting error

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -292,7 +292,7 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
         return response
 
     def execute_query(self, cypher, parameters={}):
-        logger.info("GraphQuery::", cypher)
+        logger.info(f"GraphQuery:: {cypher}")
         response =  self.neptune_client.execute_query(
             graphIdentifier=self.neptune_graph_id,
             queryString=cypher,
@@ -469,7 +469,7 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
 
 
     def execute_query(self, cypher, parameters={}):
-        logger.info("GraphQuery::", cypher)
+        logger.info(f"GraphQuery:: {cypher}")
         response = self.neptune_data_client.execute_open_cypher_query(
             openCypherQuery=cypher,
             parameters=json.dumps(parameters)


### PR DESCRIPTION

*Description of changes:*
Fixed log statement in execute_query functions.

logger.info expects arguments as (msg, *args, **kwargs), where *args are the arguments which are merged into msg using string formatting operator.

current log statement results in error "not all arguments converted during string formatting"


