### PR TITLE
[Security Fix]: Fix the Cypher safety bypass vulnerabilities

### DIFF
--- a/.github/workflows/byokg-rag-tests.yml
+++ b/.github/workflows/byokg-rag-tests.yml
@@ -82,6 +82,7 @@ jobs:
             pytest \
             pytest-cov \
             pytest-mock \
+            hypothesis \
             -r src/graphrag_toolkit/byokg_rag/requirements.txt
 
       - name: Run tests

--- a/byokg-rag/README.md
+++ b/byokg-rag/README.md
@@ -91,6 +91,14 @@ NOTE: Additional permissions may be required for Neptune Database (`neptune-db:*
    - Provides interfaces for graph traversal and querying
    - Supports multiple graph database backends
 
+## Security: Query Modification Protection
+
+The `GraphQueryRetriever` includes a safety layer (`is_query_safe()`) that blocks Cypher queries containing modification keywords (CREATE, MERGE, DELETE, SET, REMOVE, DROP, DETACH, CALL). This protects against LLM-generated or user-supplied queries that could modify graph data.
+
+**Neptune Analytics**: Write protection is enforced at two levels — application-level Cypher validation and server-enforced `readOnly=True` on the query API. Even if a query bypasses the keyword blocklist, Neptune Analytics will reject the write operation.
+
+**Neptune Database**: Write protection relies solely on application-level Cypher validation (`is_query_safe()`). Neptune DB's openCypher API does not support a `readOnly` parameter. For stronger guarantees, use Neptune Analytics (which supports server-enforced `readOnly=True`) or restrict the IAM role to `neptune-db:ReadDataViaQuery`.
+
 ## Performance
 
 Our results show that BYOKG-RAG outperforms existing approaches across multiple knowledge graph benchmarks:

--- a/byokg-rag/README.md
+++ b/byokg-rag/README.md
@@ -93,11 +93,9 @@ NOTE: Additional permissions may be required for Neptune Database (`neptune-db:*
 
 ## Security: Query Modification Protection
 
-The `GraphQueryRetriever` includes a safety layer (`is_query_safe()`) that blocks Cypher queries containing modification keywords (CREATE, MERGE, DELETE, SET, REMOVE, DROP, DETACH, CALL). This protects against LLM-generated or user-supplied queries that could modify graph data.
+The `GraphQueryRetriever` blocks Cypher queries containing modification keywords (CREATE, MERGE, DELETE, SET, REMOVE, DROP, DETACH, CALL) to protect against LLM-generated or user-supplied queries that could modify graph data.
 
-**Neptune Analytics**: Write protection is enforced at two levels — application-level Cypher validation and server-enforced `readOnly=True` on the query API. Even if a query bypasses the keyword blocklist, Neptune Analytics will reject the write operation.
-
-**Neptune Database**: Write protection relies solely on application-level Cypher validation (`is_query_safe()`). Neptune DB's openCypher API does not support a `readOnly` parameter. For stronger guarantees, use Neptune Analytics (which supports server-enforced `readOnly=True`) or restrict the IAM role to `neptune-db:ReadDataViaQuery`.
+**Neptune Database**: Write protection relies solely on application-level Cypher validation (`is_query_safe()`). For stronger guarantees, use Neptune Analytics (which supports server-enforced `readOnly=True`) or restrict the IAM role to `neptune-db:ReadDataViaQuery`.
 
 ## Performance
 

--- a/byokg-rag/pyproject.toml
+++ b/byokg-rag/pyproject.toml
@@ -22,6 +22,7 @@ test = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
+    "hypothesis>=6.0.0",
 ]
 dev = [
     "pre-commit>=4.6.0",

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graph_retrievers/graph_retrievers.py
@@ -4,6 +4,7 @@
 from abc import ABC
 import re
 import logging
+import unicodedata
 
 from ..utils import load_yaml, parse_response
 
@@ -382,17 +383,24 @@ class GraphQueryRetriever(GRetriever):
         Returns:
             bool: True if query is safe, False if it contains blocked keywords
         """
-        # if not self.block_graph_modification:
-        #     return True
+        if not self.block_graph_modification:
+            return True
         
         # Keywords that indicate graph modification operations
         modification_keywords = [
             'CREATE', 'MERGE', 'SET', 'REMOVE', 'DELETE', 'DETACH DELETE',
-            'DROP', 'DETACH'
+            'DROP', 'DETACH', 'CALL'
         ]
         
-        # Normalize query for case-insensitive matching, preserve newlines
-        query_upper = graph_query.upper()
+        # Strip inline comments (/* ... */) and single-line comments (// ...)
+        query = re.sub(r'/\*.*?\*/', '', graph_query, flags=re.DOTALL)
+        query = re.sub(r'//[^\n]*', '', query)
+        
+        # Normalize Unicode characters (NFKC collapses fullwidth and lookalikes to ASCII)
+        query = unicodedata.normalize('NFKC', query)
+        
+        # Normalize query for case-insensitive matching
+        query_upper = query.upper()
         
         # Check for each blocked keyword
         for keyword in modification_keywords:
@@ -433,7 +441,7 @@ class GraphQueryRetriever(GRetriever):
                     return [error_msg]
             
             # Execute the query
-            results = self.graph_store.execute_query(graph_query)
+            results = self.graph_store.execute_query(graph_query, read_only=self.block_graph_modification)
             
             # Verbalize the results
             import json

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -553,6 +553,13 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         
     def execute_query(self, cypher, parameters={}, read_only=False):
         logger.info(f"GraphQuery:: {cypher}")
+        if read_only:
+            logger.warning(
+                "Neptune DB does not support read-only query execution. "
+                "Write protection relies solely on application-level Cypher validation. "
+                "For stronger guarantees, use Neptune Analytics or restrict the IAM role "
+                "to neptune-db:ReadDataViaQuery."
+            )
         response = self.neptune_data_client.execute_open_cypher_query(
             openCypherQuery=cypher,
             parameters=json.dumps(parameters)

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -298,14 +298,17 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
         logger.info(response)
         return response
 
-    def execute_query(self, cypher, parameters={}):
+    def execute_query(self, cypher, parameters={}, read_only=False):
         logger.info(f"GraphQuery:: {cypher}")
-        response =  self.neptune_client.execute_query(
+        query_args = dict(
             graphIdentifier=self.neptune_graph_id,
             queryString=cypher,
             parameters=parameters,
             language='OPEN_CYPHER'
         )
+        if read_only:
+            query_args['readOnly'] = True
+        response = self.neptune_client.execute_query(**query_args)
         return json.loads(response['payload'].read())['results']
 
     def as_embedding_index(self, embedding:Embedding=None, node_embedding_text_props=None, load=True, embedding_s3_save_location=None):
@@ -397,6 +400,7 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         self.neptune_data_client = self.session.client('neptunedata', region_name=self.region, endpoint_url = self.endpoint_url)
         self.s3_client = self.session.client('s3', region_name=self.region)
         self.node_type_to_property_mapping = {}
+
 
 
     def read_from_csv(self, csv_file=None, s3_path=None, format='CSV', iam_role=None):
@@ -547,8 +551,10 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         self._refresh_schema(graphSummary)
         return graphSummary
         
-    def execute_query(self, cypher, parameters={}):
+    def execute_query(self, cypher, parameters={}, read_only=False):
         logger.info(f"GraphQuery:: {cypher}")
+        if read_only:
+            logger.warning("read_only mode is not natively supported by Neptune DB. Query will execute without read-only enforcement.")
         response = self.neptune_data_client.execute_open_cypher_query(
             openCypherQuery=cypher,
             parameters=json.dumps(parameters)

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -553,8 +553,6 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         
     def execute_query(self, cypher, parameters={}, read_only=False):
         logger.info(f"GraphQuery:: {cypher}")
-        if read_only:
-            logger.warning("read_only mode is not natively supported by Neptune DB. Query will execute without read-only enforcement.")
         response = self.neptune_data_client.execute_open_cypher_query(
             openCypherQuery=cypher,
             parameters=json.dumps(parameters)

--- a/byokg-rag/tests/unit/graph_retrievers/test_graph_retrievers.py
+++ b/byokg-rag/tests/unit/graph_retrievers/test_graph_retrievers.py
@@ -9,6 +9,8 @@ GraphScoringRetriever, PathRetriever, and GraphQueryRetriever.
 
 import pytest
 from unittest.mock import Mock, MagicMock, patch
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
 from graphrag_toolkit.byokg_rag.graph_retrievers.graph_retrievers import (
     GRetriever,
     AgenticRetriever,
@@ -639,7 +641,7 @@ class TestGraphQueryRetrieverRetrieve:
         
         assert isinstance(result, list)
         assert len(result) == 1
-        mock_graph_store.execute_query.assert_called_once_with("MATCH (n) RETURN n")
+        mock_graph_store.execute_query.assert_called_once_with("MATCH (n) RETURN n", read_only=True)
     
     def test_retrieve_unsafe_query(self, mock_graph_store):
         """Verify retrieval blocks unsafe query."""
@@ -706,3 +708,416 @@ class TestGraphQueryRetrieverRetrieve:
         assert isinstance(answers, list)
         assert "Cannot execute query that modifies the graph" in context[0]
         assert len(answers) == 0
+
+
+
+# =============================================================================
+# Bug Condition Exploration Property-Based Tests
+# =============================================================================
+
+# Strategies for generating obfuscated Cypher queries
+
+# Modification keywords that should be blocked
+MODIFICATION_KEYWORDS = ['CREATE', 'DELETE', 'MERGE', 'SET', 'REMOVE', 'DROP', 'DETACH']
+
+# Strategy: Comment bypass - insert /**/ within modification keywords
+@st.composite
+def comment_bypass_queries(draw):
+    """Generate queries with modification keywords split by inline comments.
+    
+    E.g., CRE/**/ATE (n:Person), DE/**/LETE n, ME/**/RGE (n:Node)
+    """
+    keyword = draw(st.sampled_from(MODIFICATION_KEYWORDS))
+    # Split keyword at a random position and insert /**/
+    split_pos = draw(st.integers(min_value=1, max_value=len(keyword) - 1))
+    obfuscated = keyword[:split_pos] + '/**/' + keyword[split_pos:]
+    suffix = draw(st.sampled_from([
+        ' (n:Person {name: "Evil"})',
+        ' (n:Malicious)',
+        ' n',
+        ' (n)-[:REL]->(m)',
+    ]))
+    return obfuscated + suffix
+
+
+# Strategy: APOC procedure bypass
+@st.composite
+def apoc_bypass_queries(draw):
+    """Generate queries using APOC procedures that perform write operations."""
+    apoc_call = draw(st.sampled_from([
+        "CALL apoc.create.node(['Person'], {name: 'Evil'})",
+        "CALL apoc.create.nodes(['Person'], [{name: 'Evil'}])",
+        "CALL apoc.create.relationship(n, 'KNOWS', {}, m)",
+        "CALL apoc.refactor.mergeNodes([n, m])",
+        "CALL apoc.refactor.mergeRelationships([r1, r2])",
+        "CALL apoc.create.vNode(['Person'], {name: 'Virtual'})",
+    ]))
+    return apoc_call
+
+
+# Strategy: CALL subquery bypass
+@st.composite
+def call_subquery_bypass_queries(draw):
+    """Generate queries using CALL subqueries that wrap write operations."""
+    inner_op = draw(st.sampled_from([
+        'CREATE (n:Malicious) RETURN n',
+        'CREATE (n:Person {name: "Evil"}) RETURN n',
+        'MERGE (n:Person {name: "Evil"}) RETURN n',
+        'MATCH (n) DELETE n RETURN count(n) as c',
+        'MATCH (n) SET n.hacked = true RETURN n',
+    ]))
+    return f'CALL {{ {inner_op} }}'
+
+
+# Strategy: Unicode bypass - fullwidth Latin characters
+@st.composite
+def unicode_bypass_queries(draw):
+    """Generate queries using fullwidth Unicode characters to form keywords.
+    
+    Fullwidth Latin characters (U+FF21-U+FF3A for uppercase) look similar
+    to ASCII but bypass word-boundary regex matching.
+    """
+    keyword = draw(st.sampled_from(['CREATE', 'DELETE', 'MERGE', 'DROP']))
+    # Convert to fullwidth Unicode (U+FF21 is fullwidth 'A', offset from 'A' is 0xFF21 - 0x41 = 0xFEE0)
+    fullwidth = ''.join(chr(ord(c) + 0xFEE0) if c.isalpha() else c for c in keyword)
+    suffix = draw(st.sampled_from([
+        ' (n:Person)',
+        ' (n:Malicious {name: "Evil"})',
+        ' n',
+    ]))
+    return fullwidth + suffix
+
+
+class TestBugConditionExploration:
+    """Bug condition exploration tests - these MUST FAIL on unfixed code.
+    
+    **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 2.5**
+    
+    These tests encode the EXPECTED behavior after the fix is applied.
+    When run on unfixed code, they will fail - proving the bypass vulnerabilities exist.
+    """
+
+    @given(query=comment_bypass_queries())
+    @settings(max_examples=50)
+    def test_comment_bypass_detected(self, query):
+        """Property: Queries with comment-split keywords should be detected as unsafe.
+        
+        **Validates: Requirements 1.1, 2.1**
+        
+        Bug condition: CRE/**/ATE, DE/**/LETE, ME/**/RGE etc. bypass word-boundary regex.
+        Expected: is_query_safe() returns False for all comment-obfuscated queries.
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+        
+        result = retriever.is_query_safe(query)
+        assert result is False, (
+            f"BYPASS FOUND: is_query_safe({query!r}) returned True "
+            f"- comment-split keyword was not detected"
+        )
+
+    @given(query=apoc_bypass_queries())
+    @settings(max_examples=50)
+    def test_apoc_procedure_bypass_detected(self, query):
+        """Property: APOC procedure calls should be detected as unsafe.
+        
+        **Validates: Requirements 1.2, 2.2**
+        
+        Bug condition: CALL apoc.create.node(...) etc. are not in the blocklist.
+        Expected: is_query_safe() returns False for all APOC write procedures.
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+        
+        result = retriever.is_query_safe(query)
+        assert result is False, (
+            f"BYPASS FOUND: is_query_safe({query!r}) returned True "
+            f"- APOC procedure was not detected"
+        )
+
+    @given(query=call_subquery_bypass_queries())
+    @settings(max_examples=50)
+    def test_call_subquery_bypass_detected(self, query):
+        """Property: CALL subqueries wrapping writes should be detected as unsafe.
+        
+        **Validates: Requirements 1.3, 2.3**
+        
+        Bug condition: CALL { CREATE ... } wraps write ops, CALL not in blocklist.
+        Expected: is_query_safe() returns False for all CALL subquery write operations.
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+        
+        result = retriever.is_query_safe(query)
+        assert result is False, (
+            f"BYPASS FOUND: is_query_safe({query!r}) returned True "
+            f"- CALL subquery was not detected"
+        )
+
+    @given(query=unicode_bypass_queries())
+    @settings(max_examples=50)
+    def test_unicode_bypass_detected(self, query):
+        """Property: Unicode lookalike keywords should be detected as unsafe.
+        
+        **Validates: Requirements 1.4, 2.4**
+        
+        Bug condition: Fullwidth Unicode chars (U+FF21-U+FF3A) bypass ASCII regex.
+        Expected: is_query_safe() returns False for all Unicode-obfuscated queries.
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+        
+        result = retriever.is_query_safe(query)
+        assert result is False, (
+            f"BYPASS FOUND: is_query_safe({query!r}) returned True "
+            f"- Unicode lookalike keyword was not detected"
+        )
+
+    def test_block_graph_modification_flag_bypass(self):
+        """Property: block_graph_modification=False should skip safety check.
+        
+        **Validates: Requirements 1.5, 2.5**
+        
+        Bug condition: The flag is commented out, so safety check always runs.
+        Expected: When block_graph_modification=False, is_query_safe() returns True
+        for ALL queries (including modification queries).
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(
+            graph_store=mock_store,
+            block_graph_modification=False
+        )
+        
+        # These modification queries should be ALLOWED when flag is False
+        modification_queries = [
+            "CREATE (n:Person {name: 'Test'})",
+            "MATCH (n) DELETE n",
+            "MERGE (n:Person {name: 'Test'})",
+            "MATCH (n) SET n.name = 'Evil'",
+            "MATCH (n) REMOVE n.name",
+            "DROP INDEX my_index",
+        ]
+        
+        for query in modification_queries:
+            result = retriever.is_query_safe(query)
+            assert result is True, (
+                f"FLAG BYPASS CONFIRMED: is_query_safe({query!r}) returned False "
+                f"even though block_graph_modification=False - flag is non-functional"
+            )
+
+
+# =============================================================================
+# Preservation Property-Based Tests
+# =============================================================================
+
+# Strategies for generating legitimate read-only Cypher queries
+
+# Read-only Cypher clauses that should always be allowed
+READ_ONLY_CLAUSES = ['MATCH', 'RETURN', 'WHERE', 'WITH', 'OPTIONAL MATCH', 'UNWIND', 'ORDER BY', 'LIMIT']
+
+# Blocked keywords that may appear as substrings in property names or labels
+BLOCKED_KEYWORDS_FOR_SUBSTRING = ['CREATE', 'DELETE', 'MERGE', 'SET', 'REMOVE', 'DROP', 'DETACH']
+
+
+@st.composite
+def read_only_cypher_queries(draw):
+    """Generate valid read-only Cypher queries using only safe clauses.
+
+    Constructs queries from MATCH, RETURN, WHERE, WITH, OPTIONAL MATCH,
+    UNWIND, ORDER BY, and LIMIT without any modification keywords.
+    """
+    # Generate a node label (simple alphanumeric, no blocked keywords)
+    label = draw(st.sampled_from([
+        'Person', 'Organization', 'Location', 'Event', 'Document',
+        'Product', 'Category', 'Tag', 'User', 'Account'
+    ]))
+
+    # Generate a property name (safe, no blocked keywords as standalone words)
+    prop = draw(st.sampled_from([
+        'name', 'age', 'title', 'description', 'value',
+        'count', 'status', 'type', 'date', 'score'
+    ]))
+
+    # Generate a variable name
+    var = draw(st.sampled_from(['n', 'm', 'p', 'x', 'node', 'result']))
+
+    # Build query pattern
+    pattern = draw(st.sampled_from([
+        f'MATCH ({var}:{label}) RETURN {var}',
+        f'MATCH ({var}:{label}) WHERE {var}.{prop} IS NOT NULL RETURN {var}',
+        f'MATCH ({var}:{label}) RETURN {var}.{prop}',
+        f'MATCH ({var}:{label}) WITH {var} RETURN {var}',
+        f'MATCH ({var}:{label}) WITH {var} ORDER BY {var}.{prop} RETURN {var}',
+        f'MATCH ({var}:{label}) WITH {var} ORDER BY {var}.{prop} LIMIT 10 RETURN {var}',
+        f'MATCH ({var}:{label}) WHERE {var}.{prop} > 0 RETURN {var}',
+        f'OPTIONAL MATCH ({var}:{label}) RETURN {var}',
+        f'MATCH ({var}:{label}) UNWIND [{var}] AS item RETURN item',
+        f'MATCH ({var})-[r]->({var}2:{label}) RETURN {var}, r, {var}2',
+        f'MATCH p=({var}:{label})-[*1..3]->() RETURN p',
+        f'MATCH ({var}:{label}) WHERE {var}.{prop} = "test" RETURN {var} LIMIT 5',
+    ]))
+
+    return pattern
+
+
+@st.composite
+def substring_keyword_queries(draw):
+    """Generate queries where blocked keywords appear as substrings in identifiers.
+
+    E.g., CREATED_AT contains CREATE, SETTINGS contains SET,
+    REMOVED_DATE contains REMOVE, DROPPED_ITEMS contains DROP.
+    """
+    # Property names or labels that contain blocked keywords as substrings
+    identifier = draw(st.sampled_from([
+        'CREATED_AT', 'CREATED_BY', 'CREATION_DATE',
+        'SETTINGS', 'OFFSET', 'RESET_TOKEN', 'CHARSET',
+        'REMOVED_DATE', 'REMOVED_BY', 'REMOVAL_REASON',
+        'DELETED_AT', 'UNDELETED', 'PREDELETE_STATE',
+        'MERGED_FROM', 'EMERGED', 'SUBMERGED',
+        'DROPPED_ITEMS', 'BACKDROP', 'RAINDROP',
+        'DETACHED_FROM', 'DETACHMENT_DATE',
+    ]))
+
+    # Build a read-only query using the identifier as a property or label
+    usage = draw(st.sampled_from(['property', 'label']))
+
+    if usage == 'property':
+        query = f"MATCH (n:Entity) WHERE n.{identifier} IS NOT NULL RETURN n.{identifier}"
+    else:
+        query = f"MATCH (n:{identifier}) RETURN n"
+
+    return query
+
+
+class TestPreservationReadOnlyQueries:
+    """Preservation property tests - read-only queries must continue to work.
+
+    **Validates: Requirements 3.1, 3.2**
+
+    These tests verify that legitimate read-only Cypher queries are NOT
+    false-positive blocked by is_query_safe(). They must pass on BOTH
+    unfixed and fixed code.
+    """
+
+    @given(query=read_only_cypher_queries())
+    @settings(max_examples=100)
+    def test_read_only_queries_are_safe(self, query):
+        """Property: All read-only Cypher queries return True from is_query_safe().
+
+        **Validates: Requirements 3.1**
+
+        For all queries using only MATCH, RETURN, WHERE, WITH, OPTIONAL MATCH,
+        UNWIND, ORDER BY, LIMIT that do NOT contain modification keywords,
+        is_query_safe() must return True.
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+
+        result = retriever.is_query_safe(query)
+        assert result is True, (
+            f"FALSE POSITIVE: is_query_safe({query!r}) returned False "
+            f"for a legitimate read-only query"
+        )
+
+    @given(query=substring_keyword_queries())
+    @settings(max_examples=100)
+    def test_substring_keywords_are_safe(self, query):
+        """Property: Queries with blocked keywords as substrings return True.
+
+        **Validates: Requirements 3.2**
+
+        For all queries containing blocked keywords as substrings of property
+        names or labels (e.g., CREATED_AT, SETTINGS, REMOVED_DATE),
+        is_query_safe() must return True (no false positives).
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock()
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+
+        result = retriever.is_query_safe(query)
+        assert result is True, (
+            f"FALSE POSITIVE: is_query_safe({query!r}) returned False "
+            f"for a query with a keyword substring in an identifier"
+        )
+
+
+class TestPreservationRetrieveFormat:
+    """Preservation property tests - retrieve() returns correct format.
+
+    **Validates: Requirements 3.3, 3.4, 3.5, 3.6**
+
+    These tests verify that retrieve() returns results in the correct format:
+    - list for return_answers=False
+    - tuple of (context_list, answers_list) for return_answers=True
+    - Error messages include query and exception details
+    """
+
+    @given(query=read_only_cypher_queries(), return_answers=st.booleans())
+    @settings(max_examples=100)
+    def test_retrieve_returns_correct_format(self, query, return_answers):
+        """Property: retrieve() returns correct format for all valid read queries.
+
+        **Validates: Requirements 3.5, 3.6**
+
+        For return_answers=False: returns a list
+        For return_answers=True: returns a tuple of (list, list)
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock(return_value=[{'id': 1, 'name': 'Test'}])
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+
+        result = retriever.retrieve(query, return_answers=return_answers)
+
+        if return_answers:
+            assert isinstance(result, tuple), (
+                f"retrieve({query!r}, return_answers=True) did not return a tuple"
+            )
+            context, answers = result
+            assert isinstance(context, list), (
+                f"First element of tuple is not a list for query {query!r}"
+            )
+            assert isinstance(answers, list), (
+                f"Second element of tuple is not a list for query {query!r}"
+            )
+        else:
+            assert isinstance(result, list), (
+                f"retrieve({query!r}, return_answers=False) did not return a list"
+            )
+            assert not isinstance(result, tuple), (
+                f"retrieve({query!r}, return_answers=False) returned a tuple instead of list"
+            )
+
+    @given(query=read_only_cypher_queries())
+    @settings(max_examples=50)
+    def test_retrieve_error_format(self, query):
+        """Property: Query execution errors return error message with details.
+
+        **Validates: Requirements 3.4**
+
+        When query execution raises an exception, the returned context must
+        contain the query string and exception details.
+        """
+        mock_store = Mock()
+        mock_store.execute_query = Mock(side_effect=RuntimeError("Connection timeout"))
+        retriever = GraphQueryRetriever(graph_store=mock_store)
+
+        result = retriever.retrieve(query)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        error_msg = result[0]
+        assert query in error_msg, (
+            f"Error message does not contain the query: {error_msg!r}"
+        )
+        assert "RuntimeError" in error_msg, (
+            f"Error message does not contain exception type: {error_msg!r}"
+        )
+        assert "Connection timeout" in error_msg, (
+            f"Error message does not contain exception details: {error_msg!r}"
+        )

--- a/byokg-rag/tests/unit/graph_retrievers/test_graph_retrievers.py
+++ b/byokg-rag/tests/unit/graph_retrievers/test_graph_retrievers.py
@@ -789,24 +789,21 @@ def unicode_bypass_queries(draw):
 
 
 class TestBugConditionExploration:
-    """Bug condition exploration tests - these MUST FAIL on unfixed code.
-    
-    **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 2.5**
-    
-    These tests encode the EXPECTED behavior after the fix is applied.
-    When run on unfixed code, they will fail - proving the bypass vulnerabilities exist.
+    """Property-based tests for Cypher query safety bypass vectors.
+
+    These tests use Hypothesis to generate obfuscated Cypher queries that
+    attempt to bypass the is_query_safe() blocklist through various techniques:
+    - Embedding comments within keywords (CRE/**/ATE)
+    - Using APOC write procedures (CALL apoc.create.node(...))
+    - Wrapping writes in CALL subqueries (CALL { CREATE ... })
+    - Using fullwidth Unicode characters that resemble ASCII keywords
+    - Verifying the block_graph_modification flag disables checks when False
     """
 
     @given(query=comment_bypass_queries())
     @settings(max_examples=50)
     def test_comment_bypass_detected(self, query):
-        """Property: Queries with comment-split keywords should be detected as unsafe.
-        
-        **Validates: Requirements 1.1, 2.1**
-        
-        Bug condition: CRE/**/ATE, DE/**/LETE, ME/**/RGE etc. bypass word-boundary regex.
-        Expected: is_query_safe() returns False for all comment-obfuscated queries.
-        """
+        """Queries with comment-split keywords (e.g. CRE/**/ATE) are detected as unsafe."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -820,13 +817,7 @@ class TestBugConditionExploration:
     @given(query=apoc_bypass_queries())
     @settings(max_examples=50)
     def test_apoc_procedure_bypass_detected(self, query):
-        """Property: APOC procedure calls should be detected as unsafe.
-        
-        **Validates: Requirements 1.2, 2.2**
-        
-        Bug condition: CALL apoc.create.node(...) etc. are not in the blocklist.
-        Expected: is_query_safe() returns False for all APOC write procedures.
-        """
+        """APOC procedure calls (e.g. CALL apoc.create.node) are detected as unsafe."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -840,13 +831,7 @@ class TestBugConditionExploration:
     @given(query=call_subquery_bypass_queries())
     @settings(max_examples=50)
     def test_call_subquery_bypass_detected(self, query):
-        """Property: CALL subqueries wrapping writes should be detected as unsafe.
-        
-        **Validates: Requirements 1.3, 2.3**
-        
-        Bug condition: CALL { CREATE ... } wraps write ops, CALL not in blocklist.
-        Expected: is_query_safe() returns False for all CALL subquery write operations.
-        """
+        """CALL subqueries wrapping writes (e.g. CALL { CREATE ... }) are detected as unsafe."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -860,13 +845,7 @@ class TestBugConditionExploration:
     @given(query=unicode_bypass_queries())
     @settings(max_examples=50)
     def test_unicode_bypass_detected(self, query):
-        """Property: Unicode lookalike keywords should be detected as unsafe.
-        
-        **Validates: Requirements 1.4, 2.4**
-        
-        Bug condition: Fullwidth Unicode chars (U+FF21-U+FF3A) bypass ASCII regex.
-        Expected: is_query_safe() returns False for all Unicode-obfuscated queries.
-        """
+        """Fullwidth Unicode lookalike keywords (e.g. ＣＲＥＡＴＥ) are detected as unsafe."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -878,14 +857,7 @@ class TestBugConditionExploration:
         )
 
     def test_block_graph_modification_flag_bypass(self):
