### PR TITLE
fix: use response_llm instead of extraction_llm in retrieval components

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
@@ -54,7 +54,7 @@ class KeywordVSSProvider(KeywordProviderBase):
         self.index_name = 'topic' if not isinstance(vector_store.get_index('topic'), DummyVectorIndex) else 'chunk'
 
         self.llm = llm if llm and isinstance(llm, LLMCache) else LLMCache(
-            llm=llm or GraphRAGConfig.extraction_llm,
+            llm=llm or GraphRAGConfig.response_llm,
             enable_cache=GraphRAGConfig.enable_cache if not args.no_cache else not args.no_cache
         )
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/summary/graph_summary.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/summary/graph_summary.py
@@ -51,7 +51,7 @@ class GraphSummary():
     def __init__(self, graph_store:GraphStore, llm:LLMCacheType=None, prompt_template=None, use_cached_entries=True):
         self.graph_store = graph_store
         self.llm = llm if llm and isinstance(llm, LLMCache) else LLMCache(
-            llm=llm or GraphRAGConfig.extraction_llm,
+            llm=llm or GraphRAGConfig.response_llm,
             enable_cache=GraphRAGConfig.enable_cache
         )
         self.prompt_template=prompt_template or GRAPH_SUMMARY_PROMPT


### PR DESCRIPTION
KeywordVSSProvider and GraphSummary are retrieval-time components but incorrectly default to `GraphRAGConfig.extraction_llm`. When a user sets `response_llm` to an active model but leaves `extraction_llm` as default, traversal-based search fails silently at keyword extraction.

This changes both components to use `response_llm`, consistent with `KeywordProvider` and `QueryModeRetriever`.

**Files changed:**
- `lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py`
- `lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/summary/graph_summary.py`