### PR TITLE
Add unit tests for tenant_id, metadata_utils, batch_inference_utils, and topic_utils

### DIFF
--- a/lexical-graph/tests/unit/test_tenant_id.py
+++ b/lexical-graph/tests/unit/test_tenant_id.py
@@ -1,0 +1,170 @@
+"""Tests for TenantId and to_tenant_id (tenant_id.py).
+
+TenantId wraps a tenant name string with strict validation and formatting helpers.
+The default tenant (value=None) uses simpler formatting than a custom tenant,
+allowing the same graph store to host multiple isolated tenants without collision.
+
+Validation rules
+----------------
+  - Length 1–25 characters
+  - All lowercase
+  - Alphanumeric characters and periods allowed (not at start or end)
+  - The literal string "default_" (case-insensitive) is treated as the default
+    tenant and stored as value=None instead of being validated
+"""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.tenant_id import TenantId, to_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# __init__ validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["acme", "tenant1", "a.b.c", "x"])
+def test_tenant_id_valid(value):
+    t = TenantId(value)
+    assert t.value == value
+
+
+@pytest.mark.parametrize("value", [
+    "UPPER",        # uppercase letters not allowed
+    "a" * 26,       # 26 chars > 25-char limit
+    ".start",       # leading period not allowed
+    "end.",         # trailing period not allowed
+    "has space",    # spaces not allowed
+    "special!",     # special characters not allowed
+])
+def test_tenant_id_invalid_raises(value):
+    with pytest.raises(ValueError, match="Invalid TenantId"):
+        TenantId(value)
+
+
+def test_tenant_id_default_none():
+    """No argument -> default tenant with value=None."""
+    assert TenantId().value is None
+
+
+def test_tenant_id_default_string_normalized():
+    """The sentinel string 'default_' normalizes to the default tenant (value=None)."""
+    assert TenantId("default_").value is None
+
+
+def test_tenant_id_25_chars_valid():
+    """Exactly 25 lowercase characters is the maximum valid length."""
+    value = "a" * 25
+    assert TenantId(value).value == value
+
+
+# ---------------------------------------------------------------------------
+# is_default_tenant
+# ---------------------------------------------------------------------------
+
+
+def test_is_default_tenant_true(default_tenant):
+    assert default_tenant.is_default_tenant() is True
+
+
+def test_is_default_tenant_false(custom_tenant):
+    assert custom_tenant.is_default_tenant() is False
+
+
+# ---------------------------------------------------------------------------
+# format_label
+# ---------------------------------------------------------------------------
+
+
+def test_format_label_default(default_tenant):
+    assert default_tenant.format_label("Topic") == "`Topic`"
+
+
+def test_format_label_custom(custom_tenant):
+    assert custom_tenant.format_label("Topic") == "`Topicacme__`"
+
+
+# ---------------------------------------------------------------------------
+# format_index_name
+# ---------------------------------------------------------------------------
+
+
+def test_format_index_name_default(default_tenant):
+    assert default_tenant.format_index_name("my_index") == "my_index"
+
+
+def test_format_index_name_custom(custom_tenant):
+    assert custom_tenant.format_index_name("my_index") == "my_index_acme"
+
+
+# ---------------------------------------------------------------------------
+# format_hashable
+# ---------------------------------------------------------------------------
+
+
+def test_format_hashable_default(default_tenant):
+    """Default tenant: hashable string is returned as-is."""
+    assert default_tenant.format_hashable("topic::foo") == "topic::foo"
+
+
+def test_format_hashable_custom(custom_tenant):
+    """Custom tenant: tenant name is prepended with '::' separator."""
+    assert custom_tenant.format_hashable("topic::foo") == "acme::topic::foo"
+
+
+# ---------------------------------------------------------------------------
+# format_id
+# ---------------------------------------------------------------------------
+
+
+def test_format_id_default(default_tenant):
+    """Default tenant: uses '::' double-colon separator."""
+    assert default_tenant.format_id("aws", "abc123") == "aws::abc123"
+
+
+def test_format_id_custom(custom_tenant):
+    """Custom tenant: uses single-colon separators with tenant name in the middle."""
+    assert custom_tenant.format_id("aws", "abc123") == "aws:acme:abc123"
+
+
+# ---------------------------------------------------------------------------
+# rewrite_id
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_id_default(default_tenant):
+    """Default tenant: ID is returned unchanged."""
+    assert default_tenant.rewrite_id("aws::abc:def") == "aws::abc:def"
+
+
+def test_rewrite_id_custom(custom_tenant):
+    """Custom tenant: tenant name is inserted after the prefix segment.
+
+    'aws::abc:def' splits as ['aws', '', 'abc', 'def']. Rejoining with the
+    tenant name gives 'aws:acme:abc:def'.
+    """
+    assert custom_tenant.rewrite_id("aws::abc:def") == "aws:acme:abc:def"
+
+
+# ---------------------------------------------------------------------------
+# to_tenant_id
+# ---------------------------------------------------------------------------
+
+
+def test_to_tenant_id_none():
+    """None -> returns the global DEFAULT_TENANT_ID (default tenant)."""
+    result = to_tenant_id(None)
+    assert result.is_default_tenant()
+
+
+def test_to_tenant_id_passthrough():
+    """An existing TenantId instance is returned as-is (identity check)."""
+    t = TenantId("acme")
+    assert to_tenant_id(t) is t
+
+
+def test_to_tenant_id_from_string():
+    """A plain string is wrapped in a new TenantId."""
+    result = to_tenant_id("acme")
+    assert isinstance(result, TenantId)
+    assert result.value == "acme"

