### PR TITLE
Change info message to warning for undersize batches

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_extractor_base.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_extractor_base.py
@@ -238,7 +238,7 @@ class BatchExtractorBase(BaseExtractor):
 
         if len(node_file_paths.keys()) < BEDROCK_MIN_BATCH_SIZE:
 
-            logger.info(f'[{self.description} batch] Not enough records to run batch extraction. List of nodes contains fewer records ({len(node_file_paths.keys())}) than the minimum required by Bedrock ({BEDROCK_MIN_BATCH_SIZE}), so running non-batch extractor instead.')
+            logger.warning(f'[{self.description} batch] Not enough records to run batch extraction. List of nodes contains fewer records ({len(node_file_paths.keys())}) than the minimum required by Bedrock ({BEDROCK_MIN_BATCH_SIZE}), so running non-batch extractor instead.')
             results_generators.append(self._to_results_generator(self._run_non_batch_extractor(self._get_nodes_from_temp_dir(node_file_paths.keys()))))
 
         else:


### PR DESCRIPTION
If a batch extraction job is too small for Bedrock batch inference, batch extraction falls back on chunk-by-chunk extraction. With this change, the toolkit issues a warning rather than an info message when it encounters undersize batches.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
