### PR TITLE
feat(lexical-graph): invoke graph_store init hook

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
@@ -300,6 +300,9 @@ class LexicalGraphIndex():
         self.extraction_pre_processors = pre_processors
         self.extraction_components = components
 
+        # Backend bootstrap (for example index creation) is part of object lifecycle; fail fast if unavailable.
+        self.graph_store.init()
+
     def _configure_extraction_pipeline(self, config: IndexingConfig):
         """
         Configures and initializes the extraction pipeline based on the given configuration settings. This method
@@ -783,4 +786,3 @@ class LexicalGraphIndex():
         delete_sources = DeleteSources(graph_store=self.graph_store, vector_store=self.vector_store)
 
         return delete_sources.delete_source_documents(source_ids)
-

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_query_engine.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_query_engine.py
@@ -282,6 +282,7 @@ class LexicalGraphQueryEngine(BaseQueryEngine):
         tenant_id = to_tenant_id(tenant_id)
 
         graph_store = MultiTenantGraphStore.wrap(GraphStoreFactory.for_graph_store(graph_store), tenant_id)
+        graph_store.init()
         vector_store = ReadOnlyVectorStore.wrap(
             MultiTenantVectorStore.wrap(VectorStoreFactory.for_vector_store(vector_store), tenant_id)
         )

--- a/lexical-graph/tests/unit/test_lexical_graph_index.py
+++ b/lexical-graph/tests/unit/test_lexical_graph_index.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+import pytest
 
 from llama_index.core.llms import LLM
 from llama_index.core.llms.mock import MockLLM
 from llama_index.llms.bedrock_converse import BedrockConverse
 
 from graphrag_toolkit.lexical_graph import ExtractionConfig
+from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
 from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
 
 class TestExtractionConfig:
@@ -43,3 +45,61 @@ class TestExtractionConfig:
         )
 
         assert extraction_config.extraction_llm == llm_cache
+
+class TestLexicalGraphIndex:
+
+    def test_init_invokes_graph_store_init_hook(self):
+        graph_store = Mock()
+        vector_store = Mock()
+
+        with (
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.GraphStoreFactory.for_graph_store',
+                return_value=graph_store,
+            ),
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.MultiTenantGraphStore.wrap',
+                return_value=graph_store,
+            ),
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.VectorStoreFactory.for_vector_store',
+                return_value=vector_store,
+            ),
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.MultiTenantVectorStore.wrap',
+                return_value=vector_store,
+            ),
+            patch.object(LexicalGraphIndex, '_configure_extraction_pipeline', return_value=([], [])),
+        ):
+            LexicalGraphIndex(graph_store='dummy://', vector_store='dummy://')
+
+        graph_store.init.assert_called_once_with()
+
+    def test_init_propagates_graph_store_init_failure(self):
+        graph_store = Mock()
+        graph_store.init.side_effect = RuntimeError("Graph store init failed")
+        vector_store = Mock()
+
+        with (
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.GraphStoreFactory.for_graph_store',
+                return_value=graph_store,
+            ),
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.MultiTenantGraphStore.wrap',
+                return_value=graph_store,
+            ),
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.VectorStoreFactory.for_vector_store',
+                return_value=vector_store,
+            ),
+            patch(
+                'graphrag_toolkit.lexical_graph.lexical_graph_index.MultiTenantVectorStore.wrap',
+                return_value=vector_store,
+            ),
+            patch.object(LexicalGraphIndex, '_configure_extraction_pipeline', return_value=([], [])),
+        ):
+            with pytest.raises(RuntimeError, match="Graph store init failed"):
+                LexicalGraphIndex(graph_store='dummy://', vector_store='dummy://')
+
+        graph_store.init.assert_called_once_with()

--- a/lexical-graph/tests/unit/test_lexical_graph_query_engine.py
+++ b/lexical-graph/tests/unit/test_lexical_graph_query_engine.py
@@ -26,3 +26,52 @@ class TestLexicalGraphQueryEngineErrorHandling:
                     graph_store="invalid",
                     vector_store=Mock()
                 )
+
+
+class TestLexicalGraphQueryEngine:
+
+    def test_init_invokes_graph_store_init_hook(self):
+        graph_store = Mock()
+        vector_store = Mock()
+        prompt_provider = Mock()
+        prompt_provider.get_system_prompt.return_value = "system"
+        prompt_provider.get_user_prompt.return_value = "user"
+
+        with (
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.GraphStoreFactory.for_graph_store",
+                return_value=graph_store,
+            ),
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.MultiTenantGraphStore.wrap",
+                return_value=graph_store,
+            ),
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.VectorStoreFactory.for_vector_store",
+                return_value=vector_store,
+            ),
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.MultiTenantVectorStore.wrap",
+                return_value=vector_store,
+            ),
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.ReadOnlyVectorStore.wrap",
+                return_value=vector_store,
+            ),
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.LLMCache",
+                autospec=True,
+            ),
+            patch(
+                "graphrag_toolkit.lexical_graph.lexical_graph_query_engine.ChatPromptTemplate",
+                autospec=True,
+            ),
+        ):
+            LexicalGraphQueryEngine(
+                graph_store="dummy://",
+                vector_store="dummy://",
+                retriever=Mock(),
+                prompt_provider=prompt_provider,
+            )
+
+        graph_store.init.assert_called_once_with()


### PR DESCRIPTION
Invoke existing graph_store.init() lifecycle hook during LexicalGraphIndex initialization, so backend bootstrap logic (if implemented) runs automatically. No API change; no-op for stores that don’t override init().

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
