### PR TITLE
[CHORE] Add stale issue management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last 60 days. It will be closed in 30 days if no further
+            activity occurs. If this issue is still relevant, please comment to keep it open.
+          close-issue-message: >
+            This issue was closed because it has been inactive for 90 days.
+            Please open a new issue if the problem persists.
+          days-before-stale: 60
+          days-before-close: 30
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,roadmap'


### PR DESCRIPTION
## Description
Auto-mark issues as stale after 60 days, close after 90 days. Prevents issue backlog from growing indefinitely.

## Changes
- .github/workflows/stale.yml — weekly workflow using actions/stale@v9

## Prerequisites
Create these labels before merging: stale, pinned, security, roadmap

## Testing
- Follows same pattern as aws-sdk-rust (stale_issue.yaml)
- Uses official actions/stale@v9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
