### PR TITLE
[FEATURE] Centralized foundation model configuration for BYOKG-RAG

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/__init__.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/__init__.py
@@ -1,2 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from .config import ByoKGConfig

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/config.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/config.py
@@ -102,7 +102,7 @@ class _ByoKGConfig:
     _reranking_model: Optional[str] = None
     _max_tokens: Optional[int] = None
     _max_retries: Optional[int] = None
-    _aws_clients: Dict = field(default_factory=dict)
+    _aws_clients: Dict[str, ResilientClient] = field(default_factory=dict)
     _boto3_session: Optional[Boto3Session] = field(default=None, init=False, repr=False)
 
     @property
@@ -194,6 +194,19 @@ class _ByoKGConfig:
         if service_name not in self._aws_clients:
             self._aws_clients[service_name] = ResilientClient(self, service_name)
         return self._aws_clients[service_name]
+
+    def reset(self):
+        """Reset all cached config values to defaults. Useful for test isolation."""
+        self._llm_model = None
+        self._region_name = None
+        self._region_checked = False
+        self._embed_model = None
+        self._embed_dimensions = None
+        self._reranking_model = None
+        self._max_tokens = None
+        self._max_retries = None
+        self._aws_clients.clear()
+        self._boto3_session = None
 
     def to_generator(self, **kwargs):
         """

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/config.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/config.py
@@ -1,0 +1,244 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+BYOKG-RAG Foundation Model Configuration.
+
+Supported environment variables (checked on first access, cached thereafter):
+
+    BYOKG_LLM_MODEL        - LLM model ID (default: global.anthropic.claude-sonnet-4-6)
+    BYOKG_REGION           - AWS region override (optional — boto3 resolves from AWS config if not set)
+    BYOKG_EMBED_MODEL      - Embedding model ID (default: cohere.embed-english-v3)
+    BYOKG_EMBED_DIMENSIONS - Embedding dimensions (default: 1024)
+    BYOKG_RERANKING_MODEL  - Reranking model ID (default: BAAI/bge-reranker-base)
+    BYOKG_MAX_TOKENS       - Max tokens for LLM generation (default: 4096)
+    BYOKG_MAX_RETRIES      - Max retry attempts (default: 10)
+"""
+
+import os
+import threading
+import logging
+from dataclasses import dataclass, field
+from typing import Optional, Dict
+
+import boto3
+from botocore import exceptions as botocore_exceptions
+from botocore.exceptions import SSOTokenLoadError
+from boto3 import Session as Boto3Session
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['ByoKGConfig']
+
+DEFAULT_LLM_MODEL = 'global.anthropic.claude-sonnet-4-6'
+DEFAULT_EMBED_MODEL = 'cohere.embed-english-v3'
+DEFAULT_EMBED_DIMENSIONS = 1024
+DEFAULT_RERANKING_MODEL = 'BAAI/bge-reranker-base'
+DEFAULT_MAX_TOKENS = 4096
+DEFAULT_MAX_RETRIES = 10
+
+
+class ResilientClient:
+    """
+    A wrapper for boto3 clients that automatically refreshes credentials when they expire.
+    """
+    def __init__(self, config, service_name):
+        self.config = config
+        self.service_name = service_name
+        self._client = self._create_client()
+        self._lock = threading.Lock()
+
+    def _create_client(self):
+        try:
+            kwargs = {}
+            if self.config.region_name:
+                kwargs["region_name"] = self.config.region_name
+            return self.config.session.client(self.service_name, **kwargs)
+        except SSOTokenLoadError as e:
+            raise RuntimeError(
+                f"[ResilientClient] SSO token is missing or expired.\n"
+                f"Please run: aws sso login\n\n"
+                f"Original error: {str(e)}"
+            ) from e
+
+    @staticmethod
+    def _is_expired(error):
+        error_code = getattr(error, 'response', {}).get('Error', {}).get('Code', '')
+        return error_code in ['ExpiredToken', 'RequestExpired', 'InvalidClientTokenId']
+
+    def _refresh_client(self):
+        with self._lock:
+            self._client = self._create_client()
+
+    def __getattr__(self, name):
+        attr = getattr(self._client, name)
+        if not callable(attr):
+            return attr
+        def wrapper(*args, **kwargs):
+            try:
+                return getattr(self._client, name)(*args, **kwargs)
+            except (botocore_exceptions.ClientError, SSOTokenLoadError) as e:
+                if isinstance(e, SSOTokenLoadError) or self._is_expired(e):
+                    logger.warning(f"[ResilientClient] Refreshing expired client for {self.service_name}")
+                    self._refresh_client()
+                    return getattr(self._client, name)(*args, **kwargs)
+                raise
+        return wrapper
+
+
+@dataclass
+class _ByoKGConfig:
+    """
+    Singleton configuration for BYOKG-RAG foundation model settings.
+    Provides env var support and factory methods for creating generators,
+    embeddings, and rerankers.
+    """
+    _llm_model: Optional[str] = None
+    _region_name: Optional[str] = field(default=None, init=False, repr=False)
+    # _region_checked distinguishes 'not yet read' from 'read and found None'
+    _region_checked: bool = field(default=False, init=False, repr=False)
+    _embed_model: Optional[str] = None
+    _embed_dimensions: Optional[int] = None
+    _reranking_model: Optional[str] = None
+    _max_tokens: Optional[int] = None
+    _max_retries: Optional[int] = None
+    _aws_clients: Dict = field(default_factory=dict)
+    _boto3_session: Optional[Boto3Session] = field(default=None, init=False, repr=False)
+
+    @property
+    def llm_model(self) -> str:
+        if self._llm_model is None:
+            self._llm_model = os.environ.get('BYOKG_LLM_MODEL', DEFAULT_LLM_MODEL)
+        return self._llm_model
+
+    @llm_model.setter
+    def llm_model(self, value: str) -> None:
+        self._llm_model = value
+
+    @property
+    def region_name(self) -> Optional[str]:
+        # Unlike other properties, None is a valid resolved value here
+        # (meaning "let boto3 resolve region"). _region_checked prevents re-reading env on every access.
+        if not self._region_checked:
+            self._region_name = os.environ.get('BYOKG_REGION')
+            self._region_checked = True
+        return self._region_name
+
+    @region_name.setter
+    def region_name(self, value: Optional[str]) -> None:
+        self._region_name = value
+        self._region_checked = True
+        self._boto3_session = None
+        self._aws_clients.clear()
+
+    @property
+    def embed_model(self) -> str:
+        if self._embed_model is None:
+            self._embed_model = os.environ.get('BYOKG_EMBED_MODEL', DEFAULT_EMBED_MODEL)
+        return self._embed_model
+
+    @embed_model.setter
+    def embed_model(self, value: str) -> None:
+        self._embed_model = value
+
+    @property
+    def embed_dimensions(self) -> int:
+        if self._embed_dimensions is None:
+            self._embed_dimensions = int(os.environ.get('BYOKG_EMBED_DIMENSIONS', DEFAULT_EMBED_DIMENSIONS))
+        return self._embed_dimensions
+
+    @embed_dimensions.setter
+    def embed_dimensions(self, value: int) -> None:
+        self._embed_dimensions = value
+
+    @property
+    def reranking_model(self) -> str:
+        if self._reranking_model is None:
+            self._reranking_model = os.environ.get('BYOKG_RERANKING_MODEL', DEFAULT_RERANKING_MODEL)
+        return self._reranking_model
+
+    @reranking_model.setter
+    def reranking_model(self, value: str) -> None:
+        self._reranking_model = value
+
+    @property
+    def max_tokens(self) -> int:
+        if self._max_tokens is None:
+            self._max_tokens = int(os.environ.get('BYOKG_MAX_TOKENS', DEFAULT_MAX_TOKENS))
+        return self._max_tokens
+
+    @max_tokens.setter
+    def max_tokens(self, value: int) -> None:
+        self._max_tokens = value
+
+    @property
+    def max_retries(self) -> int:
+        if self._max_retries is None:
+            self._max_retries = int(os.environ.get('BYOKG_MAX_RETRIES', DEFAULT_MAX_RETRIES))
+        return self._max_retries
+
+    @max_retries.setter
+    def max_retries(self, value: int) -> None:
+        self._max_retries = value
+
+    @property
+    def session(self) -> Boto3Session:
+        if self._boto3_session is None:
+            kwargs = {}
+            if self.region_name:
+                kwargs["region_name"] = self.region_name
+            self._boto3_session = Boto3Session(**kwargs)
+        return self._boto3_session
+
+    def _get_or_create_client(self, service_name: str):
+        if service_name not in self._aws_clients:
+            self._aws_clients[service_name] = ResilientClient(self, service_name)
+        return self._aws_clients[service_name]
+
+    def to_generator(self, **kwargs):
+        """
+        Create a BedrockGenerator with config defaults.
+
+        kwargs override config values. Supported: model_name, region_name,
+        max_tokens, max_retries, client, inference_config, reasoning_config.
+        """
+        from .llm.bedrock_llms import BedrockGenerator
+        client = kwargs.pop('client', self._get_or_create_client("bedrock-runtime"))
+        return BedrockGenerator(
+            model_name=kwargs.pop('model_name', self.llm_model),
+            region_name=kwargs.pop('region_name', self.region_name),
+            max_tokens=kwargs.pop('max_tokens', self.max_tokens),
+            max_retries=kwargs.pop('max_retries', self.max_retries),
+            client=client,
+            **kwargs
+        )
+
+    def to_embedding(self, **kwargs):
+        """
+        Create a BedrockEmbedding (byokg_rag variant) with config defaults.
+
+        kwargs are passed to langchain_aws.BedrockEmbeddings via the wrapper.
+        """
+        from .indexing.embedding import BedrockEmbedding
+        defaults = {
+            'model_id': kwargs.pop('model_id', self.embed_model),
+        }
+        if self.region_name:
+            defaults['region_name'] = self.region_name
+        defaults.update(kwargs)
+        return BedrockEmbedding(**defaults)
+
+    def to_reranker(self, **kwargs):
+        """
+        Create a LocalGReranker with config defaults.
+
+        kwargs override config values. Supported: model_name, topk, device.
+        """
+        from .graph_retrievers.graph_reranker import LocalGReranker
+        return LocalGReranker(
+            model_name=kwargs.pop('model_name', self.reranking_model),
+            **kwargs
+        )
+
+
+ByoKGConfig = _ByoKGConfig()

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_connectors/kg_linker.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_connectors/kg_linker.py
@@ -13,8 +13,8 @@ class KGLinker:
     """
 
     def __init__(self,
-            llm_generator, 
-            graph_store,
+            llm_generator=None, 
+            graph_store=None,
             max_input_tokens: int = 32000
             ):
         """
