### PR TITLE
[FIX] Increase lexical-graph test coverage threshold to 45%

### DIFF
--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           PYTHONPATH=src .venv/bin/python -m pytest \
             -v --cov-config=.coveragerc --cov=graphrag_toolkit.lexical_graph \
-            -l --tb=short --maxfail=1 --cov-fail-under=30 \
+            -l --tb=short --maxfail=1 --cov-fail-under=45 \
             tests/
 
       - name: Package coverage reports


### PR DESCRIPTION
## Description
Raises the minimum test coverage gate from 30% to 45% to enforce higher standards as the project matures. Current actual coverage is ~45.87%.

## Changes
Changed `--cov-fail-under=30` to `--cov-fail-under=45` in `.github/workflows/lexical-graph-tests.yml`.

## Problem
The 30% threshold was too permissive — allowed significant coverage regression without CI failure. Raising to 45% matches current actual coverage and prevents backsliding.

## Testing
- No functional code change — CI threshold adjustment only
- Current coverage (45.87%) passes the new 45% gate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