-        """Property: block_graph_modification=False should skip safety check.
-        
-        **Validates: Requirements 1.5, 2.5**
-        
-        Bug condition: The flag is commented out, so safety check always runs.
-        Expected: When block_graph_modification=False, is_query_safe() returns True
-        for ALL queries (including modification queries).
-        """
+        """When block_graph_modification=False, is_query_safe() allows all queries."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(
@@ -995,26 +967,17 @@ def substring_keyword_queries(draw):
 
 
 class TestPreservationReadOnlyQueries:
-    """Preservation property tests - read-only queries must continue to work.
+    """Property-based tests ensuring read-only queries are not false-positive blocked.
 
-    **Validates: Requirements 3.1, 3.2**
-
-    These tests verify that legitimate read-only Cypher queries are NOT
-    false-positive blocked by is_query_safe(). They must pass on BOTH
-    unfixed and fixed code.
+    These tests verify that legitimate read-only Cypher queries and queries
+    containing blocked keywords as substrings (e.g. CREATED_AT, SETTINGS)
+    continue to pass is_query_safe() without being incorrectly rejected.
     """
 
     @given(query=read_only_cypher_queries())
     @settings(max_examples=100)
     def test_read_only_queries_are_safe(self, query):
-        """Property: All read-only Cypher queries return True from is_query_safe().
-
-        **Validates: Requirements 3.1**
-
-        For all queries using only MATCH, RETURN, WHERE, WITH, OPTIONAL MATCH,
-        UNWIND, ORDER BY, LIMIT that do NOT contain modification keywords,
-        is_query_safe() must return True.
-        """
+        """Read-only queries (MATCH/RETURN/WHERE/WITH) are allowed by is_query_safe()."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -1028,14 +991,7 @@ class TestPreservationReadOnlyQueries:
     @given(query=substring_keyword_queries())
     @settings(max_examples=100)
     def test_substring_keywords_are_safe(self, query):
-        """Property: Queries with blocked keywords as substrings return True.
-
-        **Validates: Requirements 3.2**
-
-        For all queries containing blocked keywords as substrings of property
-        names or labels (e.g., CREATED_AT, SETTINGS, REMOVED_DATE),
-        is_query_safe() must return True (no false positives).
-        """
+        """Blocked keywords as substrings (CREATED_AT, SETTINGS) don't trigger false positives."""
         mock_store = Mock()
         mock_store.execute_query = Mock()
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -1048,26 +1004,18 @@ class TestPreservationReadOnlyQueries:
 
 
 class TestPreservationRetrieveFormat:
