### PR TITLE
Fix failing install on AL2

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -11,6 +11,7 @@ numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3
 pytest==8.4.2
+tiktoken==0.11.0
 thefuzz==0.22.1
 torch==2.6.0
 transformers>=4.44.2


### PR DESCRIPTION
Fix failing install due to https://github.com/openai/tiktoken/issues/456 not having wheels compatible with AL2
