### PR TITLE
[FIX] Update all doc links to point to docs-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The graphrag-toolkit is a collection of Python tools for building graph-enhanced
 
 ### Lexical Graph
 
-The [lexical-graph](https://github.com/awslabs/graphrag-toolkit/tree/main/lexical-graph) provides a framework for automating the construction of a [hierarchical lexical graph](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/graph-model.md) from unstructured data, and composing question-answering strategies that query this graph when answering user questions.
+The [lexical-graph](https://github.com/awslabs/graphrag-toolkit/tree/main/lexical-graph) provides a framework for automating the construction of a [hierarchical lexical graph](https://awslabs.github.io/graphrag-toolkit/lexical-graph/graph-model/) from unstructured data, and composing question-answering strategies that query this graph when answering user questions.
 
 ![Lexical graph](https://github.com/awslabs/graphrag-toolkit/raw/main/images/visualisation.png)
 

--- a/byokg-rag/README.md
+++ b/byokg-rag/README.md
@@ -129,13 +129,13 @@ Run the demo notebooks:
 
 ## Configuration Reference
 
-Complete documentation is available in the [docs/byokg-rag/](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/byokg-rag/) directory:
+Complete documentation is available in the [docs/byokg-rag/](https://awslabs.github.io/graphrag-toolkit/byokg-rag/) directory:
 
-- [Overview](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/byokg-rag/overview.md) - Architecture, KGQA approach, and system components
-- [Indexing](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/byokg-rag/indexing.md) - Dense index, fuzzy string index, and graph-store index setup
-- [Graph Stores](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/byokg-rag/graph-stores.md) - Supported graph stores and connection setup
-- [Configuration](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/byokg-rag/configuration.md) - Complete parameter documentation
-- [FAQ](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/byokg-rag/faq.md) - Common questions and troubleshooting
+- [Overview](https://awslabs.github.io/graphrag-toolkit/byokg-rag/overview/) - Architecture, KGQA approach, and system components
+- [Indexing](https://awslabs.github.io/graphrag-toolkit/byokg-rag/indexing/) - Dense index, fuzzy string index, and graph-store index setup
+- [Graph Stores](https://awslabs.github.io/graphrag-toolkit/byokg-rag/graph-stores/) - Supported graph stores and connection setup
+- [Configuration](https://awslabs.github.io/graphrag-toolkit/byokg-rag/configuration/) - Complete parameter documentation
+- [FAQ](https://awslabs.github.io/graphrag-toolkit/byokg-rag/faq/) - Common questions and troubleshooting
 
 ## Examples
 

--- a/byokg-rag/tests/README.md
+++ b/byokg-rag/tests/README.md
@@ -398,4 +398,4 @@ If you encounter segfaults:
 - [pytest documentation](https://docs.pytest.org/)
 - [pytest-cov documentation](https://pytest-cov.readthedocs.io/)
 - [unittest.mock documentation](https://docs.python.org/3/library/unittest.mock.html)
-- [GraphRAG Toolkit documentation](../../docs/byokg-rag/)
+- [GraphRAG Toolkit documentation](https://awslabs.github.io/graphrag-toolkit/byokg-rag/)

--- a/examples/lexical-graph-hybrid-dev/notebooks/01-Local-Extract-Batch.ipynb
+++ b/examples/lexical-graph-hybrid-dev/notebooks/01-Local-Extract-Batch.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## Local extract to folder\n",
     "\n",
-    "See [Run the extract and build stages separately](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/indexing.md#run-the-extract-and-build-stages-separately)"
+    "See [Run the extract and build stages separately](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#run-the-extract-and-build-stages-separately)"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "source": [
     "## Extraction to S3\n",
     "\n",
-    "See [Run the extract and build stages separately](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/indexing.md#run-the-extract-and-build-stages-separately)"
+    "See [Run the extract and build stages separately](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#run-the-extract-and-build-stages-separately)"
    ]
   },
   {

--- a/examples/lexical-graph-hybrid-dev/notebooks/02-Cloud-Setup.ipynb
+++ b/examples/lexical-graph-hybrid-dev/notebooks/02-Cloud-Setup.ipynb
@@ -121,7 +121,7 @@
    "id": "4cb92c81",
    "metadata": {},
    "source": [
-    "If you intend to use the `SentenceReranker` with the `TraversalBasedRetriever` (see the details [here](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/querying.md#statement-reranking)), install the following dependencies: "
+    "If you intend to use the `SentenceReranker` with the `TraversalBasedRetriever` (see the details [here](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/#statement-reranking)), install the following dependencies: "
    ]
   },
   {
@@ -139,7 +139,7 @@
    "id": "8e89630b",
    "metadata": {},
    "source": [
-    "If you intend to use the `BGEReranker` with a GPU machine (see the details [here](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/querying.md#semanticguidedretriever-with-a-reranking-beam-search)), install the following dependencies: "
+    "If you intend to use the `BGEReranker` with a GPU machine (see the details [here](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/#semanticguidedretriever-with-a-reranking-beam-search)), install the following dependencies: "
    ]
   },
   {

--- a/examples/lexical-graph-hybrid-dev/notebooks/04-Cloud-Querying.ipynb
+++ b/examples/lexical-graph-hybrid-dev/notebooks/04-Cloud-Querying.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "### TraversalBasedRetriever\n",
     "\n",
-    "See [TraversalBasedRetriever](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/querying.md#traversalbasedretriever)."
+    "See [TraversalBasedRetriever](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/#traversalbasedretriever)."
    ]
   },
   {
@@ -145,7 +145,7 @@
    "source": [
     "### SemanticGuidedRetriever\n",
     "\n",
-    "See [SemanticGuidedRetriever](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/querying.md#semanticguidedretriever)."
+    "See [SemanticGuidedRetriever](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/#semanticguidedretriever)."
    ]
   },
   {

--- a/examples/lexical-graph-local-dev/notebooks/01-Combined-Extract-and-Build.ipynb
+++ b/examples/lexical-graph-local-dev/notebooks/01-Combined-Extract-and-Build.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## Continuous ingest - Using native llama readers\n",
     "\n",
-    "See [Continous ingest](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/indexing.md#continous-ingest)."
+    "See [Continous ingest](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#continous-ingest)."
    ]
   },
   {

--- a/examples/lexical-graph-local-dev/notebooks/02-Querying.ipynb
+++ b/examples/lexical-graph-local-dev/notebooks/02-Querying.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "### TraversalBasedRetriever\n",
     "\n",
-    "See [TraversalBasedRetriever](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/querying.md#traversalbasedretriever)."
+    "See [TraversalBasedRetriever](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/#traversalbasedretriever)."
    ]
   },
   {

--- a/examples/lexical-graph-local-dev/notebooks/03-Querying-with-Prompting.ipynb
+++ b/examples/lexical-graph-local-dev/notebooks/03-Querying-with-Prompting.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "### TraversalBasedRetriever\n",
     "\n",
-    "See [TraversalBasedRetriever](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/querying.md#traversalbasedretriever)."
+    "See [TraversalBasedRetriever](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/#traversalbasedretriever)."
    ]
   },
   {

--- a/examples/lexical-graph/README.md
+++ b/examples/lexical-graph/README.md
@@ -2,16 +2,16 @@
 
 ### Notebooks
 
-  - [**00-Setup**](./notebooks/00-Setup.ipynb) – Installs the [lexical-graph](../../docs/lexical-graph/overview.md) package and additional dependencies.
-  - [**01-Combined Extract and Build**](./notebooks/01-Combined-Extract-and-Build.ipynb) – An example of [performing continuous ingest](../../docs/lexical-graph/indexing.md#continous-ingest) using the `LexicalGraphIndex.extract_and_build()` method.
-  - [**02-Separate Extract and Build**](./notebooks/02-Separate-Extract-and-Build.ipynb) – An example of [running the extract and build stages separately](../../docs/lexical-graph/indexing.md#run-the-extract-and-build-stages-separately), with intermediate chunks persisted to the local filesystem using a `FileBasedChunks` object.
-  - [**03-Traversal-Based Querying**](./notebooks/03-Traversal-Based-Querying.ipynb) – Examples of [querying the graph](../../docs/lexical-graph/querying.md) using [traversal-based search](../../docs/lexical-graph/traversal-based-search.md). Includes examples of visualising the results.
-  - [**04-Multi-Tenancy**](./notebooks/04-Multi-Tenancy.ipynb) – An example of creating and querying a [multi-tenant](../../docs/lexical-graph/multi-tenancy.md) graph.
+  - [**00-Setup**](./notebooks/00-Setup.ipynb) – Installs the [lexical-graph](https://awslabs.github.io/graphrag-toolkit/lexical-graph/overview/) package and additional dependencies.
+  - [**01-Combined Extract and Build**](./notebooks/01-Combined-Extract-and-Build.ipynb) – An example of [performing continuous ingest](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#continous-ingest) using the `LexicalGraphIndex.extract_and_build()` method.
+  - [**02-Separate Extract and Build**](./notebooks/02-Separate-Extract-and-Build.ipynb) – An example of [running the extract and build stages separately](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#run-the-extract-and-build-stages-separately), with intermediate chunks persisted to the local filesystem using a `FileBasedChunks` object.
+  - [**03-Traversal-Based Querying**](./notebooks/03-Traversal-Based-Querying.ipynb) – Examples of [querying the graph](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/) using [traversal-based search](https://awslabs.github.io/graphrag-toolkit/lexical-graph/traversal-based-search/). Includes examples of visualising the results.
+  - [**04-Multi-Tenancy**](./notebooks/04-Multi-Tenancy.ipynb) – An example of creating and querying a [multi-tenant](https://awslabs.github.io/graphrag-toolkit/lexical-graph/multi-tenancy/) graph.
   - [**05-Agentic-GraphRAG**](./notebooks/05-Agentic-GraphRAG.ipynb) – Example of creating an MCP server for a multi-tenant graph, and using an agent to interact with the lexical graph tools exposed by the server.
   
 #### Environment variables
 
-The notebooks assume that the [graph store and vector store connections](../../docs/lexical-graph/storage-model.md) are stored in `GRAPH_STORE` and `VECTOR_STORE` environment variables. 
+The notebooks assume that the [graph store and vector store connections](https://awslabs.github.io/graphrag-toolkit/lexical-graph/storage-model/) are stored in `GRAPH_STORE` and `VECTOR_STORE` environment variables. 
 
 If you are running these notebooks via the Cloudformation template below, a `.env` file containing these variables will already have been installed in the Amazon SageMaker environment. If you are running these notebooks in a separate environment, you will need to populate these two environment variables.
 

--- a/examples/lexical-graph/notebooks/00-Setup.ipynb
+++ b/examples/lexical-graph/notebooks/00-Setup.ipynb
@@ -121,7 +121,7 @@
    "id": "4cb92c81",
    "metadata": {},
    "source": [
-    "If you intend to use the `SentenceReranker` with the `TraversalBasedRetriever` (see the details [here](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/traversal-based-search-configuration.md#reranking-strategy)), install the following dependencies: "
+    "If you intend to use the `SentenceReranker` with the `TraversalBasedRetriever` (see the details [here](https://awslabs.github.io/graphrag-toolkit/lexical-graph/traversal-based-search-configuration/#reranking-strategy)), install the following dependencies: "
    ]
   },
   {

--- a/examples/lexical-graph/notebooks/01-Combined-Extract-and-Build.ipynb
+++ b/examples/lexical-graph/notebooks/01-Combined-Extract-and-Build.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## Continous ingest\n",
     "\n",
-    "See [Continous ingest](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/indexing.md#continous-ingest)."
+    "See [Continous ingest](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#continous-ingest)."
    ]
   },
   {

--- a/examples/lexical-graph/notebooks/02-Separate-Extract-and-Build.ipynb
+++ b/examples/lexical-graph/notebooks/02-Separate-Extract-and-Build.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## Extract\n",
     "\n",
-    "See [Run the extract and build stages separately](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/indexing.md#run-the-extract-and-build-stages-separately)"
+    "See [Run the extract and build stages separately](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/#run-the-extract-and-build-stages-separately)"
    ]
   },
   {

--- a/examples/lexical-graph/notebooks/03-Querying.ipynb
+++ b/examples/lexical-graph/notebooks/03-Querying.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "### Traversal-based search\n",
     "\n",
-    "See [Traversal-Based Search](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/traversal-based-search.md) in the documentation."
+    "See [Traversal-Based Search](https://awslabs.github.io/graphrag-toolkit/lexical-graph/traversal-based-search/) in the documentation."
    ]
   },
   {

--- a/examples/lexical-graph/notebooks/05-Agentic-GraphRAG.ipynb
+++ b/examples/lexical-graph/notebooks/05-Agentic-GraphRAG.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is an open protocol that standardizes how applications provide context to LLMs.\n",
     "\n",
-    "In this example, we're going to create a 'catalog' of tools, one per tenant in a [multi-tenant](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/multi-tenancy.md) graph. Each tool is capable of answering domain-specific questions based on the data in its tenant graph. This catalog will be advertised to clients via an MCP server. Clients (typically agents and LLMs) can then browse the catalog and choose appropriate tools for addressing their information goals.\n",
+    "In this example, we're going to create a 'catalog' of tools, one per tenant in a [multi-tenant](https://awslabs.github.io/graphrag-toolkit/lexical-graph/multi-tenancy/) graph. Each tool is capable of answering domain-specific questions based on the data in its tenant graph. This catalog will be advertised to clients via an MCP server. Clients (typically agents and LLMs) can then browse the catalog and choose appropriate tools for addressing their information goals.\n",
     "\n",
     "Each tool in the catalog is accompanied by an auto-generated description that helps a client understand the domain, scope, potential uses and kinds of questions covered by the tool. The catalog also includes a 'search' tool, which, given the name of an entity or concept, recommends one or more domain tools with knowledge of the search term."
    ]

--- a/examples/lexical-graph/workshop/assets/Appendix-2-Batch-Extraction.ipynb
+++ b/examples/lexical-graph/workshop/assets/Appendix-2-Batch-Extraction.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this workshop, you've seen how to index data on a chunk-by-chunk basis – either using separate Extract and Build steps, or combined in a single operation. In both cases, individual chunks are passed to an LLM for extraction.\n",
     "\n",
-    "For large datasets, this chunk-by-chunk approach can be slow and costly. [Batch extraction](https://github.com/awslabs/graphrag-toolkit/blob/main/docs/lexical-graph/batch-extraction.md) is a feature of the GraphRAG Toolkit that can significantly improve extraction performance for large datasets It is used with [Amazon Bedrock batch inference](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html) in the Extract stage of the indexing process. Batch extraction submits large batches of chunks to Bedrock for processing simltaneously. Bedrock batch inference workloads are charged at a 50% discount compared to On-Demand pricing.\n",
+    "For large datasets, this chunk-by-chunk approach can be slow and costly. [Batch extraction](https://awslabs.github.io/graphrag-toolkit/lexical-graph/batch-extraction/) is a feature of the GraphRAG Toolkit that can significantly improve extraction performance for large datasets It is used with [Amazon Bedrock batch inference](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html) in the Extract stage of the indexing process. Batch extraction submits large batches of chunks to Bedrock for processing simltaneously. Bedrock batch inference workloads are charged at a 50% discount compared to On-Demand pricing.\n",
     "\n",
     "This Appendix summarizes the batch extraction feature. You won't be using it during this this workshop, but it's good to know it exists for larger workloads.\n",
     "\n",

--- a/lexical-graph/README.md
+++ b/lexical-graph/README.md
@@ -1,6 +1,6 @@
 ## Lexical Graph
 
-The lexical-graph package provides a framework for automating the construction of a [hierarchical lexical graph](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/graph-model.md) from unstructured data, and composing question-answering strategies that query this graph when answering user questions.
+The lexical-graph package provides a framework for automating the construction of a [hierarchical lexical graph](https://awslabs.github.io/graphrag-toolkit/lexical-graph/graph-model/) from unstructured data, and composing question-answering strategies that query this graph when answering user questions.
 
 ### Features
 
@@ -8,9 +8,9 @@ The lexical-graph package provides a framework for automating the construction o
   - Built-in vector store support for Neptune Analytics, [Amazon OpenSearch Serverless](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless.html), [Amazon S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html) and Postgres with the pgvector extension.
   - Built-in support for foundation models (LLMs and embedding models) on [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/).
   - Easily extended to support additional graph and vector stores and model backends.
-  - [Multi-tenancy](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/multi-tenancy.md) – multiple separate lexical graphs in the same underlying graph and vector stores.
-  - Continuous ingest and [batch extraction](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/batch-extraction.md) (using [Bedrock batch inference](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html)) modes.
-  - [Versioned updates](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/versioned-updates.md) for updating source documents and querying the state of the graph and vector stores at a point in time.
+  - [Multi-tenancy](https://awslabs.github.io/graphrag-toolkit/lexical-graph/multi-tenancy/) – multiple separate lexical graphs in the same underlying graph and vector stores.
+  - Continuous ingest and [batch extraction](https://awslabs.github.io/graphrag-toolkit/lexical-graph/batch-extraction/) (using [Bedrock batch inference](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html)) modes.
+  - [Versioned updates](https://awslabs.github.io/graphrag-toolkit/lexical-graph/versioned-updates/) for updating source documents and querying the state of the graph and vector stores at a point in time.
   - Quickstart [AWS CloudFormation templates](https://github.com/awslabs/graphrag-toolkit/tree/main/examples/lexical-graph/cloudformation-templates/) for Neptune Database, OpenSearch Serverless, and Amazon Aurora Postgres.
 
 ## Installation
@@ -35,7 +35,7 @@ Or install from a release zip file:
 $ pip install https://github.com/awslabs/graphrag-toolkit/archive/refs/tags/graphrag-lexical-graph/v3.18.3.zip#subdirectory=lexical-graph
 ```
 
-If you're running on AWS, you must run your application in an AWS region containing the Amazon Bedrock foundation models used by the lexical graph (see the [configuration](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/configuration.md#graphragconfig) section in the documentation for details on the default models used), and must [enable access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) to these models before running any part of the solution.
+If you're running on AWS, you must run your application in an AWS region containing the Amazon Bedrock foundation models used by the lexical graph (see the [configuration](https://awslabs.github.io/graphrag-toolkit/lexical-graph/configuration/#graphragconfig) section in the documentation for details on the default models used), and must [enable access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) to these models before running any part of the solution.
 
 ### Additional dependencies
 
@@ -154,19 +154,19 @@ if __name__ == '__main__':
 
 ## Documentation
 
-  - [Overview](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/overview.md)
-  - [Graph Model](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/graph-model.md)
-  - [Storage Model](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/storage-model.md)
-  - [Indexing](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/indexing.md)
-    - [Batch Extraction](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/batch-extraction.md)
-    - [Configuring Batch Extraction](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/configuring-batch-extraction.md)
-    - [Versioned Updates](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/versioned-updates.md)
-  - [Querying](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/querying.md)
-    - [Traversal-Based Search](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/traversal-based-search.md)
-    - [Traversal-Based Search Configuration](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/traversal-based-search-configuration.md)
-  - [Configuration](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/configuration.md)
-  - [Security](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/security.md)
-  - [FAQ](https://github.com/awslabs/graphrag-toolkit/tree/main/docs/lexical-graph/faq.md)
+  - [Overview](https://awslabs.github.io/graphrag-toolkit/lexical-graph/overview/)
+  - [Graph Model](https://awslabs.github.io/graphrag-toolkit/lexical-graph/graph-model/)
+  - [Storage Model](https://awslabs.github.io/graphrag-toolkit/lexical-graph/storage-model/)
+  - [Indexing](https://awslabs.github.io/graphrag-toolkit/lexical-graph/indexing/)
+    - [Batch Extraction](https://awslabs.github.io/graphrag-toolkit/lexical-graph/batch-extraction/)
+    - [Configuring Batch Extraction](https://awslabs.github.io/graphrag-toolkit/lexical-graph/configuring-batch-extraction/)
+    - [Versioned Updates](https://awslabs.github.io/graphrag-toolkit/lexical-graph/versioned-updates/)
+  - [Querying](https://awslabs.github.io/graphrag-toolkit/lexical-graph/querying/)
+    - [Traversal-Based Search](https://awslabs.github.io/graphrag-toolkit/lexical-graph/traversal-based-search/)
+    - [Traversal-Based Search Configuration](https://awslabs.github.io/graphrag-toolkit/lexical-graph/traversal-based-search-configuration/)
+  - [Configuration](https://awslabs.github.io/graphrag-toolkit/lexical-graph/configuration/)
+  - [Security](https://awslabs.github.io/graphrag-toolkit/lexical-graph/security/)
+  - [FAQ](https://awslabs.github.io/graphrag-toolkit/lexical-graph/faq/)
 
 
 ## Release


### PR DESCRIPTION
## Description

The documentation was migrated from the `docs/` directory to `docs-site/` (Astro/Starlight), deployed at [https://awslabs.github.io/graphrag-toolkit/.](https://awslabs.github.io/graphrag-toolkit/) However, links across READMEs and notebooks still pointed to the removed `docs/` directory.

## Changes

Updates all broken documentation links across 17 files:
- 3 README files (root, lexical-graph, byokg-rag, examples)
- 1 test README (byokg-rag/tests)
- 12 Jupyter notebooks

Replaces:
- `github.com/.../tree/main/docs/lexical-graph/*.md` → `awslabs.github.io/graphrag-toolkit/lexical-graph/*/`
- `github.com/.../blob/main/docs/lexical-graph/*.md` → `awslabs.github.io/graphrag-toolkit/lexical-graph/*/`
- Relative `../../docs/` paths → absolute docs-site URLs

## Testing

No code changes — documentation links only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