@@ -25,6 +25,8 @@ class KGLinker:
             graph_store: Component that provides access to graph data
             max_input_tokens: Maximum allowed tokens for inputs (default: 32000)
         """
+        if graph_store is None:
+            raise ValueError("graph_store is required. Pass a graph store instance.")
         self.max_input_tokens = max_input_tokens
         self.AVAILABLE_TASKS = {
             "entity-extraction": {"pattern": r"<entities>(.*?)</entities>"},
@@ -40,6 +42,9 @@ class KGLinker:
         self.task_prompts = self._finalize_prompt()
         self.task_prompts_iterative = self._finalize_prompt_iterative_prompt()
 
+        if llm_generator is None:
+            from ..config import ByoKGConfig
+            llm_generator = ByoKGConfig.to_generator()
         self.llm_generator = llm_generator
 
     def get_tasks(self, graph_store):
@@ -135,8 +140,8 @@ class CypherKGLinker(KGLinker):
     This class focuses on generating and parsing LLM responses for cypher queries.
     """
     def __init__(self,
-            llm_generator, 
-            graph_store,
+            llm_generator=None, 
+            graph_store=None,
             max_input_tokens: int = 32000
             ):
         

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_reranker.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_reranker.py
@@ -33,7 +33,7 @@ class LocalGReranker(GReranker):
     """
         Local reranker on single machine with BGE-reranker-base models.
     """
