### PR TITLE
Add versioned zip files for lexical-graph examples and hybrid-dev notebooks

### DIFF
--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -66,6 +66,7 @@ jobs:
         working-directory: examples/lexical-graph/notebooks
         run: |
           zip lexical-graph-examples.zip *.ipynb
+          cp lexical-graph-examples.zip lexical-graph-examples-${{ steps.version.outputs.version }}.zip
           cp lexical-graph-examples.zip lexical-graph-examples-latest.zip
 
       - name: Upload lexical-graph-examples.zip
@@ -74,6 +75,7 @@ jobs:
           name: lexical-graph-examples
           path: |
             examples/lexical-graph/notebooks/lexical-graph-examples.zip
+            examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip
             examples/lexical-graph/notebooks/lexical-graph-examples-latest.zip
           retention-days: 30
 
@@ -85,6 +87,7 @@ jobs:
         working-directory: examples/lexical-graph-hybrid-dev/notebooks
         run: |
           zip lexical-graph-hybrid-dev-examples.zip *.ipynb
+          cp lexical-graph-hybrid-dev-examples.zip lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip
           cp lexical-graph-hybrid-dev-examples.zip lexical-graph-hybrid-dev-examples-latest.zip
 
       - name: Upload lexical-graph-hybrid-dev-examples.zip
@@ -93,6 +96,7 @@ jobs:
           name: lexical-graph-hybrid-dev-examples
           path: |
             examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples.zip
+            examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip
             examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-latest.zip
           retention-days: 30
 
@@ -103,9 +107,9 @@ jobs:
         with:
           files: |
             lexical-graph/dist/*
-            examples/lexical-graph/notebooks/lexical-graph-examples.zip
+            examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip
             examples/lexical-graph/notebooks/lexical-graph-examples-latest.zip
-            examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples.zip
+            examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip
             examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-latest.zip
           generate_release_notes: true
           prerelease: >-


### PR DESCRIPTION
## Fix: Append version to example zip files in release workflow

The release workflow was creating example zips with only a `-latest` suffix,
with no versioned copy attached to the GitHub Release.

### Changes

- Create a versioned copy of each example zip (e.g. `lexical-graph-examples-v1.2.3.zip`)
  alongside the existing `-latest` copy, for both `lexical-graph` and `lexical-graph-hybrid-dev`
- Include the versioned zips in the upload-artifact steps
- Attach the versioned zips (instead of the unversioned base zip) to the GitHub Release


resolves https://github.com/awslabs/graphrag-toolkit/issues/122


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
