### PR TITLE
[FIX] Install byokg requirements when running integ-tests

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -13,6 +13,6 @@ pyyaml==6.0.3
 sentence-transformers>=2.4.0
 tiktoken==0.11.0
 thefuzz==0.22.1
-torch>=2.11.0,<2.12.0
+torch>=2.0.0
 transformers>=4.44.2
 xmltodict==1.0.2

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -52,10 +52,10 @@ if [[ "$DO_SETUP" = true ]]; then
     if [[ "$BYOKG_RAG_INSTALL_URI" ]]; then
         echo "Installing byokg_rag from $BYOKG_RAG_INSTALL_URI"
         pip install $BYOKG_RAG_INSTALL_URI
-    else
-        echo "Installing byokg_rag from local install"
-        pip install -r graphrag_toolkit/byokg_rag/requirements.txt
     fi
+
+    echo "Installing byokg_rag dependencies"
+    pip install -r graphrag_toolkit/byokg_rag/requirements.txt
 
     if [[ "$LEXICAL_GRAPH_INSTALL_URI" ]]; then
         echo "Installing lexical graph from $LEXICAL_GRAPH_INSTALL_URI"
@@ -76,7 +76,6 @@ if [[ "$DO_SETUP" = true ]]; then
         pip install -r graphrag_toolkit/lexical_graph/requirements.txt
     fi
     
-    pip install thefuzz
     pip install opensearch-py llama-index-vector-stores-opensearch
     pip install psycopg2-binary pgvector
     pip install neo4j

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -76,6 +76,7 @@ if [[ "$DO_SETUP" = true ]]; then
         pip install -r graphrag_toolkit/lexical_graph/requirements.txt
     fi
     
+    pip install thefuzz
     pip install opensearch-py llama-index-vector-stores-opensearch
     pip install psycopg2-binary pgvector
     pip install neo4j


### PR DESCRIPTION
*Issue #, if available:*

fixes: #268 

*Description of changes:*

Installs package `thefuzz` (and other requirements) when running integration tests.  The requirements.txt was not succeeding because `torch` package was declaring unavailable versions. 

When running: 

```
sh build-tests.sh --test-file byokg_setup.LoadBYOKGGraph
```

We get:

```
Stack finished with status: CREATE_COMPLETE
Running tests...
{
  "description": "graphrag-toolkit integration test",
  "start": "2026-05-26 22:54:18",
  "end": "2026-05-26 22:54:19",
  "duration_seconds": 1,
  "env": {
    "graphrag_toolkit": "s3://yandcarb-graphrag-benchmark-613481987977-us-west-2-an/graphrag-toolkit-tests/gr-1779835332/packages/graphrag-toolkit.zip",
    "lexical_graph_version": "3.18.3.1779835334000",
    "graph_store": "neptune-graph://g-xg1j9xgw55",
    "vector_store": "neptune-graph://g-xg1j9xgw55",
    "delete_on_pass": false,
    "extraction_llm": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
    "response_llm": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
    "embeddings_model": "cohere.embed-english-v3",
    "embeddings_dimensions": "1024"
  },
  "result_summary": "PASS",
  "results": []
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