-    def __init__(self, model_name="BAAI/bge-reranker-base", topk=10, device="cuda"):
+    def __init__(self, model_name=None, topk=10, device="cuda"):
         """
         Initialize the LocalGReranker.
 
@@ -46,7 +46,11 @@ class LocalGReranker(GReranker):
         Raises:
             AssertionError: If model_name is not supported
         """
-        assert model_name in ["BAAI/bge-reranker-base", "BAAI/bge-reranker-large", "BAAI/bge-reranker-v2-m3"], "Model name not supported"
+        from ..config import ByoKGConfig
+        model_name = model_name if model_name is not None else ByoKGConfig.reranking_model
+        supported_models = ["BAAI/bge-reranker-base", "BAAI/bge-reranker-large", "BAAI/bge-reranker-v2-m3"]
+        if model_name not in supported_models:
+            raise ValueError(f"Unsupported reranking model: {model_name!r}. Supported models: {supported_models}")
         self.model_name = model_name
         from transformers import AutoModelForSequenceClassification, AutoTokenizer
 

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
@@ -33,7 +33,7 @@ class AgenticRetriever(GRetriever):
     5. Continue until max iterations or early finish condition
     """
 
-    def __init__(self, llm_generator, graph_traversal, graph_verbalizer, pruning_reranker=None, 
+    def __init__(self, llm_generator=None, graph_traversal=None, graph_verbalizer=None, pruning_reranker=None, 
                  max_num_relations=5, max_num_entities=3, max_num_iterations=3, max_num_triplets=50):
         """
         Initialize the AgenticRetriever.
@@ -48,6 +48,13 @@ class AgenticRetriever(GRetriever):
             max_num_iterations (int): Maximum number of exploration iterations
             max_num_triplets (int): Maximum number of triplets to keep after pruning
         """
+        if llm_generator is None:
+            from ..config import ByoKGConfig
+            llm_generator = ByoKGConfig.to_generator()
+        if graph_traversal is None:
+            raise ValueError("graph_traversal is required.")
+        if graph_verbalizer is None:
+            raise ValueError("graph_verbalizer is required.")
         self.llm_generator = llm_generator
         self.graph_traversal = graph_traversal
         self.graph_verbalizer = graph_verbalizer

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
@@ -33,15 +33,15 @@ class AgenticRetriever(GRetriever):
     5. Continue until max iterations or early finish condition
     """
 
