### PR TITLE
feat(neptune): default max_pool_connections to 32

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/neptune_graph_stores.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/neptune_graph_stores.py
@@ -108,6 +108,8 @@ def format_id_for_neptune(id_name:str):
     else:
         return NodeId(parts[1], f'id({parts[0]})', False)
         
+DEFAULT_MAX_POOL_CONNECTIONS = 32
+
 def create_config(config:Optional[str]=None):
     """
     Creates a configuration object for the application, including retries, timeouts, and
@@ -117,6 +119,11 @@ def create_config(config:Optional[str]=None):
     read timeouts, and user agent identifiers. If a configuration string in JSON format is
     provided, it will be parsed and applied to augment or override default settings. The
     toolkit version is dynamically fetched if available.
+
+    ``max_pool_connections`` defaults to :data:`DEFAULT_MAX_POOL_CONNECTIONS` when unset,
+    overriding botocore's default of 10 which serializes the traversal-based retrievers
+    (two sub-retrievers × ``num_workers=10`` each can drive up to 20 concurrent Neptune
+    queries).
 
     Args:
         config: A JSON-formatted string containing additional configuration settings. If not
@@ -136,11 +143,14 @@ def create_config(config:Optional[str]=None):
     config_args = {}
     if config:
         config_args = json.loads(config)
+
+    config_args.setdefault('max_pool_connections', DEFAULT_MAX_POOL_CONNECTIONS)
+
     return Config(
         retries={
-            'total_max_attempts': 1, 
+            'total_max_attempts': 1,
             'mode': 'standard'
-        }, 
+        },
         read_timeout=600,
         user_agent_appid=f'graphrag-lexical-graph-{toolkit_version}',
         **config_args


### PR DESCRIPTION
## Summary

Default `max_pool_connections=32` inside Neptune's `create_config` via `setdefault`, overriding botocore's default of 10 which serializes the traversal-based retrievers.

## Motivation

`create_config` in `neptune_graph_stores.py` builds a botocore `Config` without setting `max_pool_connections`:

```python
return Config(
    retries={'total_max_attempts': 1, 'mode': 'standard'},
    read_timeout=600,
    user_agent_appid=f'graphrag-lexical-graph-{toolkit_version}',
    **config_args,
)
```

Botocore defaults this to 10, but the default `CompositeTraversalBasedRetriever` can drive Neptune to **20 concurrent queries**: `ChunkBasedSearch` and `EntityNetworkSearch` run in parallel, each with `ThreadPoolExecutor(max_workers=num_workers=10)`. Half of those requests queue on the connection pool.

## Why 32?

Code-walk of the default retrieval pipeline:

| Phase | Max concurrent Neptune queries |
|---|---|
| `_init` → `EntityProvider._get_entities` | 10 (runs once) |
| `ChunkBasedSearch.do_graph_search` | 10 |
| `EntityNetworkSearch.do_graph_search` | 10 |
| **Peak simultaneous (both sub-retrievers running)** | **20** |

32 gives ~60% headroom and is symmetric with the OpenSearch pool default proposed in #204. `setdefault` preserves explicit user overrides, so `GraphStoreFactory.for_graph_store(uri, config={"max_pool_connections": N})` continues to work.

## Behaviour / compatibility

- Default callers get 32 instead of 10. Strictly more headroom; no fewer connections are made than before at low concurrency.
- Any user who explicitly passes `max_pool_connections` via the `config=` kwarg still wins (via `setdefault`).
- No API surface change.

## Test plan

- [x] Syntax verified.
- [ ] Manual smoke test against Neptune Serverless — verify no pool-exhaustion stalls under concurrent retrieval.

Fixes #206
