### PR TITLE
Add sentence-transformers to requirements

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -11,6 +11,7 @@ numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3
 pytest==8.4.2
+sentence-transformers>=2.4.0
 tiktoken==0.11.0
 thefuzz==0.22.1
 torch==2.8.0


### PR DESCRIPTION
Related issue: https://github.com/langchain-ai/langchain/discussions/23623

*Issue #, if available:*

**Notebook**: https://github.com/awslabs/graphrag-toolkit/blob/main/examples/byokg-rag/byokg_rag_neptune_analytics_embeddings.ipynb


**Code cell**: 

```
from graphrag_toolkit.byokg_rag.indexing import LocalFaissDenseIndex, HuggingFaceEmbedding


embedding_model = HuggingFaceEmbedding(model_name="BAAI/bge-m3",
                                       model_kwargs={"device":"cpu"}, #change to 'cuda' if gpu is available
                                       encode_kwargs={"batch_size": 8},
                                       multi_process=True,
                                       show_progress=True)

```

**Error**: 
```
ImportError: Could not import sentence_transformers python package. Please install it with `pip install sentence-transformers`.
```

*Description of changes:*
Adding sentence-transformers to requirements.txt to avoid error. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
