### PR TITLE
feat: show total batch count in pipeline log messages when input is sized

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -292,6 +292,8 @@ class BuildPipeline():
         """
         input_source_documents = source_documents_from_source_types(inputs)
 
+        total_batches = math.ceil(len(inputs) / self.batch_size) if hasattr(inputs, '__len__') else None
+
         for batch_num, source_documents in enumerate(iter_batch(input_source_documents, self.batch_size), 1):
 
             build_timestamp = int(time.time() * 1000)
@@ -301,7 +303,8 @@ class BuildPipeline():
 
             node_batches:List[List[BaseNode]] = self._to_node_batches(source_doc_batches, build_timestamp)
 
-            logger.info(f'Running build pipeline [batch: {batch_num}, batch_size: {self.batch_size}, num_workers: {self.num_workers}, job_sizes: {[len(b) for b in node_batches]}, batch_writes_enabled: {self.batch_writes_enabled}, batch_write_size: {self.batch_write_size}]')
+            batch_label = f'{batch_num}/{total_batches}' if total_batches else f'{batch_num}'
+            logger.info(f'Running build pipeline [batch: {batch_label}, batch_size: {self.batch_size}, num_workers: {self.num_workers}, job_sizes: {[len(b) for b in node_batches]}, batch_writes_enabled: {self.batch_writes_enabled}, batch_write_size: {self.batch_write_size}]')
 
             output_nodes = run_pipeline(
                 self.inner_pipeline,

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import math
 import multiprocessing
 import time
 from pipe import Pipe
@@ -371,6 +372,8 @@ class ExtractionPipeline():
 
         input_source_documents = source_documents_from_source_types(inputs)
 
+        total_batches = math.ceil(len(inputs) / self.batch_size) if hasattr(inputs, '__len__') else None
+
         for batch_num, source_documents in enumerate(iter_batch(input_source_documents, self.batch_size), 1):
 
             for pre_processor in self.pre_processors:
@@ -391,7 +394,8 @@ class ExtractionPipeline():
                 if self.extraction_filters.filter_source_metadata_dictionary(get_source_metadata(node))
             ]
 
-            logger.info(f'Running extraction pipeline [batch: {batch_num}, batch_size: {self.batch_size}, num_workers: {self.num_workers}]')
+            batch_label = f'{batch_num}/{total_batches}' if total_batches else f'{batch_num}'
+            logger.info(f'Running extraction pipeline [batch: {batch_label}, batch_size: {self.batch_size}, num_workers: {self.num_workers}]')
             
             node_batches = node_batcher(
                 num_batches=self.num_workers, 


### PR DESCRIPTION
## Summary

- Extends the batch-number logging added in #96 to include the **total batch count** when the caller passes a sized iterable (e.g. a list).
- True streaming iterators keep the current `batch: N` format — no regression.
- Closes #208 (follow-up to #97).

## Before / After

Before:
```
Running extraction pipeline [batch: 7, batch_size: 16, num_workers: 16]
Running build pipeline [batch: 7, batch_size: 16, ...]
```

After (list input):
```
Running extraction pipeline [batch: 7/12, batch_size: 16, num_workers: 16]
Running build pipeline [batch: 7/12, batch_size: 16, ...]
```

After (generator input — unchanged):
```
Running extraction pipeline [batch: 7, batch_size: 16, num_workers: 16]
```

## Implementation

In both `BuildPipeline.build_nodes()` and `ExtractionPipeline.extract()`:

```python
total_batches = math.ceil(len(inputs) / self.batch_size) if hasattr(inputs, '__len__') else None
...
batch_label = f'{batch_num}/{total_batches}' if total_batches else f'{batch_num}'
logger.info(f'Running ... [batch: {batch_label}, ...]')
```

Zero additional materialization — only `len()` is probed on the input; the iterable is consumed exactly as before.

## Motivation

In non-TTY environments (CloudWatch, ECS, CI/CD) tqdm progress bars are invisible (issue #129) and the per-batch log line is the only progress signal. Knowing *"batch 7 of 12"* vs just *"batch 7"* is the difference between estimating job completion and guessing. See issue #208 for full rationale.

## Test plan

- [ ] Run extraction/build with a `list[Document]` → logs `batch: N/M`
- [ ] Run extraction/build with a generator → logs `batch: N` (format unchanged)
- [ ] Empty input → no log lines (loop body doesn't execute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)