### PR TITLE
feat: Add batch number to extraction and build pipeline log messages

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -291,16 +291,16 @@ class BuildPipeline():
         """
         input_source_documents = source_documents_from_source_types(inputs)
 
-        for source_documents in iter_batch(input_source_documents, self.batch_size):
+        for batch_num, source_documents in enumerate(iter_batch(input_source_documents, self.batch_size), 1):
 
             build_timestamp = int(time.time() * 1000)
 
             num_source_docs_per_batch = math.ceil(len(source_documents)/self.num_workers)
             source_doc_batches = iter_batch(source_documents, num_source_docs_per_batch)
-            
+
             node_batches:List[List[BaseNode]] = self._to_node_batches(source_doc_batches, build_timestamp)
 
-            logger.info(f'Running build pipeline [batch_size: {self.batch_size}, num_workers: {self.num_workers}, job_sizes: {[len(b) for b in node_batches]}, batch_writes_enabled: {self.batch_writes_enabled}, batch_write_size: {self.batch_write_size}]')
+            logger.info(f'Running build pipeline [batch: {batch_num}, batch_size: {self.batch_size}, num_workers: {self.num_workers}, job_sizes: {[len(b) for b in node_batches]}, batch_writes_enabled: {self.batch_writes_enabled}, batch_write_size: {self.batch_write_size}]')
 
             output_nodes = run_pipeline(
                 self.inner_pipeline,

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -370,7 +370,7 @@ class ExtractionPipeline():
 
         input_source_documents = source_documents_from_source_types(inputs)
 
-        for source_documents in iter_batch(input_source_documents, self.batch_size):
+        for batch_num, source_documents in enumerate(iter_batch(input_source_documents, self.batch_size), 1):
 
             for pre_processor in self.pre_processors:
                 source_documents = pre_processor.parse_source_docs(source_documents)
@@ -383,14 +383,14 @@ class ExtractionPipeline():
                 for sd in source_documents
                 for n in sd.nodes
             ]
-            
+
             filtered_input_nodes = [
-                node 
-                for node in input_nodes 
-                if self.extraction_filters.filter_source_metadata_dictionary(get_source_metadata(node)) 
+                node
+                for node in input_nodes
+                if self.extraction_filters.filter_source_metadata_dictionary(get_source_metadata(node))
             ]
 
-            logger.info(f'Running extraction pipeline [batch_size: {self.batch_size}, num_workers: {self.num_workers}]')
+            logger.info(f'Running extraction pipeline [batch: {batch_num}, batch_size: {self.batch_size}, num_workers: {self.num_workers}]')
             
             node_batches = node_batcher(
                 num_batches=self.num_workers, 


### PR DESCRIPTION
## Summary

- Adds a 1-based batch counter (`batch: N`) to the `INFO`-level log messages emitted at the start of each extraction and build batch
- Makes it easy to track overall pipeline progress when processing large document sets (e.g. `batch: 12` with a known total of 25 batches = ~48% done)

## Motivation

When running `extract_and_build()` on hundreds of documents, the pipeline processes them in batches (controlled by `EXTRACTION_BATCH_SIZE` / `BUILD_BATCH_SIZE`). Currently, every batch logs an identical message:

```
Running extraction pipeline [batch_size: 8, num_workers: 4]
Running build pipeline [batch_size: 8, num_workers: 4, job_sizes: [...], ...]
```

There is no way to tell which batch is being processed without manually counting log occurrences. This change adds `batch: N` to both messages:

```
Running extraction pipeline [batch: 3, batch_size: 8, num_workers: 4]
Running build pipeline [batch: 3, batch_size: 8, num_workers: 4, job_sizes: [...], ...]
```

## Changes

- `extraction_pipeline.py`: Added `enumerate(..., 1)` to `iter_batch` loop and `batch: {batch_num}` to log message
- `build_pipeline.py`: Same change

🤖 Generated with [Claude Code](https://claude.com/claude-code)