### PR TITLE
Only copy source code to test notebook if install URI not supplied

### DIFF
--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -226,7 +226,11 @@ mkdir -p graphrag/assets/packages
 mkdir graphrag-toolkit
 mkdir lexical-graph-examples
 
-cp -r $GRAPHRAG_TOOLKIT_DIR/lexical-graph/src/* graphrag-toolkit
+if [[ -z "$LEXICAL_GRAPH_INSTALL_URI" ]]; then
+    # Only copy source code to test notebook if install URI not supplied
+	cp -r $GRAPHRAG_TOOLKIT_DIR/lexical-graph/src/* graphrag-toolkit
+fi
+
 cp -r $GRAPHRAG_TOOLKIT_DIR/lexical-graph-contrib/* graphrag-toolkit
 cp -r $GRAPHRAG_TOOLKIT_DIR/byokg-rag/src/* graphrag-toolkit
 cp -r $GRAPHRAG_TOOLKIT_DIR/examples/lexical-graph/notebooks/* lexical-graph-examples


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By default, the integration tests copy the lexical graph source to the test notebook. When the tests run, they use this local version of the toolkit.

With this change, if a `--lexical-graph-install` parameter is supplied, the source will not be copied to the notebook. This ensures the tests run against the install supplied in the parameter.

For example:

```
sh build-tests.sh --test-file lexical.short
```

will run tests against the source code copied to the notebook, whereas

```
sh build-tests.sh --test-file lexical.short --lexical-graph-install graphrag-lexical-graph
```

will run the tests against the latest version of the toolkit from PyPi.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
