### PR TITLE
[Fix] Add git-secrets pre-commit hook for secrets scanning

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,2 @@
+# Example/placeholder AWS account IDs used in documentation
+123456789012

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/awslabs/git-secrets
+    rev: 7d6b970cbd3c216353cb22b383b70c150140662e
+    hooks:
+      - id: git-secrets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,25 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
+### Setting up pre-commit hooks
+
+This repository uses [pre-commit](https://pre-commit.com/) to run security checks (e.g., secrets scanning via [git-secrets](https://github.com/awslabs/git-secrets)) before each commit. To set it up:
+
+```bash
+# Install git-secrets
+brew install git-secrets  # macOS
+# or: git clone https://github.com/awslabs/git-secrets && cd git-secrets && make install
+
+# Install pre-commit and activate hooks
+pip install pre-commit
+pre-commit install
+
+# Register AWS secret patterns
+git secrets --register-aws
+```
+
+The pre-commit framework will automatically run git-secrets on staged files before each commit, preventing accidental secret leaks.
+
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 

--- a/byokg-rag/pyproject.toml
+++ b/byokg-rag/pyproject.toml
@@ -23,6 +23,9 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
 ]
+dev = [
+    "pre-commit>=3.5.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/lexical-graph/pyproject.toml
+++ b/lexical-graph/pyproject.toml
@@ -25,6 +25,9 @@ test = [
     "pytest-asyncio>=0.21.0",
     "hypothesis>=6.0.0",
 ]
+dev = [
+    "pre-commit>=3.5.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Description

Add pre-commit hook with [git-secrets](https://github.com/awslabs/git-secrets) (AWS-owned) for local secrets scanning before commits reach the remote.

### Changes

- Add `.pre-commit-config.yaml` with awslabs/git-secrets hook
- Add `.gitallowed` for example AWS account IDs in documentation
- Add `pre-commit` as dev dependency in both `pyproject.toml` files
- Document pre-commit setup in `CONTRIBUTING.md`

### How it works

Contributors set up once:
```
brew install git-secrets  # or make install from source
pip install pre-commit
pre-commit install
git secrets --register-aws
```

On every commit, git-secrets scans staged files for AWS credential patterns (access keys, secret keys, account IDs). Matches block the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.