### PR TITLE
Add unit tests for hash utils, ID generation, and reranker utils

### DIFF
--- a/lexical-graph/tests/unit/test_id_generator.py
+++ b/lexical-graph/tests/unit/test_id_generator.py
@@ -1,0 +1,228 @@
+"""Tests for IdGenerator (id_generator.py).
+
+IdGenerator produces stable, deterministic IDs for every node type in the graph:
+sources, chunks, entities, topics, statements, and facts. All IDs are MD5 hashes
+of normalized strings so the same real-world content always maps to the same node,
+enabling deduplication without a central registry.
+
+ID hierarchy
+------------
+  source_id  = aws::<hash(text)[:8]>:<hash(metadata)[:4]>
+  chunk_id   = <source_id>:<hash(text + metadata)[:8]>   ← child of source
+  topic_id   = hash("topic::<source_id>::<topic>")        ← child of source
+  statement_id = hash("statement::<topic_id>::<stmt>")    ← child of topic
+  fact_id    = hash("fact::<value>")                      ← global (no parent)
+  entity_id  = hash("entity::<value>[:: <class>]")        ← global
+
+Tenant isolation
+----------------
+Source IDs are hashed from raw content with no tenant prefix — they are NOT
+tenant-scoped by design. Tenant context is injected later via rewrite_id_for_tenant.
+All other node types go through format_hashable, which prepends the tenant prefix
+before hashing, so they are fully isolated between tenants.
+
+Known issues documented here
+-----------------------------
+- create_chunk_id has no delimiter between text and metadata before hashing,
+  so boundary-shifted inputs that concatenate to the same string will collide.
+- IdGenerator.__init__ uses `value or config_default` semantics, which means
+  explicitly passing include_classification_in_entity_id=False is silently ignored
+  because False is falsy. The workaround is to set the field directly after construction.
+"""
+
+import re
+
+import pytest
+from graphrag_toolkit.lexical_graph.tenant_id import TenantId
+from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+
+
+# --- create_source_id ---
+
+
+def test_create_source_id_format(default_id_gen):
+    """Source ID matches the expected 'aws::<8 hex>:<4 hex>' pattern.
+
+    The first segment is the first 8 chars of hash(text), the second is
+    the first 4 chars of hash(metadata). Fixed lengths keep IDs compact.
+    """
+    result = default_id_gen.create_source_id("text", "meta")
+    assert re.match(r"aws::[a-f0-9]{8}:[a-f0-9]{4}$", result)
+
+
+def test_create_source_id_deterministic(default_id_gen):
+    """Same text + metadata always produces the same source ID."""
+    assert default_id_gen.create_source_id("text", "meta") == default_id_gen.create_source_id("text", "meta")
+
+
+def test_create_source_id_different_text(default_id_gen):
+    """Changing the text changes the source ID (first hash segment)."""
+    assert default_id_gen.create_source_id("text_a", "meta") != default_id_gen.create_source_id("text_b", "meta")
+
+
+def test_create_source_id_different_metadata(default_id_gen):
+    """Changing the metadata changes the source ID (second hash segment)."""
+    assert default_id_gen.create_source_id("text", "meta_a") != default_id_gen.create_source_id("text", "meta_b")
+
+
+# --- create_chunk_id ---
+
+
+def test_create_chunk_id_hierarchical(default_id_gen):
+    """Chunk ID starts with its parent source ID, encoding the parent-child relationship."""
+    source_id = default_id_gen.create_source_id("text", "meta")
+    chunk_id = default_id_gen.create_chunk_id(source_id, "chunk text", "chunk meta")
+    assert chunk_id.startswith(source_id + ":")
+
+
+def test_create_chunk_id_deterministic(default_id_gen):
+    """Same inputs always produce the same chunk ID."""
+    source_id = default_id_gen.create_source_id("text", "meta")
+    id1 = default_id_gen.create_chunk_id(source_id, "chunk", "meta")
+    id2 = default_id_gen.create_chunk_id(source_id, "chunk", "meta")
+    assert id1 == id2
+
+
+def test_create_chunk_id_concatenation_boundary(default_id_gen):
+    """Known behavior: text and metadata are concatenated with no delimiter before
+    hashing. Inputs whose concatenations are identical — e.g. ('foo', 'bar') and
+    ('foob', 'ar') both produce 'foobar' — hash to the same value and collide.
+
+    This is a documented limitation, not a bug we are fixing here.
+    """
+    source_id = default_id_gen.create_source_id("text", "meta")
+    id1 = default_id_gen.create_chunk_id(source_id, "foo", "bar")
+    id2 = default_id_gen.create_chunk_id(source_id, "foob", "ar")
+    assert id1 == id2  # both hash "foobar"
+
+
+# --- create_entity_id ---
+
+
+def test_create_entity_id_classification_matters_when_enabled(default_id_gen):
+    """With classification enabled, 'Amazon/Company' and 'Amazon/River' are distinct nodes."""
+    assert default_id_gen.create_entity_id("Amazon", "Company") != default_id_gen.create_entity_id("Amazon", "River")
+
+
+def test_create_entity_id_classification_ignored_when_disabled(default_tenant):
+    """With classification disabled, entity identity depends only on value — so
+    'Amazon/Company' and 'Amazon/River' collapse to the same node.
+
+    SOURCE BUG: IdGenerator.__init__ uses
+        `include_classification_in_entity_id or GraphRAGConfig.include_classification_in_entity_id`
+    Because False is falsy, passing False is silently overridden by the config default (True).
+    Workaround: set the field directly on the instance after construction.
+    """
+    gen = IdGenerator(tenant_id=default_tenant, include_classification_in_entity_id=True)
+    gen.include_classification_in_entity_id = False
+    assert gen.create_entity_id("Amazon", "Company") == gen.create_entity_id("Amazon", "River")
+
+
+def test_create_entity_id_case_insensitive(default_id_gen):
+    """Entity values are lowercased before hashing, so 'Amazon' and 'amazon' are the same node."""
+    assert default_id_gen.create_entity_id("Amazon", "Company") == default_id_gen.create_entity_id("amazon", "Company")
+
+
+def test_create_entity_id_space_normalization(default_id_gen):
+    """Spaces are replaced with underscores before hashing, so 'New York' and 'new york' collide."""
+    assert default_id_gen.create_entity_id("New York", "Location") == default_id_gen.create_entity_id("new york", "Location")
+
+
+# --- create_topic_id ---
+
+
+def test_create_topic_id_source_scoping(default_id_gen):
+    """Topics are scoped to their source: the same topic name under two different
+    sources produces two different topic IDs, avoiding cross-document contamination.
+    """
+    assert default_id_gen.create_topic_id("source_a", "Climate") != default_id_gen.create_topic_id("source_b", "Climate")
+
+
+def test_create_topic_id_deterministic(default_id_gen):
+    """Same source + topic always produces the same topic ID."""
+    assert default_id_gen.create_topic_id("source", "Climate") == default_id_gen.create_topic_id("source", "Climate")
+
+
+# --- create_statement_id ---
+
+
+def test_create_statement_id_topic_scoping(default_id_gen):
+    """Statements are scoped to their parent topic: the same statement text under two
+    different topics produces different statement IDs.
+    """
+    id1 = default_id_gen.create_statement_id("topic_a", "CO2 warms Earth")
+    id2 = default_id_gen.create_statement_id("topic_b", "CO2 warms Earth")
+    assert id1 != id2
+
+
+# --- create_fact_id ---
+
+
+def test_create_fact_id_global_dedup(default_id_gen):
+    """Facts are globally deduplicated: the same fact text always maps to the same ID
+    regardless of which document or topic it appeared in.
+    """
+    assert default_id_gen.create_fact_id("CO2 causes warming") == default_id_gen.create_fact_id("CO2 causes warming")
+
+
+def test_create_fact_id_different_values(default_id_gen):
+    """Different fact text produces different fact IDs."""
+    assert default_id_gen.create_fact_id("fact A") != default_id_gen.create_fact_id("fact B")
+
+
+# --- rewrite_id_for_tenant ---
+
+
+def test_rewrite_id_for_tenant_default_passthrough(default_id_gen):
+    """For the default tenant the ID is returned unchanged — no prefix is inserted."""
+    original = "aws::abc:def"
+    assert default_id_gen.rewrite_id_for_tenant(original) == original
+
+
+def test_rewrite_id_for_tenant_custom_insertion(custom_id_gen):
+    """For a custom tenant the tenant name is inserted after the first segment.
+
+    'aws::abc:def' becomes 'aws:acme:abc:def' — the '::' separator is replaced
+    by ':acme:' to slot the tenant between the prefix and the ID body.
+    """
+    assert custom_id_gen.rewrite_id_for_tenant("aws::abc:def") == "aws:acme:abc:def"
+
+
+# --- Tenant isolation ---
+
+
+def test_source_id_tenant_isolation(default_id_gen, custom_id_gen):
+    """Source IDs are NOT tenant-scoped by design.
+
+    create_source_id hashes raw content directly (no format_hashable call),
+    so the same document produces the same source ID across all tenants.
+    Tenant context is applied separately via rewrite_id_for_tenant.
+    """
+    id1 = default_id_gen.create_source_id("text", "meta")
+    id2 = custom_id_gen.create_source_id("text", "meta")
+    assert id1 == id2
+
+
+def test_entity_id_tenant_isolation(default_id_gen, custom_id_gen):
+    """Entity IDs are tenant-scoped: the same entity produces different IDs per tenant,
+    preventing entities from different tenants from merging in a shared graph store.
+    """
+    id1 = default_id_gen.create_entity_id("Amazon", "Company")
+    id2 = custom_id_gen.create_entity_id("Amazon", "Company")
+    assert id1 != id2
+
+
+def test_topic_id_tenant_isolation(default_id_gen, custom_id_gen):
+    """Topic IDs are tenant-scoped."""
+    id1 = default_id_gen.create_topic_id("source", "Climate")
+    id2 = custom_id_gen.create_topic_id("source", "Climate")
+    assert id1 != id2
+
+
+def test_fact_id_tenant_isolation(default_id_gen, custom_id_gen):
+    """Fact IDs are tenant-scoped, even though facts are otherwise globally deduplicated
+    within a single tenant.
+    """
+    id1 = default_id_gen.create_fact_id("some fact")
+    id2 = custom_id_gen.create_fact_id("some fact")
+    assert id1 != id2

