### PR TITLE
chore(ci): bump actions/upload-pages-artifact from 3 to 5 with hidden files preservation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,9 +42,10 @@ jobs:
           cache-dependency-path: docs-site/package-lock.json
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/dist
+          include-hidden-files: true
 
   deploy:
     needs: build


### PR DESCRIPTION
## Description

Bumps actions/upload-pages-artifact from v3 to v5 and adds `include-hidden-files: true` to preserve the `.nojekyll` file in the docs deployment artifact.

## Changes

- Bumped `actions/upload-pages-artifact@v3` → `@v5` in `.github/workflows/docs.yml`
- Added `include-hidden-files: true` to prevent v4's breaking change from excluding `dist/.nojekyll`

## Problem

The v4 release of upload-pages-artifact excludes dotfiles from artifacts by default. The docs site includes `public/.nojekyll` (copied to `dist/.nojekyll` during build) which signals GitHub Pages to skip Jekyll processing. Without `include-hidden-files: true`, this file would be silently dropped.

Supersedes #286.

## Testing

- Single workflow config change — no functional code affected
- The `include-hidden-files` input is available since v5.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.