### PR TITLE
fix: preserve http:// scheme in aoss:// connection string

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_index_factory.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_index_factory.py
@@ -45,7 +45,7 @@ class OpenSearchVectorIndexFactory(VectorIndexFactoryMethod):
         endpoint = None
         if vector_index_info.startswith(OPENSEARCH_SERVERLESS):
             endpoint = vector_index_info[len(OPENSEARCH_SERVERLESS):]
-            if not endpoint.startswith('https://'):
+            if not endpoint.startswith('https://') and not endpoint.startswith('http://'):
                 endpoint = f'https://{endpoint}'
         elif vector_index_info.startswith('https://') and vector_index_info.endswith(OPENSEARCH_SERVERLESS_DNS):
             endpoint = vector_index_info


### PR DESCRIPTION
Follow-up to #225. The previous fix always prepended `https://` when no scheme was present, but this would break local OpenSearch instances running on `http://`. Now only prepends `https://` when neither `https://` nor `http://` is present.

- `aoss://my-collection.aoss.amazonaws.com` → prepends `https://` ✅
- `aoss://https://my-collection.aoss.amazonaws.com` → no change ✅
- `aoss://http://localhost:9200` → preserved as-is ✅