--- a/lexical-graph/tests/unit/utils/test_batch_inference_utils.py
+++ b/lexical-graph/tests/unit/utils/test_batch_inference_utils.py
@@ -1,0 +1,215 @@
+"""Tests for batch inference utilities (batch_inference_utils.py).
+
+split_nodes           — partitions a list of nodes into batches for Bedrock batch
+                        inference, enforcing Bedrock's minimum (100) and maximum
+                        (50,000) batch-size constraints. The final batch absorbs any
+                        remainder that would be smaller than the minimum.
+
+get_parse_output_text_fn — returns a model-specific function that extracts the text
+                           response from a Bedrock batch-output JSON record. Raises
+                           ValueError for unrecognised model IDs.
+
+Splitting algorithm
+-------------------
+At each iteration the algorithm checks whether the remaining nodes after taking
+the next full batch would be fewer than BEDROCK_MIN_BATCH_SIZE (100). If so it
+appends all remaining nodes as one final batch (avoiding a too-small tail batch).
+The boundary condition uses strict less-than (<), so a remainder of exactly 100
+is NOT merged — it becomes a separate batch.
+"""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph import BatchJobError
+from graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils import (
+    split_nodes,
+    get_parse_output_text_fn,
+)
+
+
+# ---------------------------------------------------------------------------
+# split_nodes — happy-path splitting
+# ---------------------------------------------------------------------------
+
+
+def test_split_nodes_even_split():
+    """1 000 nodes with batch_size=500 -> 2 batches of exactly 500."""
+    nodes = list(range(1000))
+    result = split_nodes(nodes, 500)
+    assert len(result) == 2
+    assert all(len(batch) == 500 for batch in result)
+
+
+def test_split_nodes_remainder_smaller_than_minimum_merged():
+    """250 nodes, batch_size=200: remainder (50) < 100 -> merged into single batch of 250."""
+    nodes = list(range(250))
+    result = split_nodes(nodes, 200)
+    assert len(result) == 1
+    assert len(result[0]) == 250
+
+
+def test_split_nodes_exact_minimum_size():
+    """100 nodes, batch_size=100: remainder (0) < 100 -> single batch of 100."""
+    nodes = list(range(100))
+    result = split_nodes(nodes, 100)
+    assert len(result) == 1
+    assert len(result[0]) == 100
+
+
+def test_split_nodes_remainder_exactly_minimum_not_merged():
+    """300 nodes, batch_size=200: remainder is exactly 100 (== min, not <).
+    The strict-less-than check means the remainder is NOT merged, producing
+    two batches [200, 100].
+    """
+    nodes = list(range(300))
+    result = split_nodes(nodes, 200)
+    assert len(result) == 2
+    assert len(result[0]) == 200
+    assert len(result[1]) == 100
+
+
+def test_split_nodes_preserves_all_items():
+    """All input items appear in the output in the original order, with no duplicates."""
+    nodes = list(range(500))
+    result = split_nodes(nodes, 200)
+    flattened = [item for batch in result for item in batch]
+    assert flattened == nodes
+
+
+def test_split_nodes_large_batch():
+    """A batch_size equal to the maximum (50 000) is accepted."""
+    nodes = list(range(50000))
+    result = split_nodes(nodes, 50000)
+    assert len(result) == 1
+    assert len(result[0]) == 50000
+
+
+# ---------------------------------------------------------------------------
+# split_nodes — validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_split_nodes_batch_size_too_small_raises():
+    """batch_size < 100 -> BatchJobError."""
+    with pytest.raises(BatchJobError):
+        split_nodes(list(range(100)), 50)
+
+
+def test_split_nodes_batch_size_too_large_raises():
+    """batch_size > 50 000 -> BatchJobError."""
+    with pytest.raises(BatchJobError):
+        split_nodes(list(range(100)), 60000)
+
+
+def test_split_nodes_empty_list_raises():
+    """Empty node list -> BatchJobError."""
+    with pytest.raises(BatchJobError):
+        split_nodes([], 100)
+
+
+def test_split_nodes_fewer_than_minimum_raises():
+    """Fewer nodes than the minimum (50 < 100) -> BatchJobError."""
+    with pytest.raises(BatchJobError):
+        split_nodes(list(range(50)), 100)
+
+
+def test_split_nodes_exactly_minimum_batch_size_valid():
+    """batch_size == 100 (the minimum) is accepted."""
+    nodes = list(range(100))
+    result = split_nodes(nodes, 100)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_parse_output_text_fn — Nova
+# ---------------------------------------------------------------------------
+
+
+def test_get_parse_output_text_fn_nova_basic():
+    """Nova response: concatenates all text content blocks."""
+    fn = get_parse_output_text_fn("amazon.nova-lite")
+    json_data = {
+        "modelOutput": {
+            "output": {
+                "message": {
+                    "content": [{"text": "Hello "}, {"text": "World"}]
+                }
+            }
+        }
+    }
+    assert fn(json_data) == "Hello World"
+
+
+def test_get_parse_output_text_fn_nova_single_block():
+    """Nova response with a single content block."""
+    fn = get_parse_output_text_fn("amazon.nova-pro")
+    json_data = {
+        "modelOutput": {
+            "output": {
+                "message": {
+                    "content": [{"text": "Answer"}]
+                }
+            }
+        }
+    }
+    assert fn(json_data) == "Answer"
+
+
+def test_get_parse_output_text_fn_nova_empty_content():
+    """Nova response with missing nested keys returns empty string (safe .get chain)."""
+    fn = get_parse_output_text_fn("amazon.nova-lite")
+    json_data = {"modelOutput": {}}
+    assert fn(json_data) == ""
+
+
+# ---------------------------------------------------------------------------
+# get_parse_output_text_fn — Claude
+# ---------------------------------------------------------------------------
+
+
+def test_get_parse_output_text_fn_claude_basic():
+    """Claude response: concatenates all text content blocks."""
+    fn = get_parse_output_text_fn("anthropic.claude-v3")
+    json_data = {
+        "modelOutput": {
+            "content": [{"text": "Hello "}, {"text": "World"}]
+        }
+    }
+    assert fn(json_data) == "Hello World"
+
+
+def test_get_parse_output_text_fn_claude_empty_content():
+    """Claude response with empty content list returns empty string."""
+    fn = get_parse_output_text_fn("anthropic.claude-v3")
+    json_data = {"modelOutput": {"content": []}}
+    assert fn(json_data) == ""
+
+
+# ---------------------------------------------------------------------------
+# get_parse_output_text_fn — Llama
+# ---------------------------------------------------------------------------
+
+
+def test_get_parse_output_text_fn_llama_basic():
+    """Llama response: reads the top-level 'generation' key."""
+    fn = get_parse_output_text_fn("meta.llama-3")
+    json_data = {"generation": "Hello World"}
+    assert fn(json_data) == "Hello World"
+
+
+# ---------------------------------------------------------------------------
+# get_parse_output_text_fn — unknown model
+# ---------------------------------------------------------------------------
+
+
+def test_get_parse_output_text_fn_unknown_raises():
+    """An unrecognised model ID raises ValueError with a helpful message."""
+    with pytest.raises(ValueError, match="Unrecognized model_id"):
+        get_parse_output_text_fn("unknown.model")
+
+
+def test_get_parse_output_text_fn_returns_callable():
+    """Each recognised model returns a callable (not None)."""
+    for model_id in ["amazon.nova-lite", "anthropic.claude-v3", "meta.llama-3"]:
+        fn = get_parse_output_text_fn(model_id)
+        assert callable(fn)

