### PR TITLE
[FIX] Add Bandit security scan for lexical-graph

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - 'byokg-rag/**'
+      - 'lexical-graph/**'
   schedule:
     - cron: '0 9 * * 1'
 
@@ -16,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  bandit:
+  bandit-byokg-rag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -26,3 +27,14 @@ jobs:
       - run: pip install bandit
       - run: bandit -r byokg-rag/src/ -f json -o bandit-report.json || true
       - run: bandit -r byokg-rag/src/ -ll
+
+  bandit-lexical-graph:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install bandit
+      - run: bandit -r lexical-graph/src/ -f json -o bandit-report.json || true
+      - run: bandit -r lexical-graph/src/ -ll


### PR DESCRIPTION
## Description
Extends the existing security-scan workflow to cover lexical-graph alongside byokg-rag, closing a SAST coverage gap identified during AppSec review.

## Changes
- Added `lexical-graph/**` to `on.pull_request.paths` trigger in `security-scan.yml`
- Added a dedicated `bandit-lexical-graph` job scanning `lexical-graph/src/`
- Same configuration as byokg-rag: fails on medium+ severity, `contents: read` permissions

## Problem
The Bandit SAST workflow only scanned `byokg-rag/src/`. Lexical-graph had no static security analysis, leaving potential vulnerabilities undetected in PRs touching that module.

## Testing
- No functional code change — CI workflow addition only
- Bandit will run on PRs touching `lexical-graph/**` and on weekly schedule

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
