### PR TITLE
perf(retrieval): parallelize the three independent lookups in EntityVSSProvider._get_entities

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/entity_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/entity_vss_provider.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import concurrent.futures
 import logging
 from typing import List, Optional
 
@@ -108,10 +109,22 @@ class EntityVSSProvider(EntityProviderBase):
         def add_to_entities_map(entities):
             all_entities_map.update({e.entity.entityId:e for e in entities})
 
-        add_to_entities_map(self._get_entities_by_keyword_match(keywords, query_bundle))
-        add_to_entities_map(self._get_entities_for_values([query_bundle.query_str]))
-        add_to_entities_map(self._get_entities_for_values(keywords))
-        
+        # The three lookups are independent I/O calls — keyword match against the
+        # graph store, and two VSS top_k + Cypher pairs against the vector + graph
+        # stores. Running them concurrently removes two round-trips' worth of
+        # wall-clock time from every retrieve() that uses this provider. Overlapping
+        # entity IDs return the same ScoredEntity from any of the three calls, so
+        # dict last-writer-wins is idempotent regardless of completion order; the
+        # downstream rerank_entities re-sorts by score.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            futures = [
+                executor.submit(self._get_entities_by_keyword_match, keywords, query_bundle),
+                executor.submit(self._get_entities_for_values, [query_bundle.query_str]),
+                executor.submit(self._get_entities_for_values, keywords),
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                add_to_entities_map(future.result())
+
         return rerank_entities(list(all_entities_map.values()), query_bundle, keywords, self.args.reranker)
         
 


### PR DESCRIPTION
## Summary

- Collapses three strictly-serial I/O calls in `EntityVSSProvider._get_entities` into a 3-worker `ThreadPoolExecutor`.
- Closes #217.
- Validated against production Neptune Serverless + AOSS: **-45% median wall-clock (-172 ms/query)**, byte-identical output.

## The change

One file, `entity_vss_provider.py`, 1 method. The three independent calls today:

```python
add_to_entities_map(self._get_entities_by_keyword_match(keywords, query_bundle))
add_to_entities_map(self._get_entities_for_values([query_bundle.query_str]))
add_to_entities_map(self._get_entities_for_values(keywords))
```

…become:

```python
with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
    futures = [
        executor.submit(self._get_entities_by_keyword_match, keywords, query_bundle),
        executor.submit(self._get_entities_for_values, [query_bundle.query_str]),
        executor.submit(self._get_entities_for_values, keywords),
    ]
    for future in concurrent.futures.as_completed(futures):
        add_to_entities_map(future.result())
```

No API change, no new flags, no behavior toggles. Pattern matches what `CompositeTraversalBasedRetriever` already uses for sub-retriever fan-out.

## Correctness

- The three lookups produce results that are merged into a dict keyed by `entityId`. Overlapping IDs return the same `ScoredEntity` from any of the three calls — same entity data, same score from the same underlying query — so dict last-writer-wins is idempotent regardless of order.
- `rerank_entities` takes `list(all_entities_map.values())` and re-sorts by score, so dict insertion-order drift doesn't affect final ranking.
- Exception behavior preserved: `future.result()` re-raises in the same place the serial version would have.

## Validation

Ran the installed serial method (OLD) against the parallel version (NEW) on production Neptune Serverless + AOSS — toolkit v3.18.3, `pool_maxsize=32` on the OpenSearch client (matching what #204 makes the default post-release). 5 representative queries × 5 runs each, interleaved after warmup, `reranker='tfidf'` for determinism.

**Correctness:** all 5 queries returned identical entity ID sets and identical top-10 rankings.

**Perf (median of 5):**

| Query | OLD (ms) | NEW (ms) | Δ | % |
|---|---:|---:|---:|---:|
| DSP audiences | 383 | 203 | -180 | -47% |
| conversion pixel | 826 | 456 | -370 | -45% |
| seat vs advertiser | 343 | 195 | -147 | -43% |
| exclude bidders | 752 | 448 | -304 | -40% |
| video ads metrics | 359 | 210 | -148 | -41% |
| **Aggregate** | **383** | **210** | **-172** | **-45%** |

Every query shows 40–47% wall-clock savings — a tight spread because all three sub-calls now truly parallelize (no contention on the OpenSearch HTTP pool). The parallel wall-clock tracks the max of the three sub-calls, which is why savings stay consistent across queries of different shapes.

## Backwards compatibility

- Public method signature unchanged.
- Return value is an identically-shaped `List[ScoredEntity]`.
- Any `GraphStore` and `VectorStore` — pure client-side concurrency, no storage-engine features used.
- No new `args` flags or toggles.

## Test plan

- [ ] Existing suite runs green
- [ ] Maintainer spot-check against preferred `GraphStore` (Neo4j, Memgraph, etc.) — change is pure-Python concurrency so it should port cleanly

---

_Note: this PR (and the accompanying [issue #217](https://github.com/awslabs/graphrag-toolkit/issues/217)) was drafted with [Claude Code](https://claude.com/claude-code)_