--- a/lexical-graph/tests/unit/utils/test_hash_utils.py
+++ b/lexical-graph/tests/unit/utils/test_hash_utils.py
@@ -1,0 +1,75 @@
+"""Tests for get_hash (hash_utils.py).
+
+get_hash is the foundation of all ID generation in this library. Every source ID,
+chunk ID, entity ID, topic ID, etc. is ultimately an MD5 hex digest of a formatted
+string. These tests verify the properties that the rest of the system depends on:
+determinism (same input → same ID on every run), collision resistance (different
+inputs → different IDs), correct output format (32-char lowercase hex), and safe
+handling of edge-case inputs (unicode, empty string).
+
+The known-vector test pins the exact MD5 digest of "hello" so that any future
+change to the hashing algorithm (e.g. switching from MD5 or changing the encoding)
+will be caught immediately.
+"""
+
+import re
+
+import pytest
+from graphrag_toolkit.lexical_graph.indexing.utils.hash_utils import get_hash
+
+
+def test_get_hash_deterministic():
+    """Same input always produces the same hash.
+
+    This is the core contract: the graph deduplication logic relies on hashing
+    the same content twice and getting the same node ID both times.
+    """
+    assert get_hash("hello") == get_hash("hello")
+
+
+def test_get_hash_known_vector():
+    """MD5("hello") matches the well-known hex digest.
+
+    Pinning a known-good value catches any silent change to the algorithm or
+    encoding without needing to recompute what the "correct" answer should be.
+    """
+    assert get_hash("hello") == "5d41402abc4b2a76b9719d911017c592"
+
+
+def test_get_hash_different_inputs():
+    """Different inputs produce different hashes.
+
+    If two distinct strings hashed to the same value, distinct graph nodes
+    would be collapsed into one — a silent data-loss bug.
+    """
+    assert get_hash("a") != get_hash("b")
+
+
+def test_get_hash_unicode():
+    """Non-ASCII input is encoded as UTF-8 and hashed without error.
+
+    Entity and topic values can contain accented characters, CJK, etc.
+    The function must not raise and must return a valid 32-char hex string.
+    """
+    result = get_hash("caf\u00e9")
+    assert re.match(r"^[a-f0-9]{32}$", result)
+
+
+def test_get_hash_empty_string():
+    """Empty string is a valid input.
+
+    Callers may pass empty metadata strings; the function must not raise
+    and must return a stable 32-char hex string (MD5 of b'' is well-defined).
+    """
+    result = get_hash("")
+    assert re.match(r"^[a-f0-9]{32}$", result)
+
+
+def test_get_hash_hex_format():
+    """Output is always a 32-character lowercase hexadecimal string.
+
+    Downstream code slices fixed character positions from this string
+    (e.g. [:8] for source IDs, [:4] for metadata suffixes), so the
+    length and character set must be exact.
+    """
+    assert re.match(r"^[a-f0-9]{32}$", get_hash("arbitrary input"))

