### PR TITLE
fix: fixing cypher typo for ebtity->entity

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/entity_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/entity_vss_provider.py
@@ -47,7 +47,7 @@ class EntityVSSProvider(EntityProviderBase):
             MATCH (t:`__Topic__`)<-[:`__BELONGS_TO__`]-(:`__Statement__`)
             <-[:`__SUPPORTS__`]-()<-[:`__SUBJECT__`|`__OBJECT__`]-(entity)
             WHERE {self.graph_store.node_id("t.topicId")} in $nodeIds
-            AND ebtity.class <> '__Local_Entity__'
+            AND entity.class <> '__Local_Entity__'
             WITH DISTINCT entity
             MATCH (entity)-[r:`__SUBJECT__`|`__OBJECT__`]->()
             WITH entity, count(r) AS score ORDER BY score DESC LIMIT $limit


### PR DESCRIPTION
In EntityVSSProvider._get_entities_for_nodes() there is a typo in the Cypher query. 

"ebtity" is meant to be "entity"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
