### PR TITLE
Get statements and topics once per retriever 

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_based_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_based_search.py
@@ -99,7 +99,7 @@ class ChunkBasedSearch(TraversalBasedBaseRetriever):
         results = self.graph_store.execute_query(cypher, properties)
         statement_ids = [r['l'] for r in results]
 
-        return self.get_statements_by_topic_and_source(statement_ids)
+        return statement_ids
 
 
     def get_start_node_ids(self, query_bundle: QueryBundle) -> List[str]:
@@ -157,7 +157,7 @@ class ChunkBasedSearch(TraversalBasedBaseRetriever):
 
         logger.debug('Running chunk-based search...')
         
-        search_results = []
+        statement_ids = []
         
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.args.num_workers) as executor:
 
@@ -170,8 +170,9 @@ class ChunkBasedSearch(TraversalBasedBaseRetriever):
 
             for future in futures:
                 for result in future.result():
-                    search_results.append(result)
-                    
+                    statement_ids.append(result)
+
+        search_results = self.get_statements_by_topic_and_source(list(set(statement_ids)))      
         search_results_collection = self._to_search_results_collection(search_results) 
         
         retriever_name = type(self).__name__

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_based_semantic_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_based_semantic_search.py
@@ -108,7 +108,7 @@ class ChunkBasedSemanticSearch(TraversalBasedBaseRetriever):
         results = self.graph_store.execute_query(cypher, properties)
         statement_ids = [r['l'] for r in results]
 
-        return self.get_statements_by_topic_and_source(statement_ids)
+        return statement_ids
 
 
     def get_start_node_ids(self, query_bundle: QueryBundle) -> List[str]:
@@ -200,7 +200,7 @@ class ChunkBasedSemanticSearch(TraversalBasedBaseRetriever):
 
         logger.debug('Running chunk-based semantic search...')
         
-        search_results = []
+        statement_ids = []
         
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.args.num_workers) as executor:
 
@@ -213,8 +213,9 @@ class ChunkBasedSemanticSearch(TraversalBasedBaseRetriever):
 
             for future in futures:
                 for result in future.result():
-                    search_results.append(result)
-                    
+                    statement_ids.append(result)
+
+        search_results = self.get_statements_by_topic_and_source(list(set(statement_ids)))       
         search_results_collection = self._to_search_results_collection(search_results) 
         
         retriever_name = type(self).__name__

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/entity_based_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/entity_based_search.py
@@ -167,7 +167,7 @@ class EntityBasedSearch(TraversalBasedBaseRetriever):
         results = self.graph_store.execute_query(cypher, properties)
         statement_ids = [r['l'] for r in results]
 
-        return self.get_statements_by_topic_and_source(statement_ids)
+        return statement_ids
            
 
     def _single_entity_based_graph_search(self, entity_id, query:QueryBundle):
@@ -203,7 +203,7 @@ class EntityBasedSearch(TraversalBasedBaseRetriever):
         results = self.graph_store.execute_query(cypher, properties)
         statement_ids = [r['l'] for r in results]
 
-        return self.get_statements_by_topic_and_source(statement_ids)
+        return statement_ids
     
     def do_graph_search(self, query_bundle:QueryBundle, start_node_ids:List[str]) -> SearchResultCollection:
         """
@@ -225,7 +225,7 @@ class EntityBasedSearch(TraversalBasedBaseRetriever):
         """
         logger.debug('Running entity-based search...')
         
-        search_results = []
+        statement_ids = []
         
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.args.num_workers) as executor:
             
@@ -243,9 +243,9 @@ class EntityBasedSearch(TraversalBasedBaseRetriever):
 
             for future in futures:
                 for result in future.result():
-                    search_results.append(result)
+                    statement_ids.append(result)
                     
-                
+        search_results = self.get_statements_by_topic_and_source(list(set(statement_ids)))         
         search_results_collection = self._to_search_results_collection(search_results) 
         
         retriever_name = type(self).__name__

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/entity_network_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/entity_network_search.py
@@ -82,7 +82,7 @@ class EntityNetworkSearch(TraversalBasedBaseRetriever):
         results = self.graph_store.execute_query(cypher, properties)
         statement_ids = [r['l'] for r in results]
 
-        return self.get_statements_by_topic_and_source(statement_ids)
+        return statement_ids
     
     def _get_node_ids(self, query_bundle: QueryBundle) -> List[str]:
 
@@ -136,7 +136,7 @@ class EntityNetworkSearch(TraversalBasedBaseRetriever):
 
         start = time.time()
         
-        search_results = []
+        statement_ids = []
         
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.args.num_workers) as executor:
 
@@ -149,7 +149,9 @@ class EntityNetworkSearch(TraversalBasedBaseRetriever):
 
             for future in futures:
                 for result in future.result():
-                    search_results.append(result)
+                    statement_ids.append(result)
+
+        search_results = self.get_statements_by_topic_and_source(list(set(statement_ids)))
 
         end = time.time()
         duration_ms = (end-start) * 1000

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/topic_based_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/topic_based_search.py
@@ -111,7 +111,7 @@ class TopicBasedSearch(TraversalBasedBaseRetriever):
         results = self.graph_store.execute_query(cypher, properties)
         statement_ids = [r['l'] for r in results]
 
-        return self.get_statements_by_topic_and_source(statement_ids)
+        return statement_ids
         
 
     def get_start_node_ids(self, query_bundle: QueryBundle) -> List[str]:
@@ -165,7 +165,7 @@ class TopicBasedSearch(TraversalBasedBaseRetriever):
 
         logger.debug('Running topic-based search...')
         
-        search_results = []
+        statement_ids = []
         
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.args.num_workers) as executor:
 
@@ -178,8 +178,9 @@ class TopicBasedSearch(TraversalBasedBaseRetriever):
 
             for future in futures:
                 for result in future.result():
-                    search_results.append(result)
-                    
+                    statement_ids.append(result)
+
+        search_results = self.get_statements_by_topic_and_source(list(set(statement_ids)))           
         search_results_collection = self._to_search_results_collection(search_results) 
         
         retriever_name = type(self).__name__


### PR DESCRIPTION
Get statements and topics once per retriever rather than once per retrieval operation.

Achieves up to 50% reduction in number of graph queries.

*Issue #, if available:* https://github.com/awslabs/graphrag-toolkit/issues/263

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