--- a/lexical-graph/tests/unit/utils/test_reranker_utils.py
+++ b/lexical-graph/tests/unit/utils/test_reranker_utils.py
@@ -1,0 +1,84 @@
+"""Tests for reranker utilities (reranker_utils.py).
+
+This module provides two utilities used during retrieval ranking:
+
+  to_float   — coerces numpy scalar types to plain Python floats so that
+               scores can be safely serialized to JSON or compared with
+               standard Python operators. Non-numpy values pass through unchanged.
+
+  score_values_with_tfidf — ranks a list of candidate strings against a list of
+               query terms using TF-IDF character n-gram matching (via tfidf_matcher).
+               Returns a dict of {value: score} sorted highest-first. The primary
+               use case is fuzzy-matching extracted entity/topic names back to a
+               canonical vocabulary.
+"""
+
+import numpy
+import pytest
+from graphrag_toolkit.lexical_graph.utils.reranker_utils import to_float, score_values_with_tfidf
+
+
+# --- to_float ---
+# numpy float scalars are not plain Python floats. Storing them in dicts or
+# returning them over an API can cause JSON serialization errors. to_float
+# converts them via .item(), which returns the equivalent Python primitive.
+
+
+def test_to_float_numpy_float64():
+    """numpy.float64 is unwrapped to a Python float via .item()."""
+    result = to_float(numpy.float64(3.14))
+    assert isinstance(result, float)
+    assert result == pytest.approx(3.14)
+
+
+def test_to_float_numpy_float32():
+    """numpy.float32 is unwrapped to a Python float via .item()."""
+    result = to_float(numpy.float32(2.5))
+    assert isinstance(result, float)
+    assert result == pytest.approx(2.5)
+
+
+def test_to_float_python_float_passthrough():
+    """A plain Python float is returned as-is (no conversion needed)."""
+    assert to_float(3.14) == 3.14
+
+
+def test_to_float_int_passthrough():
+    """A plain int is returned as-is (int is not a numpy type)."""
+    assert to_float(1) == 1
+
+
+# --- score_values_with_tfidf ---
+# The function uses character trigram TF-IDF to score each value in `values`
+# against the query terms in `match_values`. Results are returned as a dict
+# sorted by score descending. An exact string match should always score highest.
+
+
+def test_score_values_with_tfidf_exact_match_highest():
+    """A value identical to the query term should rank first in the result dict.
+
+    The returned dict is sorted highest-score-first, so the first key is the
+    top-ranked result. An exact match should outscore all dissimilar candidates.
+    """
+    values = ["apple pie", "banana split", "cherry tart"]
+    result = score_values_with_tfidf(values, ["apple pie"])
+    top_value = list(result.keys())[0]
+    assert top_value == "apple pie"
+
+
+def test_score_values_with_tfidf_return_type():
+    """Result is a dict with string keys and numeric (int or float) score values."""
+    result = score_values_with_tfidf(["alpha", "beta", "gamma"], ["alpha"])
+    assert isinstance(result, dict)
+    for k, v in result.items():
+        assert isinstance(k, str)
+        assert isinstance(v, (int, float))
+
+
+def test_score_values_with_tfidf_non_negative():
+    """All scores must be >= 0. TF-IDF cosine similarity is bounded [0, 1],
+    and the ranked-score multiplier (1.0 or 0.9) preserves non-negativity.
+    """
+    result = score_values_with_tfidf(["one", "two", "three"], ["one"])
+    for score in result.values():
+        assert score >= 0.0


### PR DESCRIPTION
## Summary

Add unit tests for hashing, ID generation, and reranker utilities.

- **`test_hash_utils.py`** (6 tests): covers `get_hash` determinism, known MD5 vector, uniqueness, unicode input, empty string, and 32-char hex output format
- **`test_id_generator.py`** (22 tests): covers `create_source_id`, `create_chunk_id`, `create_entity_id`, `create_topic_id`, `create_statement_id`, `create_fact_id`, `rewrite_id_for_tenant`, and tenant isolation across all node types. 
- **`test_reranker_utils.py`** (7 tests): covers `to_float` numpy scalar coercion and `score_values_with_tfidf` return type, score ordering, and non-negative score guarantees

## Test plan

- [ ] Run `PYTHONPATH=lexical-graph/src .venv/bin/python -m pytest lexical-graph/tests/unit/ -v` — 73 tests pass across all phases
- [ ] Verify no regressions in previous unit tests