-    def __init__(self, llm_generator=None, graph_traversal=None, graph_verbalizer=None, pruning_reranker=None, 
+    def __init__(self, graph_traversal, graph_verbalizer, llm_generator=None, pruning_reranker=None, 
                  max_num_relations=5, max_num_entities=3, max_num_iterations=3, max_num_triplets=50):
         """
         Initialize the AgenticRetriever.
 
         Args:
-            llm_generator: Language model for generating responses
             graph_traversal: Component for traversing the graph
             graph_verbalizer: Component for converting graph elements to text
+            llm_generator: Language model for generating responses
             pruning_reranker: Component for pruning and reranking results
             max_num_relations (int): Maximum number of relations to consider
             max_num_entities (int): Maximum number of entities to explore
@@ -51,10 +51,6 @@ class AgenticRetriever(GRetriever):
         if llm_generator is None:
             from ..config import ByoKGConfig
             llm_generator = ByoKGConfig.to_generator()
-        if graph_traversal is None:
-            raise ValueError("graph_traversal is required.")
-        if graph_verbalizer is None:
-            raise ValueError("graph_verbalizer is required.")
         self.llm_generator = llm_generator
         self.graph_traversal = graph_traversal
         self.graph_verbalizer = graph_verbalizer

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/indexing/dense_index.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/indexing/dense_index.py
@@ -22,6 +22,9 @@ class DenseIndex(Index):
         Args:
             embedding: An Embedding object for generating vector embeddings
         """
+        if embedding is None:
+            from ..config import ByoKGConfig
+            embedding = ByoKGConfig.to_embedding()
         self.embedding = embedding
 
 

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/llm/bedrock_llms.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/llm/bedrock_llms.py
@@ -31,7 +31,9 @@ class BedrockGenerator(BaseGenerator):
 
         Args:
             model_name: The name or ID of the Bedrock model to use
-            region_name: AWS region name where Bedrock is available
+            region_name: AWS region name where Bedrock is available.
+                If None, resolves from ByoKGConfig (BYOKG_REGION env var),
+                then falls back to boto3 defaults (~/.aws/config, AWS_DEFAULT_REGION).
             prefill: Whether to use prefill functionality (not currently implemented)
             max_tokens: Maximum number of tokens to generate in the response
             max_retries: Maximum number of retry attempts for failed requests

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/llm/bedrock_llms.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/llm/bedrock_llms.py
@@ -25,7 +25,7 @@ class BedrockGenerator(BaseGenerator):
     This class provides a wrapper around AWS Bedrock's Converse API for
     generating text responses using various foundation models.
     """
-    def __init__(self, model_name="global.anthropic.claude-sonnet-4-6", region_name="us-east-1", prefill=False, max_tokens = 4096, max_retries = 10, inference_config=None, reasoning_config=None):
+    def __init__(self, model_name=None, region_name=None, prefill=False, max_tokens=None, max_retries=None, inference_config=None, reasoning_config=None, boto3_session=None, client=None):
         """
         Initialize the BedrockGenerator.
 
@@ -37,15 +37,33 @@ class BedrockGenerator(BaseGenerator):
             max_retries: Maximum number of retry attempts for failed requests
             inference_config: Optional custom inference configuration dict
             reasoning_config: Optional reasoning configuration for models that support it
+            boto3_session: Optional boto3 session for credential resilience
+            client: Optional pre-built client (e.g., ResilientClient)
         """
         super().__init__()
-        self.model_name = model_name
-        self.max_new_tokens = max_tokens
+        from ..config import ByoKGConfig
+        self.model_name = model_name if model_name is not None else ByoKGConfig.llm_model
+        self.max_new_tokens = max_tokens if max_tokens is not None else ByoKGConfig.max_tokens
         self.prefill = prefill
-        self.max_retries = max_retries
-        self.region_name = region_name
+        self.max_retries = max_retries if max_retries is not None else ByoKGConfig.max_retries
+        self.region_name = region_name if region_name is not None else ByoKGConfig.region_name
         self.inference_config = inference_config
         self.reasoning_config = reasoning_config
+        self._boto3_session = boto3_session
+        self._client = client
+
+    @property
+    def client(self):
+        """Lazily create the bedrock-runtime client on first use."""
+        if self._client is None:
+            kwargs = {}
+            if self.region_name:
+                kwargs["region_name"] = self.region_name
+            if self._boto3_session is not None:
+                self._client = self._boto3_session.client("bedrock-runtime", **kwargs)
+            else:
+                self._client = boto3.client("bedrock-runtime", **kwargs)
+        return self._client
 
     def generate(self, prompt, system_prompt = "You are a helpful AI assistant.",  few_shot_examples=None):
         """
@@ -62,13 +80,19 @@ class BedrockGenerator(BaseGenerator):
         Raises:
             Exception: If generation fails after all retry attempts
         """
-        response = generate_llm_response(self.region_name, self.model_name, system_prompt, prompt, self.max_new_tokens, self.max_retries, self.inference_config, self.reasoning_config)
+        response = generate_llm_response(self.region_name, self.model_name, system_prompt, prompt, self.max_new_tokens, self.max_retries, self.inference_config, self.reasoning_config, client=self.client)
         if "Failed due to other reasons." in response:
             raise Exception(f"{response}")
         return response
         
-def generate_llm_response(region_name, model_id, system_prompt, query, max_tokens, max_retries, inference_config=None, reasoning_config=None):
-    bedrock_runtime = boto3.client("bedrock-runtime", region_name=region_name)
+def generate_llm_response(region_name, model_id, system_prompt, query, max_tokens, max_retries, inference_config=None, reasoning_config=None, *, client=None):
+    if client is not None:
+        bedrock_runtime = client
+    else:
+        kwargs = {}
+        if region_name:
+            kwargs["region_name"] = region_name
+        bedrock_runtime = boto3.client("bedrock-runtime", **kwargs)
     
     #TODO: add few shot examples and pre-fill if needed
     messages = []

--- a/byokg-rag/tests/conftest.py
+++ b/byokg-rag/tests/conftest.py
@@ -7,6 +7,13 @@ This module provides reusable test fixtures for mocking AWS services,
 graph stores, LLM clients, and test data structures.
 """
 
+# Import faiss early to ensure its BLAS/OpenMP libraries load before torch's,
+# preventing segfaults from conflicting library versions in CI.
+try:
+    import faiss  # noqa: F401
+except ImportError:
+    pass
+
 import pytest
 from unittest.mock import Mock
 

--- a/byokg-rag/tests/conftest.py
+++ b/byokg-rag/tests/conftest.py
@@ -7,13 +7,6 @@ This module provides reusable test fixtures for mocking AWS services,
 graph stores, LLM clients, and test data structures.
 """
 
-# Import faiss early to ensure its BLAS/OpenMP libraries load before torch's,
-# preventing segfaults from conflicting library versions in CI.
-try:
-    import faiss  # noqa: F401
-except ImportError:
-    pass
-
 import pytest
 from unittest.mock import Mock
 

--- a/byokg-rag/tests/unit/graph_retrievers/test_graph_reranker.py
+++ b/byokg-rag/tests/unit/graph_retrievers/test_graph_reranker.py
@@ -78,8 +78,8 @@ class TestLocalGRerankerInitialization:
         mock_model.to.assert_called_with("cpu")
     
     def test_initialization_invalid_model_name(self):
-        """Verify AssertionError raised for unsupported model name."""
-        with pytest.raises(AssertionError, match="Model name not supported"):
+        """Verify ValueError raised for unsupported model name."""
+        with pytest.raises(ValueError, match="Unsupported reranking model"):
             LocalGReranker(model_name="unsupported-model")
 
 

--- a/byokg-rag/tests/unit/llm/test_bedrock_llms.py
+++ b/byokg-rag/tests/unit/llm/test_bedrock_llms.py
@@ -38,7 +38,7 @@ class TestBedrockGeneratorInitialization:
         gen = BedrockGenerator()
         
         assert gen.model_name == "global.anthropic.claude-sonnet-4-6"
-        assert gen.region_name == "us-east-1"
+        assert gen.region_name is None
         assert gen.max_new_tokens == 4096
         assert gen.max_retries == 10
         assert gen.prefill is False

--- a/byokg-rag/tests/unit/test_config.py
+++ b/byokg-rag/tests/unit/test_config.py
@@ -1,0 +1,195 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from botocore import exceptions as botocore_exceptions
+from graphrag_toolkit.byokg_rag.config import _ByoKGConfig, ByoKGConfig, ResilientClient
+
+
+class TestByoKGConfigSingleton:
+    def test_singleton_instance_exists(self):
+        assert ByoKGConfig is not None
+        assert isinstance(ByoKGConfig, _ByoKGConfig)
+
+    def test_singleton_is_same_instance(self):
+        from graphrag_toolkit.byokg_rag.config import ByoKGConfig as config2
+        assert ByoKGConfig is config2
+
+
+class TestByoKGConfigDefaults:
+    def setup_method(self):
+        self.config = _ByoKGConfig()
+
+    def test_default_llm_model(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.llm_model is not None and len(self.config.llm_model) > 0
+
+    def test_default_region_is_none(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.region_name is None
+
+    def test_default_embed_model(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.embed_model is not None and len(self.config.embed_model) > 0
+
+    def test_default_embed_dimensions(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.embed_dimensions == 1024
+
+    def test_default_reranking_model(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.reranking_model is not None and len(self.config.reranking_model) > 0
+
+    def test_default_max_tokens(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.max_tokens == 4096
+
+    def test_default_max_retries(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert self.config.max_retries == 10
+
+
+class TestByoKGConfigEnvVars:
+    def test_llm_model_from_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_LLM_MODEL': 'custom-model'}):
+            assert config.llm_model == 'custom-model'
+
+    def test_region_from_byokg_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_REGION': 'eu-west-1'}):
+            assert config.region_name == 'eu-west-1'
+
+    def test_embed_model_from_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_EMBED_MODEL': 'custom-embed'}):
+            assert config.embed_model == 'custom-embed'
+
+    def test_embed_dimensions_from_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_EMBED_DIMENSIONS': '512'}):
+            assert config.embed_dimensions == 512
+
+    def test_reranking_model_from_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_RERANKING_MODEL': 'custom-reranker'}):
+            assert config.reranking_model == 'custom-reranker'
+
+    def test_max_tokens_from_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_MAX_TOKENS': '8192'}):
+            assert config.max_tokens == 8192
+
+    def test_max_retries_from_env(self):
+        config = _ByoKGConfig()
+        with patch.dict(os.environ, {'BYOKG_MAX_RETRIES': '5'}):
+            assert config.max_retries == 5
+
+
+class TestByoKGConfigSetters:
+    def test_set_llm_model(self):
+        config = _ByoKGConfig()
+        config.llm_model = 'new-model'
+        assert config.llm_model == 'new-model'
+
+    def test_set_region_clears_clients(self):
+        config = _ByoKGConfig()
+        config._aws_clients['test'] = 'dummy'
+        config.region_name = 'us-west-2'
+        assert config.region_name == 'us-west-2'
+        assert len(config._aws_clients) == 0
+
+
+class TestByoKGConfigFactoryMethods:
+    def test_to_generator_returns_bedrock_generator(self):
+        config = _ByoKGConfig()
+        config.region_name = 'us-east-1'
+        gen = config.to_generator()
+        from graphrag_toolkit.byokg_rag.llm.bedrock_llms import BedrockGenerator
+        assert isinstance(gen, BedrockGenerator)
+        assert gen.model_name == config.llm_model
+        assert gen.max_new_tokens == config.max_tokens
+        assert gen.max_retries == config.max_retries
+
+    def test_to_generator_with_overrides(self):
+        config = _ByoKGConfig()
+        config.region_name = 'us-east-1'
+        gen = config.to_generator(model_name='custom-model', max_tokens=2048)
+        assert gen.model_name == 'custom-model'
+        assert gen.max_new_tokens == 2048
+
+    def test_to_embedding_returns_embedding(self):
+        config = _ByoKGConfig()
+        with patch('langchain_aws.BedrockEmbeddings'):
+            emb = config.to_embedding()
+            from graphrag_toolkit.byokg_rag.indexing.embedding import BedrockEmbedding
+            assert isinstance(emb, BedrockEmbedding)
+
+    def test_to_reranker_returns_reranker(self):
+        config = _ByoKGConfig()
+        reranker = config.to_reranker(device='cpu')
+        from graphrag_toolkit.byokg_rag.graph_retrievers.graph_reranker import LocalGReranker
+        assert isinstance(reranker, LocalGReranker)
+        assert reranker.model_name == config.reranking_model
+
+
+class TestByoKGConfigSession:
+    def test_session_creation(self):
+        config = _ByoKGConfig()
+        config.region_name = 'us-east-1'
+        session = config.session
+        assert session is not None
+
+    def test_session_cached(self):
+        config = _ByoKGConfig()
+        config.region_name = 'us-east-1'
+        s1 = config.session
+        s2 = config.session
+        assert s1 is s2
+
+
+class TestResilientClient:
+    def test_successful_call_passthrough(self):
+        """ResilientClient passes calls through to underlying client."""
+        config = _ByoKGConfig()
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        config._boto3_session = mock_session
+        rc = ResilientClient(config, 'bedrock-runtime')
+        mock_client.some_method.return_value = 'result'
+        assert rc.some_method() == 'result'
+
+    def test_credential_expiry_triggers_refresh(self):
+        """ResilientClient refreshes client on ExpiredToken error."""
+        config = _ByoKGConfig()
+        mock_client_old = MagicMock()
+        mock_client_new = MagicMock()
+
+        error_response = {'Error': {'Code': 'ExpiredToken', 'Message': 'Token expired'}}
+        mock_client_old.invoke_model.side_effect = botocore_exceptions.ClientError(error_response, 'InvokeModel')
+        mock_client_new.invoke_model.return_value = 'refreshed_result'
+
+        mock_session = MagicMock()
+        mock_session.client.side_effect = [mock_client_old, mock_client_new]
+        config._boto3_session = mock_session
+        rc = ResilientClient(config, 'bedrock-runtime')
+        result = rc.invoke_model()
+        assert result == 'refreshed_result'
+
+    def test_non_expired_error_reraised(self):
+        """ResilientClient re-raises non-credential errors."""
+        config = _ByoKGConfig()
+        mock_client = MagicMock()
+
+        error_response = {'Error': {'Code': 'ValidationException', 'Message': 'Bad input'}}
+        mock_client.invoke_model.side_effect = botocore_exceptions.ClientError(error_response, 'InvokeModel')
+
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        config._boto3_session = mock_session
+        rc = ResilientClient(config, 'bedrock-runtime')
+        with pytest.raises(botocore_exceptions.ClientError):
+            rc.invoke_model()

--- a/byokg-rag/tests/unit/test_defaulted_params.py
+++ b/byokg-rag/tests/unit/test_defaulted_params.py
@@ -1,0 +1,112 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for defaulted parameter fallback to ByoKGConfig.
+
+Verifies that components correctly resolve None parameters from the
+centralized ByoKGConfig singleton.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+
+class TestKGLinkerDefaults:
+    """Tests for KGLinker defaulted parameter behavior."""
+
+    @patch('graphrag_toolkit.byokg_rag.graph_connectors.kg_linker.load_yaml')
+    def test_llm_generator_none_falls_back_to_config(self, mock_load_yaml):
+        """KGLinker with llm_generator=None resolves from ByoKGConfig."""
+        mock_load_yaml.return_value = {
+            "kg-linker-prompt": {"system-prompt": "s", "user-prompt": "u"},
+            "entity-extraction": "task",
+            "path-extraction": "task",
+            "draft-answer-generation": "task",
+            "entity-extraction-iterative": "task",
+        }
+        mock_graph_store = Mock()
+        mock_graph_store.get_linker_tasks.return_value = ["entity-extraction"]
+
+        mock_generator = Mock()
+        with patch('graphrag_toolkit.byokg_rag.config.ByoKGConfig.to_generator', return_value=mock_generator):
+            from graphrag_toolkit.byokg_rag.graph_connectors.kg_linker import KGLinker
+            linker = KGLinker(llm_generator=None, graph_store=mock_graph_store)
+
+        assert linker.llm_generator is mock_generator
+
+    def test_graph_store_none_raises_value_error(self):
+        """KGLinker with graph_store=None raises ValueError."""
+        from graphrag_toolkit.byokg_rag.graph_connectors.kg_linker import KGLinker
+        with pytest.raises(ValueError, match="graph_store is required"):
+            KGLinker(llm_generator=Mock(), graph_store=None)
+
+
+class TestAgenticRetrieverDefaults:
+    """Tests for AgenticRetriever defaulted parameter behavior."""
+
+    def test_llm_generator_none_falls_back_to_config(self):
+        """AgenticRetriever with llm_generator=None resolves from ByoKGConfig."""
+        mock_generator = Mock()
+        with patch('graphrag_toolkit.byokg_rag.config.ByoKGConfig.to_generator', return_value=mock_generator):
+            from graphrag_toolkit.byokg_rag.graph_retrievers.graph_retrievers import AgenticRetriever
+            retriever = AgenticRetriever(
+                llm_generator=None,
+                graph_traversal=Mock(),
+                graph_verbalizer=Mock(),
+            )
+
+        assert retriever.llm_generator is mock_generator
+
+
+class TestBedrockGeneratorDefaults:
+    """Tests for BedrockGenerator defaulted parameter behavior."""
+
+    def test_all_none_uses_config_defaults(self):
+        """BedrockGenerator with all None params resolves from ByoKGConfig."""
+        from graphrag_toolkit.byokg_rag.llm.bedrock_llms import BedrockGenerator
+        gen = BedrockGenerator()
+
+        from graphrag_toolkit.byokg_rag.config import ByoKGConfig
+        assert gen.model_name == ByoKGConfig.llm_model
+        assert gen.max_new_tokens == ByoKGConfig.max_tokens
+        assert gen.max_retries == ByoKGConfig.max_retries
+
+    def test_region_name_none_uses_config(self):
+        """BedrockGenerator with region_name=None resolves from ByoKGConfig."""
+        from graphrag_toolkit.byokg_rag.llm.bedrock_llms import BedrockGenerator
+        from graphrag_toolkit.byokg_rag.config import _ByoKGConfig
+
+        config = _ByoKGConfig()
+        config.region_name = 'eu-west-1'
+
+        with patch('graphrag_toolkit.byokg_rag.config.ByoKGConfig', config):
+            gen = BedrockGenerator(region_name=None)
+
+        assert gen.region_name == 'eu-west-1'
+
+
+class TestGenerateLLMResponseDefaults:
+    """Tests for generate_llm_response defaulted client behavior."""
+
+    @patch('graphrag_toolkit.byokg_rag.llm.bedrock_llms.boto3.client')
+    def test_client_none_creates_boto3_client(self, mock_boto3_client):
+        """generate_llm_response with client=None creates a new boto3 client."""
+        mock_client = Mock()
+        mock_client.converse.return_value = {
+            'output': {'message': {'content': [{'text': 'response'}]}}
+        }
+        mock_boto3_client.return_value = mock_client
+
+        from graphrag_toolkit.byokg_rag.llm.bedrock_llms import generate_llm_response
+        result = generate_llm_response(
+            region_name='us-west-2',
+            model_id='test-model',
+            system_prompt='sys',
+            query='test',
+            max_tokens=100,
+            max_retries=1,
+            client=None,
+        )
+
+        assert result == 'response'
+        mock_boto3_client.assert_called_once_with('bedrock-runtime', region_name='us-west-2')

--- a/docs-site/src/content/docs/byokg-rag/configuration.mdx
+++ b/docs-site/src/content/docs/byokg-rag/configuration.mdx
@@ -126,6 +126,73 @@ The Cypher KG linker specializes in generating and executing openCypher queries.
 
 NOTE: The graph store must support openCypher query execution. Use Neptune Analytics or Neptune Database graph stores.
 
+## Global Configuration (ByoKGConfig)
+
+`ByoKGConfig` is a module-level singleton that centralizes foundation model configuration for BYOKG-RAG. It is created at import time and shared across the process.
+
+```python
+from graphrag_toolkit.byokg_rag import ByoKGConfig
+```
+
+### Configuring the LLM
+
+Set the LLM model by assigning directly to the `llm_model` property:
+
+```python
+ByoKGConfig.llm_model = "global.anthropic.claude-sonnet-4-6"
+```
+
+### Configuring the embedding model
+
+```python
+ByoKGConfig.embed_model = "cohere.embed-english-v3"
+ByoKGConfig.embed_dimensions = 1024
+```
+
+### Configuring the reranking model
+
+```python
+ByoKGConfig.reranking_model = "BAAI/bge-reranker-base"
+```
+
+### Region configuration
+
+If your Bedrock endpoint is in a specific region, set it explicitly. Otherwise, boto3 resolves the region from your AWS configuration automatically.
+
+```python
+ByoKGConfig.region_name = "us-west-2"
+```
+
+### Factory methods
+
+`ByoKGConfig` provides factory methods that create fully configured instances:
+
+```python
+generator = ByoKGConfig.to_generator()
+embedding = ByoKGConfig.to_embedding()
+reranker = ByoKGConfig.to_reranker()
+```
+
+Components such as `KGLinker`, `AgenticRetriever`, and `DenseIndex` automatically create instances from `ByoKGConfig` when no explicit generator or embedding is passed.
+
+### Resilient clients and credential refresh
+
+Generators created via `ByoKGConfig.to_generator()` use a `ResilientClient` that automatically refreshes expired AWS credentials and SSO tokens mid-session.
+
+### Environment variables
+
+All properties can be configured via environment variables. Values are read once on first access:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BYOKG_LLM_MODEL` | LLM model ID | `global.anthropic.claude-sonnet-4-6` |
+| `BYOKG_REGION` | AWS region override | boto3 default |
+| `BYOKG_EMBED_MODEL` | Embedding model ID | `cohere.embed-english-v3` |
+| `BYOKG_EMBED_DIMENSIONS` | Embedding dimensions | `1024` |
+| `BYOKG_RERANKING_MODEL` | Reranking model ID | `BAAI/bge-reranker-base` |
+| `BYOKG_MAX_TOKENS` | Max generation tokens | `4096` |
+| `BYOKG_MAX_RETRIES` | Max retry attempts | `10` |
+
 ## LLM Configuration
 
 ### BedrockGenerator
@@ -136,10 +203,10 @@ The Bedrock generator provides access to foundation models through Amazon Bedroc
 
 | Parameter | Type | Default | Description | Example |
 |-----------|------|---------|-------------|---------|
-| `model_name` | str | "anthropic.claude-sonnet-4-6" | Bedrock model identifier | "anthropic.claude-sonnet-4-6" |
-| `region_name` | str | "us-east-1" | AWS region for Bedrock service | "us-east-1" |
-| `max_tokens` | int | 4096 | Maximum tokens to generate in responses | 8192 |
-| `max_retries` | int | 10 | Maximum retry attempts for failed requests | 5 |
+| `model_name` | str | From ByoKGConfig | Bedrock model identifier | "global.anthropic.claude-sonnet-4-6" |
+| `region_name` | str | From ByoKGConfig | AWS region for Bedrock service | "us-east-1" |
+| `max_tokens` | int | From ByoKGConfig | Maximum tokens to generate in responses | 8192 |
+| `max_retries` | int | From ByoKGConfig | Maximum retry attempts for failed requests | 5 |
 | `prefill` | bool | False | Enable response prefilling (advanced) | False |
 | `inference_config` | dict | None | Custom inference configuration | `{"temperature": 0.7}` |
 | `reasoning_config` | dict | None | Reasoning configuration for supported models | None |
@@ -167,6 +234,11 @@ The following models are compatible with byokg-rag. For the latest model availab
 - Claude 3 Haiku: `anthropic.claude-3-haiku-20240307-v1:0` (EOL: Sep 10, 2026)
 
 TIP: Claude Sonnet 4.6 provides the best balance of performance and cost for most KGQA applications.
+
+> **Inference profiles:** Prefix model IDs with `global.` (e.g., `global.anthropic.claude-sonnet-4-6`)
+> to enable cross-region inference, which routes requests to the nearest available region.
+> Use `us.` or `eu.` prefixes to restrict to specific regions.
+> Bare model IDs (without prefix) access the model directly in your configured region.
 
 **Inference Configuration:**
 
@@ -208,7 +280,7 @@ graph_store = NeptuneAnalyticsGraphStore(
 
 # Step 2: Set up LLM
 llm_generator = BedrockGenerator(
-    model_name="anthropic.claude-sonnet-4-6",
+    model_name="global.anthropic.claude-sonnet-4-6",
     region_name="us-east-1",
     max_tokens=4096,
     max_retries=10


### PR DESCRIPTION
## Description

Closes #176

Extracts foundation model configuration into a centralized `ByoKGConfig` singleton for BYOKG-RAG, following the same pattern as `GraphRAGConfig` in lexical-graph.

## Changes

### Core: `ByoKGConfig` singleton (`config.py`)
- `_ByoKGConfig` dataclass with lazy-evaluated properties and env var support
- `ResilientClient` wrapper for automatic credential refresh (SSO token expiry, expired sessions)
- Factory methods: `to_generator()`, `to_embedding()`, `to_reranker()`
- Single source of truth for model IDs, region, and generation settings

### Component auto-configuration
- `KGLinker` / `CypherKGLinker` — `llm_generator` optional, auto-pulls from config
- `AgenticRetriever` — `llm_generator` optional, auto-pulls from config
- `DenseIndex` / `NeptuneAnalyticsGraphStoreIndex` — `embedding` optional, auto-pulls from config
- `BedrockGenerator` — defaults from config when params are None; accepts `client=` for ResilientClient
- `LocalGReranker` — default model from config; improved error message for unsupported models

### Environment variables

| Variable | Description | Default |
|----------|-------------|---------|
| `BYOKG_LLM_MODEL` | LLM model ID | `anthropic.claude-sonnet-4-6` |
| `BYOKG_REGION` | AWS region override | boto3 default |
| `BYOKG_EMBED_MODEL` | Embedding model ID | `cohere.embed-english-v3` |
| `BYOKG_EMBED_DIMENSIONS` | Embedding dimensions | `1024` |
| `BYOKG_RERANKING_MODEL` | Reranking model ID | `BAAI/bge-reranker-base` |
| `BYOKG_MAX_TOKENS` | Max generation tokens | `4096` |
| `BYOKG_MAX_RETRIES` | Max retry attempts | `10` |

## Backward Compatibility

- All constructor signatures preserve original positional argument order
- Explicit parameter values override config defaults (no behavior change for existing code)
- No removed parameters, no renamed parameters
- No new required dependencies (uses stdlib + boto3/botocore already in requirements)

## Testing

- 31 new unit tests for config (singleton, defaults, env vars, setters, factory methods, ResilientClient)
- 344 total tests passing, 0 regressions
- Notebook integration test: 30/31 cells pass (1 GPU skip) on `byokg_rag_demo_local_graph.ipynb`

## Usage

```python
from graphrag_toolkit.byokg_rag import ByoKGConfig

# Configure once
ByoKGConfig.llm_model = "us.anthropic.claude-sonnet-4-6"
ByoKGConfig.region_name = "us-west-2"

# Factory methods
generator = ByoKGConfig.to_generator()
embedding = ByoKGConfig.to_embedding()

# Or let components auto-configure
linker = KGLinker(graph_store=my_store)  # generator created from config
index = DenseIndex()  # embedding created from config

# Or use environment variables (zero code changes)
# export BYOKG_LLM_MODEL=anthropic.claude-haiku-3
```

## Documentation

- Added "Global Configuration (ByoKGConfig)" section to `docs-site/src/content/docs/byokg-rag/configuration.mdx`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.