### PR TITLE
[FIX] Align byokg-rag shared dependencies with lexical-graph

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -1,12 +1,12 @@
 --only-binary :all:
 
-boto3>=1.39.11
-botocore>=1.39.11
+boto3>=1.40.61
+botocore>=1.40.61
 colorama==0.4.6
 faiss-cpu==1.9.0
 langchain_huggingface==0.3.1
 langchain_aws==0.2.33
-llama-index-embeddings-bedrock==0.6.2
+llama-index-embeddings-bedrock==0.8.0
 numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3


### PR DESCRIPTION
## Description
Align shared dependency versions in byokg-rag to match lexical-graph, enabling co-installation of both packages without pip resolution conflicts.

## Changes
* Bump `llama-index-embeddings-bedrock` from ==0.6.2 to ==0.8.0 (matches lexical-graph)
* Bump `boto3` minimum from >=1.39.11 to >=1.40.61 (matches lexical-graph)
* Bump `botocore` minimum from >=1.39.11 to >=1.40.61 (matches lexical-graph)

## Root Cause
byokg-rag pinned `llama-index-embeddings-bedrock==0.6.2` while lexical-graph pins ==0.8.0, causing `ResolutionImpossible` when both packages are installed in the same environment. The upgrade is backward-compatible — byokg-rag only uses `BedrockEmbedding.get_text_embedding()` and `get_text_embedding_batch()`, which are unchanged in 0.8.0.

## Testing
* Verified `pip install --dry-run -e ./byokg-rag -e ./lexical-graph` resolves successfully after the change
* Confirmed no API breaking changes between llama-index-embeddings-bedrock 0.6.2 and 0.8.0 for the used interface

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.