### PR TITLE
Clean up gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ __pycache__/
 
 # Build artifacts
 dist/
-/build/
 *.egg-info/
 
 # Coverage reports


### PR DESCRIPTION
*Issue #, if available:*

Related to: #177

*Description of changes:*

Under #177 the `build` directory was updated in the `.gitignore` file and it should be removed.  `build` directories are not created as part of the pip build process on either the lexical-graph or the byokg-rag projects.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