--- a/lexical-graph/tests/unit/utils/test_hash_utils.py
+++ b/lexical-graph/tests/unit/utils/test_hash_utils.py
@@ -3,8 +3,8 @@
 get_hash is the foundation of all ID generation in this library. Every source ID,
 chunk ID, entity ID, topic ID, etc. is ultimately an MD5 hex digest of a formatted
 string. These tests verify the properties that the rest of the system depends on:
-determinism (same input → same ID on every run), collision resistance (different
-inputs → different IDs), correct output format (32-char lowercase hex), and safe
+determinism (same input -> same ID on every run), collision resistance (different
+inputs -> different IDs), correct output format (32-char lowercase hex), and safe
 handling of edge-case inputs (unicode, empty string).
 
 The known-vector test pins the exact MD5 digest of "hello" so that any future

--- a/lexical-graph/tests/unit/utils/test_metadata_utils.py
+++ b/lexical-graph/tests/unit/utils/test_metadata_utils.py
@@ -1,0 +1,68 @@
+"""Tests for metadata utilities (metadata_utils.py).
+
+get_properties_str — converts a properties dict to a sorted 'key:value;...' string,
+                     returning a default value when the dict is empty or None.
+
+last_accessed_date — returns {'last_accessed_date': '<YYYY-MM-DD>'} using today's date.
+                     datetime.datetime.now() is mocked to give deterministic output.
+"""
+
+import datetime
+import re
+
+import pytest
+from unittest.mock import patch
+
+from graphrag_toolkit.lexical_graph.indexing.utils.metadata_utils import (
+    get_properties_str,
+    last_accessed_date,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_properties_str
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("properties,default,expected", [
+    ({"b": 2, "a": 1}, "x", "a:1;b:2"),       # keys sorted alphabetically
+    ({"single": "v"}, "x", "single:v"),         # single entry
+    ({}, "default", "default"),                  # empty dict -> default
+    (None, "default", "default"),                # None -> default
+])
+def test_get_properties_str(properties, default, expected):
+    assert get_properties_str(properties, default) == expected
+
+
+# ---------------------------------------------------------------------------
+# last_accessed_date
+# ---------------------------------------------------------------------------
+
+
+def test_last_accessed_date_returns_dict():
+    result = last_accessed_date()
+    assert isinstance(result, dict)
+    assert "last_accessed_date" in result
+
+
+def test_last_accessed_date_format():
+    """Date value matches YYYY-MM-DD format."""
+    result = last_accessed_date()
+    assert re.match(r"^\d{4}-\d{2}-\d{2}$", result["last_accessed_date"])
+
+
+def test_last_accessed_date_mocked():
+    """With a mocked datetime, the returned date matches the fixed value."""
+    fake_now = datetime.datetime(2025, 6, 15, 12, 0, 0)
+    with patch(
+        "graphrag_toolkit.lexical_graph.indexing.utils.metadata_utils.datetime"
+    ) as mock_dt:
+        mock_dt.datetime.now.return_value = fake_now
+        result = last_accessed_date()
+    assert result == {"last_accessed_date": "2025-06-15"}
+
+
+def test_last_accessed_date_accepts_extra_args():
+    """The function signature is (*args), so extra positional args are silently ignored."""
+    result = last_accessed_date("ignored", "also ignored")
+    assert "last_accessed_date" in result

--- a/lexical-graph/tests/unit/utils/test_topic_utils.py
+++ b/lexical-graph/tests/unit/utils/test_topic_utils.py
@@ -1,0 +1,422 @@
+"""Tests for topic_utils.py — string normalisation helpers and the LLM output parser.
+
+String normalisation pipeline
+------------------------------
+  format_value             : replaces underscores with spaces (tested in test_format_helpers.py)
+  remove_parenthetical_content : strips everything between the first '(' and last ')' on a line
+  remove_articles          : strips leading English articles ('a ', 'an ', 'the ') case-insensitively
+  clean                    : composed pipeline — format_value -> remove_parenthetical_content -> remove_articles
+
+parse_extracted_topics
+-----------------------
+Parses the multi-section text format produced by the LLM topic-extraction prompt:
+
+  topic: <name>
+  entities:
+  <value>|<classification>
+  ...
+  proposition: <statement text>
+  <subject>|<predicate>|<object>
+  ...
+
+Returns (TopicCollection, garbage_lines).
+
+Key behaviours tested here
+---------------------------
+- Empty topics (no entities or statements) are excluded from the result.
+- Duplicate entities within a topic are deduplicated by their cleaned value.
+- A relationship line whose subject is not in the entity dict -> both subject and
+  complement get LOCAL_ENTITY_CLASSIFICATION; the line is also appended to details.
+- A relationship line whose object is not in the entity dict -> complement gets
+  LOCAL_ENTITY_CLASSIFICATION while the subject retains its known entity.
+- An entity line without exactly one '|' separator -> appended to garbage.
+- A relationship segment that does not have exactly three '|'-delimited parts but
+  has non-empty text -> appended to the current statement's details (not garbage).
+- A topic: line value that contains extra colons loses those colons because the code
+  joins split segments with '' (empty string). This is a known limitation.
+- Lines outside any recognised state -> appended to garbage.
+"""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.indexing.utils.topic_utils import (
+    remove_parenthetical_content,
+    remove_articles,
+    clean,
+    parse_extracted_topics,
+)
+from graphrag_toolkit.lexical_graph.indexing.constants import (
+    LOCAL_ENTITY_CLASSIFICATION,
+    DEFAULT_TOPIC,
+)
+
+
+# ---------------------------------------------------------------------------
+# remove_parenthetical_content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("input_val,expected", [
+    ("Amazon (company)", "Amazon"),          # single parenthetical at end
+    ("A (B) C (D) E", "A E"),               # greedy: first '(' to last ')' consumed
+    ("No parens", "No parens"),             # no-op
+    ("A (B (C)) D", "A D"),                 # nested parens handled by greedy match
+    ("(leading) text", "text"),             # leading parenthetical stripped
+    ("", ""),                               # empty string
+])
+def test_remove_parenthetical_content(input_val, expected):
+    assert remove_parenthetical_content(input_val) == expected
+
+
+def test_remove_parenthetical_content_double_space_collapsed():
+    """After removing parenthetical content, double spaces are collapsed to single."""
+    result = remove_parenthetical_content("word (paren) end")
+    assert "  " not in result
+
+
+# ---------------------------------------------------------------------------
+# remove_articles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("input_val,expected", [
+    ("The White House", "White House"),     # "The" removed, case preserved in remainder
+    ("An example", "example"),             # "An" removed
+    ("A test", "test"),                    # "A" removed
+    ("Anthem", "Anthem"),                  # "An" without trailing space — no match
+    ("the lower", "lower"),               # lowercase "the"
+    ("THE UPPER", "UPPER"),               # uppercase "THE"
+    ("a", "a"),                           # bare "a" with no trailing space — no match
+    ("", ""),                             # empty string
+])
+def test_remove_articles(input_val, expected):
+    assert remove_articles(input_val) == expected
+
+
+def test_remove_articles_only_first_article_stripped():
+    """Only the leading article is stripped; inner occurrences are preserved."""
+    result = remove_articles("The cat and the dog")
+    assert result == "cat and the dog"
+
+
+# ---------------------------------------------------------------------------
+# clean (composed pipeline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("input_val,expected", [
+    ("the_Amazon_(river)", "Amazon"),       # underscore->space, parens stripped, article stripped
+    ("A_simple_test", "simple test"),       # underscore->space, article stripped
+    ("plain", "plain"),                     # no transformations needed
+])
+def test_clean(input_val, expected):
+    assert clean(input_val) == expected
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — single well-formed topic
+# ---------------------------------------------------------------------------
+
+
+SINGLE_TOPIC_INPUT = """\
+topic: Climate Change
+entities:
+CO2|Gas
+Earth|Planet
+proposition: CO2 causes warming
+CO2|causes warming|Earth"""
+
+
+def test_parse_single_topic_count():
+    topics, garbage = parse_extracted_topics(SINGLE_TOPIC_INPUT)
+    assert len(topics.topics) == 1
+
+
+def test_parse_single_topic_value():
+    topics, _ = parse_extracted_topics(SINGLE_TOPIC_INPUT)
+    assert topics.topics[0].value == "Climate Change"
+
+
+def test_parse_single_topic_entities():
+    topics, _ = parse_extracted_topics(SINGLE_TOPIC_INPUT)
+    assert len(topics.topics[0].entities) == 2
+
+
+def test_parse_single_topic_statements():
+    topics, _ = parse_extracted_topics(SINGLE_TOPIC_INPUT)
+    assert len(topics.topics[0].statements) == 1
+
+
+def test_parse_single_topic_facts():
+    topics, _ = parse_extracted_topics(SINGLE_TOPIC_INPUT)
+    assert len(topics.topics[0].statements[0].facts) == 1
+
+
+def test_parse_single_topic_no_garbage():
+    _, garbage = parse_extracted_topics(SINGLE_TOPIC_INPUT)
+    assert not garbage
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — multiple topics
+# ---------------------------------------------------------------------------
+
+
+MULTI_TOPIC_INPUT = """\
+topic: Climate
+entities:
+CO2|Gas
+proposition: CO2 warms
+CO2|warms|CO2
+topic: Economy
+entities:
+GDP|Metric
+proposition: GDP grows
+GDP|grows|GDP"""
+
+
+def test_parse_multiple_topics_count():
+    topics, _ = parse_extracted_topics(MULTI_TOPIC_INPUT)
+    assert len(topics.topics) == 2
+
+
+def test_parse_multiple_topics_values():
+    topics, _ = parse_extracted_topics(MULTI_TOPIC_INPUT)
+    assert topics.topics[0].value == "Climate"
+    assert topics.topics[1].value == "Economy"
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — empty topics excluded
+# ---------------------------------------------------------------------------
+
+
+EMPTY_TOPIC_INPUT = """\
+topic: Empty
+topic: Real
+entities:
+Item|Thing
+proposition: Item exists
+Item|exists|Item"""
+
+
+def test_parse_empty_topic_excluded():
+    """A topic with no entities and no statements is not added to the result."""
+    topics, _ = parse_extracted_topics(EMPTY_TOPIC_INPUT)
+    assert len(topics.topics) == 1
+    assert topics.topics[0].value == "Real"
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — entity deduplication
+# ---------------------------------------------------------------------------
+
+
+DEDUP_ENTITY_INPUT = """\
+topic: Test
+entities:
+Amazon|Company
+Amazon|Company
+proposition: Amazon operates
+Amazon|operates|Amazon"""
+
+
+def test_parse_entity_deduplication():
+    """Duplicate entity lines (same cleaned value) are stored only once."""
+    topics, _ = parse_extracted_topics(DEDUP_ENTITY_INPUT)
+    assert len(topics.topics[0].entities) == 1
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — unknown subject -> both sides become local entities
+# ---------------------------------------------------------------------------
+
+
+UNKNOWN_SUBJECT_INPUT = """\
+topic: Test
+entities:
+KnownEntity|Type
+proposition: Something happens
+UnknownSubject|does|KnownEntity"""
+
+
+def test_parse_unknown_subject_subject_is_local_entity():
+    """When neither subject nor object is in the entity dict, the subject gets
+    LOCAL_ENTITY_CLASSIFICATION."""
+    topics, _ = parse_extracted_topics(UNKNOWN_SUBJECT_INPUT)
+    fact = topics.topics[0].statements[0].facts[0]
+    assert fact.subject.classification == LOCAL_ENTITY_CLASSIFICATION
+
+
+def test_parse_unknown_subject_complement_is_local_entity():
+    """When the subject is unknown, the complement also gets LOCAL_ENTITY_CLASSIFICATION
+    (the code falls into the else-branch that creates two local entities)."""
+    topics, _ = parse_extracted_topics(UNKNOWN_SUBJECT_INPUT)
+    fact = topics.topics[0].statements[0].facts[0]
+    assert fact.complement.classification == LOCAL_ENTITY_CLASSIFICATION
+    assert fact.complement.value == "KnownEntity"
+
+
+def test_parse_unknown_subject_adds_detail():
+    """The else-branch also appends the raw line to statement.details."""
+    topics, _ = parse_extracted_topics(UNKNOWN_SUBJECT_INPUT)
+    stmt = topics.topics[0].statements[0]
+    assert len(stmt.details) == 1
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — unknown object -> complement created
+# ---------------------------------------------------------------------------
+
+
+UNKNOWN_OBJECT_INPUT = """\
+topic: Test
+entities:
+KnownEntity|Type
+proposition: Known does something
+KnownEntity|relates to|UnknownObject"""
+
+
+def test_parse_unknown_object_subject_is_known():
+    """Subject is in the entity dict -> uses the known entity."""
+    topics, _ = parse_extracted_topics(UNKNOWN_OBJECT_INPUT)
+    fact = topics.topics[0].statements[0].facts[0]
+    assert fact.subject.value == "KnownEntity"
+
+
+def test_parse_unknown_object_complement_is_local_entity():
+    """Object not in entity dict -> complement gets LOCAL_ENTITY_CLASSIFICATION."""
+    topics, _ = parse_extracted_topics(UNKNOWN_OBJECT_INPUT)
+    fact = topics.topics[0].statements[0].facts[0]
+    assert fact.complement.classification == LOCAL_ENTITY_CLASSIFICATION
+    assert fact.complement.value == "UnknownObject"
+
+
+def test_parse_unknown_object_fact_object_is_none():
+    """When the complement path is used, fact.object remains None."""
+    topics, _ = parse_extracted_topics(UNKNOWN_OBJECT_INPUT)
+    fact = topics.topics[0].statements[0].facts[0]
+    assert fact.object is None
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — unparseable entity line -> garbage
+# ---------------------------------------------------------------------------
+
+
+BAD_ENTITY_INPUT = """\
+topic: Test
+entities:
+bad entity line without pipe
+Good|Entity
+proposition: Good exists
+Good|exists|Good"""
+
+
+def test_parse_unparseable_entity_goes_to_garbage():
+    """An entity line without exactly one '|' is appended to garbage."""
+    _, garbage = parse_extracted_topics(BAD_ENTITY_INPUT)
+    assert any("UNPARSEABLE ENTITY" in g for g in garbage)
+
+
+def test_parse_unparseable_entity_valid_entity_still_parsed():
+    """The bad line does not prevent the valid entity on the next line from being parsed."""
+    topics, _ = parse_extracted_topics(BAD_ENTITY_INPUT)
+    assert len(topics.topics[0].entities) == 1
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — unparseable relationship line -> detail
+# ---------------------------------------------------------------------------
+
+
+BAD_RELATIONSHIP_INPUT = """\
+topic: Test
+entities:
+A|Type
+proposition: Some statement
+only two segments here"""
+
+
+def test_parse_unparseable_relationship_becomes_detail():
+    """A relationship line without three '|'-delimited segments but with non-empty
+    text is appended to statement.details (not to garbage)."""
+    topics, _ = parse_extracted_topics(BAD_RELATIONSHIP_INPUT)
+    stmt = topics.topics[0].statements[0]
+    assert len(stmt.details) == 1
+
+
+def test_parse_unparseable_relationship_not_in_garbage():
+    """Non-empty single-segment lines in relationship-extraction state go to details,
+    NOT to garbage."""
+    _, garbage = parse_extracted_topics(BAD_RELATIONSHIP_INPUT)
+    assert not any("UNPARSEABLE" in g for g in garbage)
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — colon in topic value
+# ---------------------------------------------------------------------------
+
+
+COLON_TOPIC_INPUT = """\
+topic: Key: Value Pair
+entities:
+Item|Thing
+proposition: Item exists
+Item|exists|Item"""
+
+
+def test_parse_colon_in_topic_value():
+    """The topic parser splits on ':' and joins with '' (empty string), so any colons
+    inside the topic value after the first ':' are lost.
+
+    Known limitation: 'topic: Key: Value Pair' is stored as 'Key Value Pair'
+    (not 'Key: Value Pair').
+    """
+    topics, _ = parse_extracted_topics(COLON_TOPIC_INPUT)
+    # The code does ''.join(line.split(':')[1:]).strip(), which drops the inner colon.
+    assert topics.topics[0].value == "Key Value Pair"
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — empty input
+# ---------------------------------------------------------------------------
+
+
+def test_parse_empty_input():
+    topics, garbage = parse_extracted_topics("")
+    assert len(topics.topics) == 0
+    assert len(garbage) == 0
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — only garbage lines
+# ---------------------------------------------------------------------------
+
+
+def test_parse_only_garbage():
+    """Lines outside any recognised state (no topic/entities/proposition header yet)
+    are classified as garbage."""
+    topics, garbage = parse_extracted_topics("random nonsense\nmore junk")
+    assert len(topics.topics) == 0
+    assert len(garbage) == 2
+
+
+# ---------------------------------------------------------------------------
+# parse_extracted_topics — entities/proposition before any topic: header
+# ---------------------------------------------------------------------------
+
+
+PROPOSITION_BEFORE_TOPIC = """\
+entities:
+Item|Thing
+proposition: Item exists
+Item|exists|Item"""
+
+
+def test_parse_proposition_before_topic_uses_default():
+    """When no 'topic:' line precedes the content, the implicit default topic
+    ('context') is used."""
+    topics, _ = parse_extracted_topics(PROPOSITION_BEFORE_TOPIC)
+    assert len(topics.topics) == 1
+    assert topics.topics[0].value == DEFAULT_TOPIC


### PR DESCRIPTION
- test_tenant_id.py: validation rules, format_label/index_name/hashable/id,
  rewrite_id, and to_tenant_id conversion
- test_metadata_utils.py: get_properties_str sorting and defaults,
  last_accessed_date with mocked datetime
- test_batch_inference_utils.py: split_nodes batch splitting and boundary
  conditions, get_parse_output_text_fn for Nova/Claude/Llama
- test_topic_utils.py: remove_parenthetical_content, remove_articles, clean pipeline, and parse_extracted_topics with 12 edge case scenarios

resolves https://github.com/awslabs/graphrag-toolkit/issues/111


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
