### PR TITLE
fix: update default models from legacy Claude 3.7 Sonnet to Claude Sonnet 4

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -31,8 +31,8 @@ LLMType = Union[LLM, str]
 EmbeddingType = Union[BaseEmbedding, str]
 logger = logging.getLogger(__name__)
 
-DEFAULT_EXTRACTION_MODEL = 'us.anthropic.claude-3-7-sonnet-20250219-v1:0'
-DEFAULT_RESPONSE_MODEL = 'us.anthropic.claude-3-7-sonnet-20250219-v1:0'
+DEFAULT_EXTRACTION_MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0'
+DEFAULT_RESPONSE_MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0'
 DEFAULT_EMBEDDINGS_MODEL = 'cohere.embed-english-v3'
 DEFAULT_RERANKING_MODEL = 'mixedbread-ai/mxbai-rerank-xsmall-v1'
 DEFAULT_BEDROCK_RERANKING_MODEL = 'cohere.rerank-v3-5:0'


### PR DESCRIPTION
The previous default model `us.anthropic.claude-3-7-sonnet-20250219-v1:0` is marked as Legacy by Anthropic on Amazon Bedrock. Accounts that have not used this model in the last 30 days receive a hard `ResourceNotFoundException` error.

Updates both `DEFAULT_EXTRACTION_MODEL` and `DEFAULT_RESPONSE_MODEL` to `us.anthropic.claude-sonnet-4-20250514-v1:0`.

**Files changed:**
- `lexical-graph/src/graphrag_toolkit/lexical_graph/config.py`