### PR TITLE
fix: prepend https:// to AOSS endpoint when using aoss:// connection string

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_index_factory.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_index_factory.py
@@ -45,6 +45,8 @@ class OpenSearchVectorIndexFactory(VectorIndexFactoryMethod):
         endpoint = None
         if vector_index_info.startswith(OPENSEARCH_SERVERLESS):
             endpoint = vector_index_info[len(OPENSEARCH_SERVERLESS):]
+            if not endpoint.startswith('https://'):
+                endpoint = f'https://{endpoint}'
         elif vector_index_info.startswith('https://') and vector_index_info.endswith(OPENSEARCH_SERVERLESS_DNS):
             endpoint = vector_index_info
         if endpoint:


### PR DESCRIPTION
When using `aoss://xyz.us-east-1.aoss.amazonaws.com`, the factory strips the `aoss://` prefix leaving a bare hostname. The `opensearch-py` client defaults bare hostnames to port 9200, but AOSS only listens on 443. This causes a ~530s connection timeout followed by a "Network is unreachable" error.

Now automatically prepends `https://` if not already present after stripping the `aoss://` prefix.

**Files changed:**
- `lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_index_factory.py`