### PR TITLE
[CHORE] Add CODEOWNERS for automatic review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files
+* @awslabs/graphrag-toolkit-team


### PR DESCRIPTION
## Description
Auto-request reviews from @awslabs/graphrag-toolkit-team on all PRs.

## Changes
- .github/CODEOWNERS — single wildcard rule assigning team

## Prerequisites
The @awslabs/graphrag-toolkit-team must exist in the GitHub org for this to take effect.

## Testing
- Follows pattern from awslabs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