-    """Preservation property tests - retrieve() returns correct format.
+    """Property-based tests for retrieve() return format consistency.
 
-    **Validates: Requirements 3.3, 3.4, 3.5, 3.6**
-
-    These tests verify that retrieve() returns results in the correct format:
-    - list for return_answers=False
-    - tuple of (context_list, answers_list) for return_answers=True
-    - Error messages include query and exception details
+    Verifies that retrieve() returns:
+    - A list when return_answers=False
+    - A tuple of (context_list, answers_list) when return_answers=True
+    - Error messages containing the query and exception details on failure
     """
 
     @given(query=read_only_cypher_queries(), return_answers=st.booleans())
     @settings(max_examples=100)
     def test_retrieve_returns_correct_format(self, query, return_answers):
-        """Property: retrieve() returns correct format for all valid read queries.
-
-        **Validates: Requirements 3.5, 3.6**
-
-        For return_answers=False: returns a list
-        For return_answers=True: returns a tuple of (list, list)
-        """
+        """retrieve() returns list or (list, list) tuple based on return_answers flag."""
         mock_store = Mock()
         mock_store.execute_query = Mock(return_value=[{'id': 1, 'name': 'Test'}])
         retriever = GraphQueryRetriever(graph_store=mock_store)
@@ -1096,13 +1044,7 @@ class TestPreservationRetrieveFormat:
     @given(query=read_only_cypher_queries())
     @settings(max_examples=50)
     def test_retrieve_error_format(self, query):
-        """Property: Query execution errors return error message with details.
-
-        **Validates: Requirements 3.4**
-
-        When query execution raises an exception, the returned context must
-        contain the query string and exception details.
-        """
+        """Query execution errors return a message containing the query and exception details."""
         mock_store = Mock()
         mock_store.execute_query = Mock(side_effect=RuntimeError("Connection timeout"))
         retriever = GraphQueryRetriever(graph_store=mock_store)

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -1081,3 +1081,158 @@ class TestBaseNeptuneGraphStore:
         call_args = mock_s3_client.put_object.call_args[1]
         assert call_args['Bucket'] == 'test-bucket'
         assert call_args['Body'] == 'test,data\n1,2'
+
+
+class TestNeptuneReadOnlyPropagation:
+    """Tests for read_only parameter propagation in execute_query."""
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_analytics_read_only_true_passes_to_api(self, mock_session, mock_neptune_client, mock_s3_client):
+        """When read_only=True, readOnly=True is passed to Neptune Analytics API."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode())
+        }
+
+        store = NeptuneAnalyticsGraphStore(
+            graph_identifier='test-graph-id',
+            region='us-west-2'
+        )
+
+        store.execute_query("MATCH (n) RETURN n", read_only=True)
+
+        call_args = mock_neptune_client.execute_query.call_args[1]
+        assert call_args['readOnly'] is True
+        assert call_args['queryString'] == "MATCH (n) RETURN n"
+        assert call_args['language'] == 'OPEN_CYPHER'
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_analytics_read_only_false_omits_param(self, mock_session, mock_neptune_client, mock_s3_client):
+        """When read_only=False, readOnly is not passed to Neptune Analytics API."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode())
+        }
+
+        store = NeptuneAnalyticsGraphStore(
+            graph_identifier='test-graph-id',
+            region='us-west-2'
+        )
+
+        store.execute_query("MATCH (n) RETURN n", read_only=False)
+
+        call_args = mock_neptune_client.execute_query.call_args[1]
+        assert 'readOnly' not in call_args
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_analytics_read_only_default_omits_param(self, mock_session, mock_neptune_client, mock_s3_client):
+        """When read_only is not specified, readOnly is not passed to Neptune Analytics API."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode())
+        }
+
+        store = NeptuneAnalyticsGraphStore(
+            graph_identifier='test-graph-id',
+            region='us-west-2'
+        )
+
+        store.execute_query("MATCH (n) RETURN n")
+
+        call_args = mock_neptune_client.execute_query.call_args[1]
+        assert 'readOnly' not in call_args
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_db_read_only_true_logs_warning(self, mock_session, mock_neptune_data_client, mock_s3_client, caplog):
+        """When read_only=True, Neptune DB logs a warning and still executes."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [{'n': 'test'}]
+        }
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2'
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = store.execute_query("MATCH (n) RETURN n", read_only=True)
+
+        assert 'does not support read-only' in caplog.text
+        assert result == [{'n': 'test'}]
+        mock_neptune_data_client.execute_open_cypher_query.assert_called_once()
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_db_read_only_false_no_warning(self, mock_session, mock_neptune_data_client, mock_s3_client, caplog):
+        """When read_only=False, Neptune DB does not log a warning."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [{'n': 'test'}]
+        }
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2'
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            store.execute_query("MATCH (n) RETURN n", read_only=False)
+
+        assert 'does not support read-only' not in caplog.text
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_db_read_only_does_not_pass_to_api(self, mock_session, mock_neptune_data_client, mock_s3_client):
+        """Neptune DB never passes readOnly to the openCypher API regardless of the flag."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': []
+        }
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2'
+        )
+
+        store.execute_query("MATCH (n) RETURN n", read_only=True)
+
+        call_args = mock_neptune_data_client.execute_open_cypher_query.call_args[1]
+        assert 'readOnly' not in call_args
+        assert call_args['openCypherQuery'] == "MATCH (n) RETURN n"

--- a/integration-tests/byokg.all
+++ b/integration-tests/byokg.all
@@ -1,1 +1,2 @@
 byokg_setup.LoadBYOKGGraph
+byokg_cypher_safety.CypherSafetyCheck

--- a/integration-tests/byokg.short
+++ b/integration-tests/byokg.short
@@ -1,0 +1,2 @@
+byokg_setup.LoadBYOKGGraph
+byokg_cypher_safety.CypherSafetyCheck

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
@@ -1,0 +1,158 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import unittest
+from typing import Dict, Any
+
+from graphrag_toolkit_tests.integration_test_base import IntegrationTestBase
+from graphrag_toolkit_tests.integration_test_handler import IntegrationTestHandler
+
+from graphrag_toolkit.byokg_rag.graphstore import NeptuneAnalyticsGraphStore
+from graphrag_toolkit.byokg_rag.graph_retrievers.graph_retrievers import GraphQueryRetriever
+
+
+class CypherSafetyCheck(IntegrationTestBase):
+    """Integration test verifying that the GraphQueryRetriever blocks
+    obfuscated write queries against a live Neptune Analytics graph.
+
+    This test confirms that:
+    1. Comment-split keywords (CRE/**/ATE) are blocked
+    2. CALL/APOC procedures are blocked
+    3. Unicode lookalike keywords are blocked
+    4. The block_graph_modification flag works correctly
+    5. Legitimate read queries still execute successfully
+    6. The Neptune Analytics readOnly parameter rejects writes at driver level
+    """
+
+    @property
+    def description(self):
+        return 'Verify Cypher safety checks block obfuscated write queries'
+
+    def _run_test(self, handler: IntegrationTestHandler, params: Dict[str, Any]):
+
+        region = os.environ['AWS_REGION_NAME']
+        graph_store_id = os.environ['GRAPH_STORE']
+
+        if not graph_store_id.startswith('neptune-graph://'):
+            raise ValueError(
+                f"Invalid graph store id. Expected Neptune graph beginning "
+                f"'neptune-graph://', but received {graph_store_id}."
+            )
+
+        graph_identifier = graph_store_id[16:]
+        graph_store = NeptuneAnalyticsGraphStore(
+            graph_identifier=graph_identifier, region=region
+        )
+
+        retriever = GraphQueryRetriever(
+            graph_store=graph_store, block_graph_modification=True
+        )
+
+        # Run a legitimate read query to confirm connectivity
+        read_result = retriever.retrieve(
+            "MATCH (n) RETURN n LIMIT 1", return_answers=True
+        )
+        read_context, read_answers = read_result
+
+        # Collect results for bypass attempts
+        bypass_results = {}
+
+        # Comment bypass attempts
+        comment_queries = [
+            "CRE/**/ATE (n:MaliciousNode {name: 'should_not_exist'})",
+            "ME/**/RGE (n:MaliciousNode {name: 'should_not_exist'})",
+            "MATCH (n) DE/**/LETE n",
+        ]
+        for q in comment_queries:
+            result = retriever.retrieve(q)
+            bypass_results[f"comment:{q[:30]}"] = (
+                "Cannot execute query" in result[0]
+            )
+
+        # CALL/APOC bypass attempts
+        call_queries = [
+            "CALL apoc.create.node(['MaliciousNode'], {name: 'evil'})",
+            "CALL { CREATE (n:MaliciousNode) RETURN n }",
+        ]
+        for q in call_queries:
+            result = retriever.retrieve(q)
+            bypass_results[f"call:{q[:30]}"] = (
+                "Cannot execute query" in result[0]
+            )
+
+        # Unicode bypass attempts
+        unicode_create = ''.join(
+            chr(ord(c) + 0xFEE0) if c.isalpha() else c for c in 'CREATE'
+        )
+        unicode_queries = [
+            f"{unicode_create} (n:MaliciousNode {{name: 'evil'}})",
+        ]
+        for q in unicode_queries:
+            result = retriever.retrieve(q)
+            bypass_results[f"unicode:{q[:30]}"] = (
+                "Cannot execute query" in result[0]
+            )
+
+        # Flag bypass - when False, queries should execute (read-only at driver level)
+        retriever_no_block = GraphQueryRetriever(
+            graph_store=graph_store, block_graph_modification=False
+        )
+        flag_safe_result = retriever_no_block.is_query_safe(
+            "CREATE (n:MaliciousNode)"
+        )
+
+        # Verify no MaliciousNode was created
+        verify_result = graph_store.execute_query(
+            "MATCH (n:MaliciousNode) RETURN count(n) as cnt"
+        )
+        malicious_count = verify_result[0]['cnt'] if verify_result else 0
+
+        class CypherSafetyAssertions(unittest.TestCase):
+
+            @classmethod
+            def setUpClass(cls):
+                cls._read_context = read_context
+                cls._read_answers = read_answers
+                cls._bypass_results = bypass_results
+                cls._flag_safe_result = flag_safe_result
+                cls._malicious_count = malicious_count
+
+            def test_read_query_succeeds(self):
+                """Legitimate read query executes successfully"""
+                self.assertTrue(len(self._read_context) > 0)
+                self.assertNotIn("Cannot execute query", self._read_context[0])
+                self.assertNotIn("Error", self._read_context[0])
+
+            def test_comment_bypass_blocked(self):
+                """Comment-split keywords (CRE/**/ATE) are blocked"""
+                comment_blocked = [
+                    v for k, v in self._bypass_results.items()
+                    if k.startswith("comment:")
+                ]
+                self.assertTrue(all(comment_blocked))
+
+            def test_call_bypass_blocked(self):
+                """CALL/APOC procedures are blocked"""
+                call_blocked = [
+                    v for k, v in self._bypass_results.items()
+                    if k.startswith("call:")
+                ]
+                self.assertTrue(all(call_blocked))
+
+            def test_unicode_bypass_blocked(self):
+                """Unicode lookalike keywords are blocked"""
+                unicode_blocked = [
+                    v for k, v in self._bypass_results.items()
+                    if k.startswith("unicode:")
+                ]
+                self.assertTrue(all(unicode_blocked))
+
+            def test_flag_disables_check(self):
+                """block_graph_modification=False skips safety check"""
+                self.assertTrue(self._flag_safe_result)
+
+            def test_no_malicious_nodes_created(self):
+                """No MaliciousNode was created in the graph"""
+                self.assertEqual(self._malicious_count, 0)
+
+        handler.run_assertions(CypherSafetyAssertions)


### PR DESCRIPTION
*Description of changes:*
- Fix the Cypher safety bypass vulnerabilities in `GraphQueryRetriever.is_query_safe()` by hardening the method with comment stripping, Unicode normalization, expanded blocklist (including `CALL`), restoring the `block_graph_modification` flag, and adding driver-level read-only enforcement via `NeptuneAnalyticsGraphStore.execute_query()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
