### PR TITLE
[FIX] Import faiss early in byokg-rag conftest to prevent BLAS/torch segfaults

### DIFF
--- a/byokg-rag/tests/conftest.py
+++ b/byokg-rag/tests/conftest.py
@@ -7,6 +7,13 @@ This module provides reusable test fixtures for mocking AWS services,
 graph stores, LLM clients, and test data structures.
 """
 
+# Import faiss early to ensure its BLAS/OpenMP libraries load before torch's,
+# preventing segfaults from conflicting library versions in CI.
+try:
+    import faiss  # noqa: F401
+except ImportError:
+    pass
+
 import pytest
 from unittest.mock import Mock
 


### PR DESCRIPTION
## Description

Imports faiss before torch/pytest loads to prevent segfaults caused by conflicting BLAS/OpenMP library versions when both faiss and torch are installed.

## Changes

Adds a defensive early import of faiss in `byokg-rag/tests/conftest.py`. The import is wrapped in try/except so it's a no-op when faiss is not installed.

## Problem

When faiss and torch are both present, their BLAS libraries can conflict if torch loads first. This causes intermittent segfaults in CI during test collection. Importing faiss first ensures its BLAS bindings are loaded before torch's.

## Testing

- No functional change — defensive import only
- Resolves intermittent CI segfaults on test runs with faiss + torch installed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
