### PR TITLE
Add None check for reranker when pruning triplets

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
@@ -144,7 +144,7 @@ class AgenticRetriever(GRetriever):
 
             # Verbalize and prune triplets
             text_triplets = self.graph_verbalizer.verbalize_merge_triplets(current_entity_relations_list)
-            if len(text_triplets) > self.max_num_triplets:
+            if len(text_triplets) > self.max_num_triplets and self.pruning_reranker is not None:
                 text_triplets, ids = self.pruning_reranker.rerank_input_with_query(
                     query, text_triplets, topk=self.max_num_triplets
                 )


### PR DESCRIPTION
We could also do e.g.

            # Verbalize and prune triplets
            text_triplets = self.graph_verbalizer.verbalize_merge_triplets(current_entity_relations_list)
            if len(text_triplets) > self.max_num_triplets:
                if self.pruning_reranker is not None:
                    # We have a reranker available, so we use it.
                    text_triplets, ids = self.pruning_reranker.rerank_input_with_query(
                        query, text_triplets, topk=self.max_num_triplets
                    )
                else:
                    # We don't have a reranker, so we just take the first max_num_triplets,
                    # and corresponding ids of the first max_num_triplets.
                    text_triplets = text_triplets[:self.max_num_triplets]
                    ids = ids[:self.max_num_triplets]

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
