### PR TITLE
[FIX] Correct off-by-one validation in ToolParameters ArgTransform limit

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/protocols/mcp_server.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/protocols/mcp_server.py
@@ -35,7 +35,7 @@ class ToolParameters():
             update_params_function:UpdateParametersFunction = lambda _, query_engine_params: query_engine_params
         ):
 
-        if len(parameters) == 3:
+        if len(parameters) > 3:
             raise ValueError('Maximum number of tool parameters exceeded. You can only supply up to 3 tool parameters.')
         
         self.parameters = parameters

--- a/lexical-graph/tests/unit/protocols/__init__.py
+++ b/lexical-graph/tests/unit/protocols/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/lexical-graph/tests/unit/protocols/test_tool_parameters.py
+++ b/lexical-graph/tests/unit/protocols/test_tool_parameters.py
@@ -1,0 +1,106 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Mock fastmcp before importing ToolParameters
+mock_not_set = object()
+
+mock_fastmcp_modules = {
+    'fastmcp': MagicMock(),
+    'fastmcp.tools': MagicMock(),
+    'fastmcp.tools.tool_transform': MagicMock(ArgTransform=MagicMock),
+    'fastmcp.utilities': MagicMock(),
+    'fastmcp.utilities.types': MagicMock(NotSet=mock_not_set),
+}
+
+
+def make_arg_transform(name):
+    """Create a mock ArgTransform with a name."""
+    arg = MagicMock()
+    arg.name = name
+    return arg
+
+
+@pytest.fixture(autouse=True)
+def mock_fastmcp():
+    with patch.dict('sys.modules', mock_fastmcp_modules):
+        yield
+
+
+def _import_tool_parameters():
+    """Import ToolParameters with mocked dependencies."""
+    import importlib
+    import graphrag_toolkit.lexical_graph.protocols.mcp_server as mod
+    importlib.reload(mod)
+    return mod.ToolParameters
+
+
+class TestToolParametersValidation:
+    """Tests for ToolParameters parameter count validation."""
+
+    def test_zero_parameters_accepted(self):
+        """ToolParameters should accept an empty parameter list."""
+        ToolParameters = _import_tool_parameters()
+        tp = ToolParameters(parameters=[])
+        assert tp.parameters == []
+
+    def test_one_parameter_accepted(self):
+        """ToolParameters should accept 1 ArgTransform."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform('param1')]
+        tp = ToolParameters(parameters=params)
+        assert len(tp.parameters) == 1
+
+    def test_two_parameters_accepted(self):
+        """ToolParameters should accept 2 ArgTransforms."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform('param1'), make_arg_transform('param2')]
+        tp = ToolParameters(parameters=params)
+        assert len(tp.parameters) == 2
+
+    def test_three_parameters_accepted(self):
+        """ToolParameters should accept 3 ArgTransforms (maximum allowed)."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform('param1'), make_arg_transform('param2'), make_arg_transform('param3')]
+        tp = ToolParameters(parameters=params)
+        assert len(tp.parameters) == 3
+
+    def test_four_parameters_rejected(self):
+        """ToolParameters should reject more than 3 ArgTransforms."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform(f'param{i}') for i in range(4)]
+        with pytest.raises(ValueError, match='Maximum number of tool parameters exceeded'):
+            ToolParameters(parameters=params)
+
+    def test_five_parameters_rejected(self):
+        """ToolParameters should reject 5 ArgTransforms."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform(f'param{i}') for i in range(5)]
+        with pytest.raises(ValueError, match='Maximum number of tool parameters exceeded'):
+            ToolParameters(parameters=params)
+
+    def test_parameter_without_name_rejected(self):
+        """ToolParameters should reject ArgTransform with missing name."""
+        ToolParameters = _import_tool_parameters()
+        arg = MagicMock()
+        arg.name = mock_not_set
+        with pytest.raises(ValueError, match='Tool parameter name missing'):
+            ToolParameters(parameters=[arg])
+
+    def test_parameters_marked_required(self):
+        """All parameters should be marked as required."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform('param1'), make_arg_transform('param2')]
+        tp = ToolParameters(parameters=params)
+        for p in tp.parameters:
+            assert p.required is True
+
+    def test_parameters_marked_not_hidden(self):
+        """All parameters should be marked as not hidden."""
+        ToolParameters = _import_tool_parameters()
+        params = [make_arg_transform('param1'), make_arg_transform('param2')]
+        tp = ToolParameters(parameters=params)
+        for p in tp.parameters:
+            assert p.hide is False


### PR DESCRIPTION
## Description

Fixes an off-by-one error in the `ToolParameters` validation that incorrectly rejects exactly 3 `ArgTransform` parameters, despite the underlying function supporting 3 placeholder argument slots (`_arg_1`, `_arg_2`, `_arg_3`).

## Changes

- Changed `if len(parameters) == 3` to `if len(parameters) > 3` in `lexical-graph/src/graphrag_toolkit/lexical_graph/protocols/mcp_server.py`
- Added unit tests covering all boundary cases in `lexical-graph/tests/unit/protocols/test_tool_parameters.py`

## Problem

The validation check used `== 3` which rejected exactly 3 parameters (the actual maximum supported) and silently allowed 4+ (which would fail at runtime). Users attempting to use the full 3-parameter capacity received a misleading `ValueError`.

## Testing

9 unit tests added and passing:
- 0, 1, 2, 3 parameters accepted (3 was previously rejected)
- 4, 5 parameters correctly rejected
- Missing parameter name rejected
- Parameters correctly marked as required and not hidden

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.