### PR TITLE
[Fix] Pin the `torch` dependency

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -13,6 +13,6 @@ pyyaml==6.0.3
 sentence-transformers>=2.4.0
 tiktoken==0.11.0
 thefuzz==0.22.1
-torch
+torch>=2.11.0,<2.12.0
 transformers>=4.44.2
 xmltodict==1.0.2


### PR DESCRIPTION
## Description

Pin the `torch` dependency to a known-good version range to address supply chain risk identified during AppSec review.

### Changes

**Dependency Management**

- Pin `torch` from unpinned → `>=2.11.0,<2.12.0` in `byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt`

### Backward Compatibility

- No breaking changes — existing installations within the `>=2.11.0,<2.12.0` range continue to work
- Users on older torch versions will need to upgrade to 2.11.x (latest stable)

### Testing

- No code changes — dependency constraint only
- Existing test suite unaffected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.