### PR TITLE
[FIX] Cast embeddings to float32 before FAISS search to prevent segfault

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/indexing/dense_index.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/indexing/dense_index.py
@@ -68,7 +68,7 @@ class LocalFaissDenseIndex(DenseIndex):
         :return:
         """
 
-        query_emb = np.array(self.embedding.embed(input)).reshape(1, -1)
+        query_emb = np.array(self.embedding.embed(input), dtype=np.float32).reshape(1, -1)
 
         if id_selector is None:
             D, I = self.faiss_index.search(query_emb, topk)
@@ -94,7 +94,7 @@ class LocalFaissDenseIndex(DenseIndex):
         if id_selector is not None:
             raise NotImplementedError(f"id_selector not implemented for {self.__class__.__name__}")
 
-        query_emb = np.array(self.embedding.batch_embed(inputs)).reshape(len(inputs), -1)
+        query_emb = np.array(self.embedding.batch_embed(inputs), dtype=np.float32).reshape(len(inputs), -1)
 
         D, I = self.faiss_index.search(query_emb, topk)
 
@@ -133,9 +133,9 @@ class LocalFaissDenseIndex(DenseIndex):
             None
         """
         if isinstance(embeddings, np.ndarray):
-            doc_embs = embeddings
+            doc_embs = embeddings.astype(np.float32)
         else:
-            doc_embs = np.array(self.embedding.batch_embed(documents))
+            doc_embs = np.array(self.embedding.batch_embed(documents), dtype=np.float32)
         self.doc_store.extend(documents)
         self.doc_ids.extend(ids)
         for _id in ids:


### PR DESCRIPTION
## Description

Fixes segfault in `test_dense_index_match_multiple_queries` on Linux/Python 3.10 CI.

## Changes

- Added explicit `dtype=np.float32` to numpy array creation before FAISS index operations in `dense_index.py`

## Root Cause

FAISS C++ `search()` expects `float32` arrays. `np.array()` defaults to `float64`. On platforms where faiss-cpu does not auto-convert dtypes (Linux x86/Python 3.10), the SWIG wrapper passes a `float64` pointer to C++ code that interprets it as `float32`, reading garbage memory and causing a segfault.

## Testing

- All 16 dense_index tests pass (previously 1 segfault)
- No regressions in other tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.