### PR TITLE
[FIX] Skip docs site deployment in forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,12 @@ name: Deploy docs site
 
 # Builds the Astro Starlight site under docs-site/ and publishes it to GitHub Pages.
 # Requires "Settings → Pages → Source: GitHub Actions" to be enabled on the repo.
+#
+# This workflow only runs in the upstream repository (awslabs/graphrag-toolkit).
+# To deploy docs from your fork:
+#   1. Enable GitHub Pages: Settings → Pages → Source → GitHub Actions
+#   2. Remove the 'if: github.repository == ...' conditions from both jobs below
+#   3. Push to your fork's main branch with changes in docs-site/
 
 on:
   push:
@@ -22,6 +28,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'awslabs/graphrag-toolkit'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,6 +48,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.repository == 'awslabs/graphrag-toolkit'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Description

The docs.yml workflow fails in forks because GitHub Pages is not configured. The `deploy-pages` action requires Pages to be enabled in repository settings, which forks don't have by default.

## Changes

Adds `if: github.repository == 'awslabs/graphrag-toolkit'` condition to both `build` and `deploy` jobs in `.github/workflows/docs.yml`.

## Behavior

| Repository | Before | After |
|-----------|--------|-------|
| awslabs/graphrag-toolkit | Deploys docs ✅ | Deploys docs ✅ (unchanged) |
| Any fork | Fails with permissions error ❌ | Jobs skipped (green) ✅ |

## Testing

- No functional code changes — workflow condition only
- Verified the condition syntax matches GitHub Actions documentation
- Standard pattern used across AWS open-source repositories

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
