### PR TITLE
[FEATURE] Increase lexical-graph unit-test coverage to 58% across retrieval, storage, and utils

### DIFF
--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           PYTHONPATH=src .venv/bin/python -m pytest \
             -v --cov-config=.coveragerc --cov=graphrag_toolkit.lexical_graph \
-            -l --tb=short --maxfail=1 --cov-fail-under=46 \
+            -l --tb=short --maxfail=1 --cov-fail-under=56 \
             tests/
 
       - name: Package coverage reports

--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           PYTHONPATH=src .venv/bin/python -m pytest \
             -v --cov-config=.coveragerc --cov=graphrag_toolkit.lexical_graph \
-            -l --tb=short --maxfail=1 --cov-fail-under=45 \
+            -l --tb=short --maxfail=1 --cov-fail-under=46 \
             tests/
 
       - name: Package coverage reports

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
@@ -130,9 +130,10 @@ class KeywordVSSProvider(KeywordProviderBase):
             executor.shutdown()
 
             for future in futures:
-                for result in future.result():
+                result = future.result()
+                if result:
                     content.append(result)
-        
+
         return content
     
     def _get_content(self, node_ids:List[str]) -> List[str]:

--- a/lexical-graph/tests/unit/retrieval/processors/test_rerank_statements.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_rerank_statements.py
@@ -3,7 +3,7 @@
 
 """Tests for retrieval/processors/rerank_statements."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from llama_index.core.schema import QueryBundle
@@ -76,6 +76,65 @@ class TestDefaultRerankingSourceMetadataFn:
         result = default_reranking_source_metadata_fn(source)
         assert 'Hello' in result and 'Alice' in result
         assert ', ' in result
+
+    def test_none_value_stringified_via_typeerror(self):
+        # parse(None) raises TypeError, which falls back to str(None).
+        source = Source(
+            sourceId='s', metadata={'x': None},
+            versioning=Versioning(valid_from=0, valid_to=9),
+        )
+        assert default_reranking_source_metadata_fn(source) == 'None'
+
+
+def _entity_contexts():
+    return EntityContexts(contexts=[], keywords=[])
+
+
+class TestScoreValuesWithTfidf:
+    def test_delegates_to_tfidf_scorer(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='tfidf', debug_results=[], max_statements=5),
+            FilterConfig(),
+        )
+        with patch.object(mod, 'score_values_with_tfidf', return_value={'a': 0.5}) as scorer:
+            out = processor._score_values_with_tfidf(
+                ['a', 'b'], QueryBundle('hello world'), _entity_contexts(),
+            )
+        assert out == {'a': 0.5}
+        scorer.assert_called_once()
+
+
+class TestScoreValuesWithModel:
+    def test_builds_score_map_from_reranker(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='model', debug_results=[], max_statements=5),
+            FilterConfig(),
+            reranking_model=Mock(),
+        )
+        node = Mock(text='a', score=0.9)
+        with patch.object(mod, 'SentenceReranker') as reranker_cls:
+            reranker_cls.return_value.postprocess_nodes.return_value = [node]
+            out = processor._score_values(['a'], QueryBundle('q'), _entity_contexts())
+        assert out == {'a': 0.9}
+
+
+class TestScoreValuesWithBedrock:
+    def test_maps_results_back_to_values(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='bedrock', debug_results=[], max_statements=5),
+            FilterConfig(),
+        )
+        with patch.object(mod, 'boto3') as boto3_mod, \
+             patch.object(mod, 'GraphRAGConfig') as config:
+            boto3_mod.Session.return_value.region_name = 'us-east-1'
+            config.bedrock_reranking_model = 'model-x'
+            boto3_mod.client.return_value.rerank.return_value = {
+                'results': [{'index': 0, 'relevanceScore': 0.7}],
+            }
+            out = processor._score_values_with_bedrock(
+                ['a', 'b'], QueryBundle('q'), _entity_contexts(),
+            )
+        assert out == {'a': 0.7}
 
 
 class TestProcessResults:

--- a/lexical-graph/tests/unit/retrieval/processors/test_rerank_statements.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_rerank_statements.py
@@ -1,0 +1,151 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/processors/rerank_statements."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    EntityContexts,
+    SearchResult,
+    SearchResultCollection,
+    Source,
+    Statement,
+    Topic,
+    Versioning,
+)
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.processors import rerank_statements as mod
+from graphrag_toolkit.lexical_graph.retrieval.processors.rerank_statements import (
+    RerankStatements,
+    default_reranking_source_metadata_fn,
+)
+
+
+def _collection_with_statements():
+    versioning = Versioning(valid_from=0, valid_to=9999999999)
+    source = Source(sourceId='doc1', metadata={'author': 'alice'}, versioning=versioning)
+    statements = [
+        Statement(statement='s1', statement_str='one fact', score=0.0),
+        Statement(statement='s2', statement_str='two fact', score=0.0),
+    ]
+    topic = Topic(topic='T', topicId='t1', statements=statements)
+    return SearchResultCollection(
+        results=[SearchResult(source=source, topics=[topic])],
+        entity_contexts=EntityContexts(contexts=[], keywords=[]),
+    )
+
+
+class TestDefaultRerankingSourceMetadataFn:
+    def test_numeric_value_stringified(self):
+        source = Source(sourceId='s', metadata={'year': 2024}, versioning=Versioning(valid_from=0, valid_to=9))
+        assert default_reranking_source_metadata_fn(source) == '2024'
+
+    def test_date_value_reformatted(self):
+        source = Source(
+            sourceId='s', metadata={'date': '2024-03-15'},
+            versioning=Versioning(valid_from=0, valid_to=9),
+        )
+        result = default_reranking_source_metadata_fn(source)
+        assert 'March' in result and '2024' in result
+
+    def test_url_value_dropped(self):
+        source = Source(
+            sourceId='s', metadata={'url': 'https://example.com/foo'},
+            versioning=Versioning(valid_from=0, valid_to=9),
+        )
+        assert default_reranking_source_metadata_fn(source) == ''
+
+    def test_plain_text_passthrough(self):
+        source = Source(
+            sourceId='s', metadata={'title': 'Hello World'},
+            versioning=Versioning(valid_from=0, valid_to=9),
+        )
+        assert default_reranking_source_metadata_fn(source) == 'Hello World'
+
+    def test_combines_multiple_values_with_comma(self):
+        source = Source(
+            sourceId='s',
+            metadata={'title': 'Hello', 'author': 'Alice'},
+            versioning=Versioning(valid_from=0, valid_to=9),
+        )
+        result = default_reranking_source_metadata_fn(source)
+        assert 'Hello' in result and 'Alice' in result
+        assert ', ' in result
+
+
+class TestProcessResults:
+    def test_none_reranker_returns_results_unchanged(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='none', debug_results=[]), FilterConfig(),
+        )
+        collection = _collection_with_statements()
+        result = processor._process_results(collection, QueryBundle('q'))
+        assert result is collection
+
+    def test_no_reranker_value_returns_results_unchanged(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker=None, debug_results=[]), FilterConfig(),
+        )
+        collection = _collection_with_statements()
+        assert processor._process_results(collection, QueryBundle('q')) is collection
+
+    def test_unknown_reranker_returns_results_unchanged(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='something-weird', debug_results=[]), FilterConfig(),
+        )
+        collection = _collection_with_statements()
+        assert processor._process_results(collection, QueryBundle('q')) is collection
+
+    def test_empty_results_short_circuits(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='tfidf', debug_results=[]), FilterConfig(),
+        )
+        empty = SearchResultCollection(
+            results=[],
+            entity_contexts=EntityContexts(contexts=[], keywords=[]),
+        )
+        result = processor._process_results(empty, QueryBundle('q'))
+        assert result is empty
+
+    def test_tfidf_reranker_assigns_scores_and_sorts(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='tfidf', debug_results=[], max_statements=10),
+            FilterConfig(),
+        )
+        collection = _collection_with_statements()
+
+        # Bypass the actual tfidf scoring with deterministic output.
+        with patch.object(processor, '_score_values_with_tfidf') as scorer:
+            # Build keys the way _format_statement_context does: source, topic, statement.
+            def fake(values, *_a, **_kw):
+                return {values[0]: 0.2, values[1]: 0.9}
+            scorer.side_effect = fake
+            result = processor._process_results(collection, QueryBundle('q'))
+
+        statements = result.results[0].topics[0].statements
+        assert statements[0].statement_str == 'two fact'
+        assert statements[0].score == 0.9
+        assert statements[1].score == 0.2
+
+    def test_model_reranker_dispatches_to_score_values(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='model', debug_results=[]), FilterConfig(),
+        )
+        with patch.object(processor, '_score_values') as scorer:
+            scorer.return_value = {}
+            processor._process_results(_collection_with_statements(), QueryBundle('q'))
+        scorer.assert_called_once()
+
+    def test_bedrock_reranker_dispatches_to_score_values_with_bedrock(self):
+        processor = RerankStatements(
+            ProcessorArgs(reranker='bedrock', debug_results=[]), FilterConfig(),
+        )
+        with patch.object(processor, '_score_values_with_bedrock') as scorer:
+            scorer.return_value = {}
+            processor._process_results(_collection_with_statements(), QueryBundle('q'))
+        scorer.assert_called_once()

--- a/lexical-graph/tests/unit/retrieval/processors/test_rerank_statements.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_rerank_statements.py
@@ -132,20 +132,36 @@ class TestProcessResults:
         assert statements[0].score == 0.9
         assert statements[1].score == 0.2
 
-    def test_model_reranker_dispatches_to_score_values(self):
+    def test_model_reranker_dispatches_and_applies_scores(self):
         processor = RerankStatements(
-            ProcessorArgs(reranker='model', debug_results=[]), FilterConfig(),
+            ProcessorArgs(reranker='model', debug_results=[], max_statements=10),
+            FilterConfig(),
         )
         with patch.object(processor, '_score_values') as scorer:
-            scorer.return_value = {}
-            processor._process_results(_collection_with_statements(), QueryBundle('q'))
+            scorer.side_effect = lambda values, *_a, **_kw: {
+                values[0]: 0.1, values[1]: 0.8,
+            }
+            result = processor._process_results(
+                _collection_with_statements(), QueryBundle('q'),
+            )
         scorer.assert_called_once()
+        statements = result.results[0].topics[0].statements
+        assert {s.score for s in statements} == {0.1, 0.8}
+        assert statements[0].score >= statements[1].score
 
-    def test_bedrock_reranker_dispatches_to_score_values_with_bedrock(self):
+    def test_bedrock_reranker_dispatches_and_applies_scores(self):
         processor = RerankStatements(
-            ProcessorArgs(reranker='bedrock', debug_results=[]), FilterConfig(),
+            ProcessorArgs(reranker='bedrock', debug_results=[], max_statements=10),
+            FilterConfig(),
         )
         with patch.object(processor, '_score_values_with_bedrock') as scorer:
-            scorer.return_value = {}
-            processor._process_results(_collection_with_statements(), QueryBundle('q'))
+            scorer.side_effect = lambda values, *_a, **_kw: {
+                values[0]: 0.3, values[1]: 0.7,
+            }
+            result = processor._process_results(
+                _collection_with_statements(), QueryBundle('q'),
+            )
         scorer.assert_called_once()
+        statements = result.results[0].topics[0].statements
+        assert {s.score for s in statements} == {0.3, 0.7}
+        assert statements[0].score >= statements[1].score

--- a/lexical-graph/tests/unit/retrieval/processors/test_truncate_statements.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_truncate_statements.py
@@ -1,0 +1,58 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/processors/truncate_statements."""
+
+import pytest
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    EntityContexts,
+    SearchResult,
+    SearchResultCollection,
+    Source,
+    Statement,
+    Topic,
+    Versioning,
+)
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.processors.truncate_statements import (
+    TruncateStatements,
+)
+
+
+def _collection_with_statements(n):
+    versioning = Versioning(valid_from=0, valid_to=9999999999)
+    source = Source(sourceId='doc1', metadata={}, versioning=versioning)
+    statements = [Statement(statement=f's{i}', score=1.0 - i * 0.1) for i in range(n)]
+    topic = Topic(topic='T', topicId='t1', statements=statements)
+    result = SearchResult(source=source, topics=[topic])
+    return SearchResultCollection(
+        results=[result],
+        entity_contexts=EntityContexts(contexts=[], keywords=[]),
+    )
+
+
+class TestTruncateStatements:
+    def test_truncates_to_max_statements_per_topic(self):
+        processor = TruncateStatements(
+            ProcessorArgs(debug_results=[], max_statements_per_topic=2),
+            FilterConfig(),
+        )
+        processed = processor._process_results(
+            _collection_with_statements(5), QueryBundle('q')
+        )
+        topic = processed.results[0].topics[0]
+        assert len(topic.statements) == 2
+        assert [s.statement for s in topic.statements] == ['s0', 's1']
+
+    def test_leaves_topic_unchanged_when_under_limit(self):
+        processor = TruncateStatements(
+            ProcessorArgs(debug_results=[], max_statements_per_topic=10),
+            FilterConfig(),
+        )
+        processed = processor._process_results(
+            _collection_with_statements(3), QueryBundle('q')
+        )
+        assert len(processed.results[0].topics[0].statements) == 3

--- a/lexical-graph/tests/unit/retrieval/processors/test_update_chunk_metadata.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_update_chunk_metadata.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/processors/update_chunk_metadata."""
+
+import pytest
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    Chunk,
+    EntityContexts,
+    SearchResult,
+    SearchResultCollection,
+    Source,
+    Statement,
+    Topic,
+    Versioning,
+)
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.processors.update_chunk_metadata import (
+    UpdateChunkMetadata,
+)
+
+
+def _collection(chunks):
+    versioning = Versioning(valid_from=0, valid_to=9999999999)
+    source = Source(sourceId='doc1', metadata={}, versioning=versioning)
+    topic = Topic(
+        topic='T',
+        topicId='t1',
+        chunks=chunks,
+        statements=[Statement(statement='s1', score=0.5)],
+    )
+    return SearchResultCollection(
+        results=[SearchResult(source=source, topics=[topic])],
+        entity_contexts=EntityContexts(contexts=[], keywords=[]),
+    )
+
+
+@pytest.fixture
+def processor():
+    return UpdateChunkMetadata(ProcessorArgs(debug_results=[]), FilterConfig())
+
+
+class TestUpdateChunkMetadata:
+    def test_moves_metadata_value_to_chunk_value(self, processor):
+        chunk = Chunk(
+            chunkId='c1',
+            value=None,
+            metadata={'value': 'hoisted text', 'other': 'keep'},
+        )
+        processed = processor._process_results(_collection([chunk]), QueryBundle('q'))
+        out = processed.results[0].topics[0].chunks[0]
+        assert out.value == 'hoisted text'
+        assert 'value' not in out.metadata
+        assert out.metadata.get('other') == 'keep'
+
+    def test_strips_chunk_id_from_metadata(self, processor):
+        chunk = Chunk(chunkId='c1', metadata={'chunkId': 'shadow', 'k': 'v'})
+        processed = processor._process_results(_collection([chunk]), QueryBundle('q'))
+        out = processed.results[0].topics[0].chunks[0]
+        assert 'chunkId' not in out.metadata
+
+    def test_missing_value_leaves_chunk_value_unchanged(self, processor):
+        chunk = Chunk(chunkId='c1', value='already set', metadata={'other': 'x'})
+        processed = processor._process_results(_collection([chunk]), QueryBundle('q'))
+        out = processed.results[0].topics[0].chunks[0]
+        assert out.value == 'already set'

--- a/lexical-graph/tests/unit/retrieval/processors/test_zero_scores.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_zero_scores.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/processors/zero_scores."""
+
+import pytest
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    EntityContexts,
+    SearchResult,
+    SearchResultCollection,
+    Source,
+    Statement,
+    Topic,
+    Versioning,
+)
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.processors.zero_scores import ZeroScores
+
+
+@pytest.fixture
+def processor():
+    return ZeroScores(ProcessorArgs(debug_results=[]), FilterConfig())
+
+
+def _collection():
+    versioning = Versioning(valid_from=0, valid_to=9999999999)
+    source = Source(sourceId='doc1', metadata={}, versioning=versioning)
+    topic = Topic(
+        topic='T',
+        topicId='t1',
+        statements=[
+            Statement(statement='s1', score=0.9),
+            Statement(statement='s2', score=0.5),
+        ],
+    )
+    result = SearchResult(source=source, topics=[topic], score=0.95)
+    return SearchResultCollection(
+        results=[result],
+        entity_contexts=EntityContexts(contexts=[], keywords=[]),
+    )
+
+
+class TestZeroScores:
+    def test_zeroes_search_result_and_statement_scores(self, processor):
+        processed = processor._process_results(_collection(), QueryBundle('q'))
+        result = processed.results[0]
+        assert result.score == 0.0
+        assert all(s.score == 0.0 for s in result.topics[0].statements)

--- a/lexical-graph/tests/unit/retrieval/query_context/test_entity_context_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_entity_context_provider.py
@@ -117,6 +117,49 @@ class TestGetNeighbourEntities:
         assert set(ids) == {'n1', 'n2', 'n3'}
 
 
+class TestGetEntityIdContextTree:
+    def test_builds_tree_from_graph_results(self):
+        provider, store = _provider(ec_max_depth=2)
+        store.execute_query.return_value = [
+            {'result': {'entity': {'entityId': 'e1'}, 'others': ['c1', 'c2']}},
+        ]
+        tree = provider._get_entity_id_context_tree([_se('e1', 'apple', score=1.0)])
+        assert 'e1' in tree
+        assert 'c1' in tree['e1'] and 'c2' in tree['e1']
+
+    def test_skips_entities_with_non_positive_score(self):
+        provider, store = _provider(ec_max_depth=2)
+        store.execute_query.return_value = []
+        tree = provider._get_entity_id_context_tree([_se('e1', 'apple', score=0.0)])
+        assert tree == {}
+        store.execute_query.assert_not_called()
+
+    def test_emits_debug_when_enabled(self):
+        provider, store = _provider(ec_max_depth=2, debug_results=['EntityContextProvider'])
+        store.execute_query.return_value = []
+        tree = provider._get_entity_id_context_tree([_se('e1', 'apple', score=1.0)])
+        assert 'e1' in tree
+
+
+class TestGetEntityContexts:
+    def test_builds_contexts_from_tree(self):
+        provider, _ = _provider(ec_max_contexts=5)
+        entities = [_se('e1', 'apple'), _se('c1', 'pie')]
+        tree = {'e1': {'c1': {}}}
+        contexts = provider._get_entity_contexts(entities, tree, QueryBundle('q'))
+        assert isinstance(contexts, list)
+        assert contexts
+        ids = [se.entity.entityId for se in contexts[0]]
+        assert ids == ['e1', 'c1']
+
+    def test_respects_max_contexts_limit(self):
+        provider, _ = _provider(ec_max_contexts=1, debug_results=['EntityContextProvider'])
+        entities = [_se('e1', 'apple'), _se('c1', 'pie'), _se('c2', 'tart')]
+        tree = {'e1': {'c1': {}}, 'c2': {}}
+        contexts = provider._get_entity_contexts(entities, tree, QueryBundle('q'))
+        assert len(contexts) <= 1
+
+
 class TestGetEntityContextsEntryPoint:
     def test_returns_empty_when_max_contexts_zero(self):
         provider, _ = _provider(ec_max_contexts=0)

--- a/lexical-graph/tests/unit/retrieval/query_context/test_entity_context_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_entity_context_provider.py
@@ -1,0 +1,145 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/entity_context_provider."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.model import Entity, ScoredEntity
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context import (
+    entity_context_provider as mod,
+)
+from graphrag_toolkit.lexical_graph.retrieval.query_context.entity_context_provider import (
+    EntityContextProvider,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+
+
+def _se(entity_id, value, classification='thing', score=1.0, reranking_score=1.0):
+    e = ScoredEntity(
+        entity=Entity(entityId=entity_id, value=value, classification=classification),
+        score=score,
+    )
+    e.reranking_score = reranking_score
+    return e
+
+
+def _provider(**args):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    return EntityContextProvider(
+        graph_store=graph_store,
+        args=ProcessorArgs(**args),
+    ), graph_store
+
+
+class TestDedupContexts:
+    def test_keeps_longest_path_only(self):
+        provider, _ = _provider()
+        short = [_se('e1', 'a'), _se('e2', 'b')]
+        long = [_se('e1', 'a'), _se('e2', 'b'), _se('e3', 'c')]
+        result = provider.dedup_contexts([short, long])
+        assert long in result
+        assert short not in result
+
+    def test_keeps_unrelated_contexts(self):
+        provider, _ = _provider()
+        c1 = [_se('e1', 'apple')]
+        c2 = [_se('e2', 'orange')]
+        result = provider.dedup_contexts([c1, c2])
+        assert len(result) == 2
+
+    def test_lowercases_for_dedup_key(self):
+        provider, _ = _provider()
+        c1 = [_se('e1', 'Apple')]
+        c2 = [_se('e2', 'apple'), _se('e3', 'pie')]
+        result = provider.dedup_contexts([c1, c2])
+        assert c2 in result
+        assert c1 not in result
+
+
+class TestOrderContexts:
+    def test_orders_by_average_reranking_score(self):
+        provider, _ = _provider()
+        low = [_se('e1', 'a', reranking_score=0.1)]
+        high = [_se('e2', 'b', reranking_score=0.9)]
+        result = provider.order_contexts([low, high])
+        assert result[0] is high
+
+
+class TestOrderContextSubtrees:
+    def test_groups_subtrees_by_root_entity(self):
+        provider, _ = _provider()
+        root_a_low = [_se('a', 'A', reranking_score=0.1), _se('a2', 'a2')]
+        root_a_high = [_se('a', 'A', reranking_score=0.9), _se('a3', 'a3')]
+        root_b = [_se('b', 'B', reranking_score=0.5)]
+        result = provider.order_context_subtrees([root_a_low, root_a_high, root_b])
+        a_indices = [i for i, c in enumerate(result) if c[0].entity.entityId == 'a']
+        assert a_indices == [0, 1] or a_indices == [1, 2]
+        # the higher-scoring root_a context comes before root_a_low
+        assert result.index(root_a_high) < result.index(root_a_low)
+
+
+class TestFilterEntities:
+    def test_filters_outside_score_window(self):
+        provider, _ = _provider(ec_max_score_factor=2, ec_min_score_factor=0.5)
+        entities = [
+            _se('top', 'top', score=10.0),
+            _se('keep', 'keep', score=8.0),
+            _se('too_low', 'low', score=1.0),
+            _se('too_high', 'huge', score=100.0),
+        ]
+        result = provider.filter_entities(entities)
+        ids = [r.entity.entityId for r in result]
+        assert 'keep' in ids and 'top' in ids
+        assert 'too_low' not in ids and 'too_high' not in ids
+
+
+class TestGetNeighbourEntities:
+    def test_walks_tree_and_queries_graph(self):
+        provider, store = _provider()
+        store.execute_query.return_value = [
+            {'result': {
+                'entity': {'entityId': 'n1', 'value': 'apple', 'classification': 'fruit'},
+                'score': 5,
+            }},
+        ]
+        tree = {'root': {'n1': {}, 'n2': {'n3': {}}}}
+        result = provider._get_neighbour_entities(tree)
+        assert len(result) == 1
+        ids = store.execute_query.call_args.args[1]['entityIds']
+        # Root keys of the tree (top-level entities) are not collected; only their
+        # descendants — _get_neighbour_entities expands ALL nodes below the roots.
+        assert set(ids) == {'n1', 'n2', 'n3'}
+
+
+class TestGetEntityContextsEntryPoint:
+    def test_returns_empty_when_max_contexts_zero(self):
+        provider, _ = _provider(ec_max_contexts=0)
+        result = provider.get_entity_contexts(
+            [_se('e1', 'apple')], ['apple'], QueryBundle('q'),
+        )
+        assert result.contexts == []
+
+    def test_returns_empty_when_no_entities(self):
+        provider, _ = _provider(ec_max_contexts=3)
+        result = provider.get_entity_contexts([], ['apple'], QueryBundle('q'))
+        assert result.contexts == []
+
+    def test_short_circuits_through_tree_pipeline(self):
+        provider, _ = _provider(ec_max_contexts=3, ec_max_depth=2)
+        # Force a deterministic tree + neighbour set so the surrounding logic runs
+        # without needing a full graph store response shape.
+        with patch.object(provider, '_get_entity_id_context_tree', return_value={'e1': {}}), \
+             patch.object(provider, '_get_neighbour_entities', return_value=[]), \
+             patch.object(mod, 'rerank_entities', side_effect=lambda es, *a, **kw: es):
+            result = provider.get_entity_contexts(
+                [_se('e1', 'apple', score=1.0, reranking_score=1.0)],
+                ['apple'],
+                QueryBundle('q'),
+            )
+        assert hasattr(result, 'contexts')

--- a/lexical-graph/tests/unit/retrieval/query_context/test_entity_from_top_statement_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_entity_from_top_statement_provider.py
@@ -1,0 +1,102 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/entity_from_top_statement_provider."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context import (
+    entity_from_top_statement_provider as mod,
+)
+from graphrag_toolkit.lexical_graph.retrieval.query_context.entity_from_top_statement_provider import (
+    EntityFromTopStatementProvider,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.storage.vector.dummy_vector_index import (
+    DummyVectorIndex,
+)
+
+
+def _provider(topic_results=None, statement_results=None, entity_results=None,
+              use_chunk_index=False):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    side_effect = []
+    if statement_results is not None:
+        side_effect.append(statement_results)
+    if entity_results is not None:
+        side_effect.append(entity_results)
+    graph_store.execute_query.side_effect = side_effect
+
+    vector_store = MagicMock()
+    topic_index = MagicMock() if not use_chunk_index else DummyVectorIndex(index_name='topic')
+    chunk_index = MagicMock()
+    if topic_results is not None:
+        if use_chunk_index:
+            chunk_index.top_k.return_value = topic_results
+        else:
+            topic_index.top_k.return_value = topic_results
+    vector_store.get_index.side_effect = lambda index_name: {
+        'topic': topic_index,
+        'chunk': chunk_index,
+    }[index_name]
+
+    return EntityFromTopStatementProvider(
+        graph_store=graph_store,
+        vector_store=vector_store,
+        args=ProcessorArgs(ec_max_entities=10),
+    ), graph_store
+
+
+class TestEntityFromTopStatementProvider:
+    def test_uses_chunk_index_when_topic_index_is_dummy(self):
+        provider, _ = _provider(use_chunk_index=True)
+        assert provider.index_name == 'chunk'
+
+    def test_get_top_statement_id_runs_topic_cypher(self):
+        provider, store = _provider(
+            topic_results=[{'topic': {'topicId': 't1'}}, {'topic': {'topicId': 't2'}}],
+            statement_results=[
+                {'result': {'statement': 'apple is a fruit', 'statementId': 'stmt-1'}},
+                {'result': {'statement': 'orange is a fruit', 'statementId': 'stmt-2'}},
+            ],
+        )
+        with patch.object(mod, 'score_values_with_tfidf') as scorer:
+            scorer.return_value = {'apple is a fruit': 0.9, 'orange is a fruit': 0.2}
+            sid = provider._get_top_statement_id(QueryBundle('apple?'))
+        assert sid == 'stmt-1'
+        cypher, _ = store.execute_query.call_args.args
+        assert 'topic' in cypher.lower()
+
+    def test_get_top_statement_id_runs_chunk_cypher_when_chunk_mode(self):
+        provider, store = _provider(
+            use_chunk_index=True,
+            topic_results=[{'chunk': {'chunkId': 'c1'}}],
+            statement_results=[{'result': {'statement': 'x', 'statementId': 's1'}}],
+        )
+        with patch.object(mod, 'score_values_with_tfidf', return_value={'x': 0.5}):
+            provider._get_top_statement_id(QueryBundle('q'))
+        cypher, _ = store.execute_query.call_args.args
+        assert 'chunk' in cypher.lower()
+
+    def test_get_entities_returns_empty_when_no_top_statement(self):
+        provider, _ = _provider()
+        with patch.object(provider, '_get_top_statement_id', return_value=None):
+            assert provider._get_entities([], QueryBundle('q')) == []
+
+    def test_get_entities_for_statement_validates_results(self):
+        provider, store = _provider()
+        store.execute_query.side_effect = None
+        store.execute_query.return_value = [
+            {'result': {
+                'entity': {'entityId': 'e1', 'value': 'apple', 'classification': 'fruit'},
+                'score': 7,
+            }},
+        ]
+        result = provider._get_entities_for_statement('stmt-1')
+        assert len(result) == 1
+        assert result[0].entity.entityId == 'e1'

--- a/lexical-graph/tests/unit/retrieval/query_context/test_entity_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_entity_provider.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/entity_provider."""
+
+from unittest.mock import MagicMock
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context.entity_provider import (
+    EntityProvider,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+
+
+def _entity_row(entity_id, value, classification, score):
+    return {
+        'result': {
+            'entity': {'entityId': entity_id, 'value': value, 'classification': classification},
+            'score': score,
+        }
+    }
+
+
+def _provider(execute_responses):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    graph_store.execute_query.side_effect = execute_responses
+    return EntityProvider(
+        graph_store=graph_store,
+        args=ProcessorArgs(num_workers=1, ec_max_entities=10),
+    ), graph_store
+
+
+class TestGetEntitiesForKeyword:
+    def test_simple_keyword_runs_exact_match_query(self):
+        provider, store = _provider([[_entity_row('e1', 'apple', 'fruit', 5)]])
+        entities = provider._get_entities_for_keyword('apple')
+        assert len(entities) == 1
+        cypher, params = store.execute_query.call_args.args
+        assert 'entity.search_str = $keyword' in cypher
+        assert 'class <> ' in cypher
+        assert params == {'keyword': 'apple'}
+
+    def test_classified_keyword_filters_by_class(self):
+        provider, store = _provider([[_entity_row('e1', 'apple', 'fruit', 5)]])
+        provider._get_entities_for_keyword('apple|fruit')
+        _, params = store.execute_query.call_args.args
+        assert params == {'keyword': 'apple', 'classification': 'fruit'}
+
+    def test_zero_score_results_dropped(self):
+        # Both the exact and STARTS WITH fallback return only zero-score rows.
+        zero = [_entity_row('e1', 'apple', 'fruit', 0)]
+        provider, _ = _provider([zero, zero])
+        entities = provider._get_entities_for_keyword('apple')
+        assert entities == []
+
+    def test_falls_back_to_starts_with_when_no_exact_match(self):
+        provider, store = _provider([
+            [],
+            [_entity_row('e2', 'apple-pie', 'fruit', 3)],
+        ])
+        entities = provider._get_entities_for_keyword('apple')
+        assert len(entities) == 1
+        assert store.execute_query.call_count == 2
+        cypher2, _ = store.execute_query.call_args_list[1].args
+        assert 'STARTS WITH' in cypher2
+
+
+class TestGetEntities:
+    def test_dedups_and_sums_scores_across_keywords(self):
+        # Both keyword lookups return entity e1 with scores 3 and 5;
+        # provider should sum to 8 and rank above any other.
+        provider, _ = _provider([
+            [_entity_row('e1', 'apple', 'fruit', 3)],
+            [_entity_row('e1', 'apple', 'fruit', 5), _entity_row('e2', 'orange', 'fruit', 2)],
+        ])
+        result = provider._get_entities(['apple', 'apple'], QueryBundle('q'))
+        ids_scores = [(r.entity.entityId, r.score) for r in result]
+        assert ids_scores[0] == ('e1', 8)
+        assert ('e2', 2) in ids_scores
+
+    def test_sorts_descending_by_score(self):
+        provider, _ = _provider([
+            [_entity_row('e1', 'a', 'x', 1), _entity_row('e2', 'b', 'x', 5)],
+        ])
+        result = provider._get_entities(['a'], QueryBundle('q'))
+        assert [r.entity.entityId for r in result] == ['e2', 'e1']

--- a/lexical-graph/tests/unit/retrieval/query_context/test_entity_vss_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_entity_vss_provider.py
@@ -1,0 +1,92 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/entity_vss_provider."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.model import Entity, ScoredEntity
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context import entity_vss_provider
+from graphrag_toolkit.lexical_graph.retrieval.query_context.entity_vss_provider import (
+    EntityVSSProvider,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.storage.vector.dummy_vector_index import (
+    DummyVectorIndex,
+)
+
+
+def _scored(entity_id, value, classification, score):
+    return ScoredEntity(
+        entity=Entity(entityId=entity_id, value=value, classification=classification),
+        score=score,
+    )
+
+
+def _provider(index_name='topic'):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    vector_store = MagicMock()
+    topic_index = MagicMock() if index_name == 'topic' else DummyVectorIndex(index_name='topic')
+    chunk_index = MagicMock()
+    vector_store.get_index.side_effect = lambda index_name: {
+        'topic': topic_index,
+        'chunk': chunk_index,
+    }[index_name]
+    provider = EntityVSSProvider(
+        graph_store=graph_store,
+        vector_store=vector_store,
+        args=ProcessorArgs(intermediate_limit=5, ec_max_entities=10, reranker='tfidf'),
+    )
+    return provider, graph_store, topic_index, chunk_index
+
+
+class TestEntityVSSProvider:
+    def test_index_name_falls_back_to_chunk_when_topic_is_dummy(self):
+        provider, _, _, _ = _provider(index_name='chunk')
+        assert provider.index_name == 'chunk'
+
+    def test_index_name_is_topic_when_topic_index_present(self):
+        provider, _, _, _ = _provider(index_name='topic')
+        assert provider.index_name == 'topic'
+
+    def test_get_node_ids_extracts_ids_from_topk_results(self):
+        provider, _, topic_index, _ = _provider(index_name='topic')
+        topic_index.top_k.return_value = [
+            {'topic': {'topicId': 't1'}},
+            {'topic': {'topicId': 't2'}},
+        ]
+        assert provider._get_node_ids(['kw1', 'kw2']) == ['t1', 't2']
+
+    def test_get_entities_for_nodes_picks_topic_cypher(self):
+        provider, graph_store, _, _ = _provider(index_name='topic')
+        graph_store.execute_query.return_value = [
+            {'result': {'entity': {'entityId': 'e1', 'value': 'apple', 'classification': 'fruit'}, 'score': 5}},
+        ]
+        result = provider._get_entities_for_nodes(['t1'])
+        assert len(result) == 1
+        assert result[0].entity.entityId == 'e1'
+        assert 'topic ids' in graph_store.execute_query.call_args.args[0]
+
+    def test_get_entities_for_nodes_picks_chunk_cypher_when_chunk_mode(self):
+        provider, graph_store, _, _ = _provider(index_name='chunk')
+        graph_store.execute_query.return_value = []
+        provider._get_entities_for_nodes(['c1'])
+        assert 'chunk ids' in graph_store.execute_query.call_args.args[0]
+
+    def test_get_entities_dedups_across_threads_and_reranks(self):
+        provider, _, _, _ = _provider(index_name='topic')
+
+        e1 = _scored('e1', 'apple', 'fruit', 0.9)
+        e2 = _scored('e2', 'orange', 'fruit', 0.5)
+        # Two of the three lookups return the same entity, one returns a fresh entity.
+        with patch.object(provider, '_get_entities_by_keyword_match', return_value=[e1]), \
+             patch.object(provider, '_get_entities_for_values', side_effect=[[e1, e2], [e2]]), \
+             patch.object(entity_vss_provider, 'rerank_entities', side_effect=lambda entities, *a, **kw: entities):
+            result = provider._get_entities(['fruit'], QueryBundle('q'))
+        ids = sorted(r.entity.entityId for r in result)
+        assert ids == ['e1', 'e2']

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_nlp_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_nlp_provider.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/keyword_nlp_provider."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.errors import ModelError
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+
+
+def _provider_with_spacy(monkeypatch, ents):
+    doc = SimpleNamespace(ents=[SimpleNamespace(text=t) for t in ents])
+    nlp = MagicMock(return_value=doc)
+    fake_spacy = SimpleNamespace(load=MagicMock(return_value=nlp))
+    monkeypatch.setitem(sys.modules, 'spacy', fake_spacy)
+    from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_nlp_provider import (
+        KeywordNLPProvider,
+    )
+    return KeywordNLPProvider(args=ProcessorArgs(max_keywords=10))
+
+
+class TestKeywordNLPProvider:
+    def test_missing_spacy_raises_import_error(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, 'spacy', None)
+        from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_nlp_provider import (
+            KeywordNLPProvider,
+        )
+        with pytest.raises(ImportError, match='spacy package not found'):
+            KeywordNLPProvider(args=ProcessorArgs())
+
+    def test_missing_spacy_model_raises_model_error(self, monkeypatch):
+        fake_spacy = SimpleNamespace(load=MagicMock(side_effect=OSError))
+        monkeypatch.setitem(sys.modules, 'spacy', fake_spacy)
+        from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_nlp_provider import (
+            KeywordNLPProvider,
+        )
+        with pytest.raises(ModelError, match='spaCy model'):
+            KeywordNLPProvider(args=ProcessorArgs())
+
+    def test_extracts_entity_text_as_keywords(self, monkeypatch):
+        provider = _provider_with_spacy(monkeypatch, ['Alice', 'Bob'])
+        result = provider.get_keywords(QueryBundle('Who knows Alice and Bob?'))
+        assert sorted(result) == ['Alice', 'Bob']
+
+    def test_dedups_case_insensitively_keeping_last(self, monkeypatch):
+        provider = _provider_with_spacy(monkeypatch, ['Alice', 'alice', 'Bob'])
+        result = provider.get_keywords(QueryBundle('q'))
+        assert sorted(s.lower() for s in result) == ['alice', 'bob']

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_provider.py
@@ -1,0 +1,68 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/keyword_provider."""
+
+from unittest.mock import MagicMock
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_provider import (
+    KeywordProvider,
+    KeywordProviderMode,
+)
+from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
+
+
+def _provider(llm_responses, mode=KeywordProviderMode.ALL, max_keywords=4):
+    llm = MagicMock(spec=LLMCache)
+    llm.predict.side_effect = llm_responses
+    provider = KeywordProvider(
+        args=ProcessorArgs(no_cache=True, max_keywords=max_keywords),
+        llm=llm,
+        mode=mode,
+    )
+    return provider, llm
+
+
+class TestKeywordProvider:
+    def test_simple_mode_calls_llm_once(self):
+        provider, llm = _provider(['alpha^beta'], mode=KeywordProviderMode.SIMPLE)
+        result = provider.get_keywords(QueryBundle('q'))
+        assert result == ['alpha', 'beta']
+        assert llm.predict.call_count == 1
+
+    def test_all_mode_combines_simple_and_enriched(self):
+        provider, llm = _provider(
+            ['alpha^beta', 'gamma^delta'], mode=KeywordProviderMode.ALL,
+        )
+        result = provider.get_keywords(QueryBundle('q'))
+        assert set(result) == {'alpha', 'beta', 'gamma', 'delta'}
+        assert llm.predict.call_count == 2
+
+    def test_dedups_case_insensitively(self):
+        provider, _ = _provider(
+            ['Alpha^Beta', 'alpha^GAMMA'], mode=KeywordProviderMode.ALL,
+        )
+        result = provider.get_keywords(QueryBundle('q'))
+        assert sorted(result) == ['alpha', 'beta', 'gamma']
+
+    def test_truncates_to_max_keywords(self):
+        provider, _ = _provider(
+            ['a^b^c^d^e', 'f^g^h^i^j'],
+            mode=KeywordProviderMode.ALL,
+            max_keywords=3,
+        )
+        result = provider.get_keywords(QueryBundle('q'))
+        assert len(result) == 3
+
+    def test_num_keywords_passed_as_half_of_max(self):
+        provider, llm = _provider(['k1'], mode=KeywordProviderMode.SIMPLE, max_keywords=6)
+        provider.get_keywords(QueryBundle('q'))
+        assert llm.predict.call_args.kwargs['max_keywords'] == 3
+
+    def test_num_keywords_minimum_one(self):
+        provider, llm = _provider(['k1'], mode=KeywordProviderMode.SIMPLE, max_keywords=1)
+        provider.get_keywords(QueryBundle('q'))
+        assert llm.predict.call_args.kwargs['max_keywords'] == 1

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
@@ -81,3 +81,27 @@ class TestKeywordVSSProvider:
         g1.assert_called_once()
         g2.assert_called_once_with(['c1'])
         assert result == ['apple', 'orange']
+
+    def test_get_topic_content_runs_per_topic(self):
+        provider, store, _ = _provider()  # topic index
+        store.execute_query.return_value = [{'statement': 'fact', 'details': 'a/nb'}]
+        result = provider._get_topic_content(['t1'])
+        assert isinstance(result, list)
+        store.execute_query.assert_called()
+
+    def test_get_content_dispatches_to_topic_index(self):
+        provider, store, _ = _provider()  # topic index
+        store.execute_query.return_value = []
+        assert provider._get_content(['t1']) == []
+
+    def test_get_node_ids_emits_debug_when_enabled(self):
+        provider, _, _ = _provider()
+        provider.args.debug_results = ['KeywordVSSProvider']
+        with patch.object(mod, 'get_diverse_vss_elements') as gd:
+            gd.return_value = [{'topic': {'topicId': 't1'}}]
+            assert provider._get_node_ids(QueryBundle('q')) == ['t1']
+
+    def test_get_keywords_from_content_emits_debug_when_enabled(self):
+        provider, _, _ = _provider(llm_response='apple')
+        provider.args.debug_results = ['KeywordVSSProvider']
+        assert provider._get_keywords_from_content('q', ['ctx']) == ['apple']

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/keyword_vss_provider."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context import (
+    keyword_vss_provider as mod,
+)
+from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_vss_provider import (
+    KeywordVSSProvider,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.storage.vector.dummy_vector_index import (
+    DummyVectorIndex,
+)
+from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
+
+
+def _provider(use_chunk_index=False, llm_response=''):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    vector_store = MagicMock()
+    topic_index = MagicMock() if not use_chunk_index else DummyVectorIndex(index_name='topic')
+    vector_store.get_index.side_effect = lambda index_name: {
+        'topic': topic_index,
+        'chunk': MagicMock(),
+    }[index_name]
+
+    llm = MagicMock(spec=LLMCache)
+    llm.predict.return_value = llm_response
+
+    provider = KeywordVSSProvider(
+        graph_store=graph_store,
+        vector_store=vector_store,
+        args=ProcessorArgs(no_cache=True, max_keywords=5, num_workers=1, intermediate_limit=5),
+        llm=llm,
+    )
+    return provider, graph_store, llm
+
+
+class TestKeywordVSSProvider:
+    def test_index_name_falls_back_to_chunk_when_topic_dummy(self):
+        provider, _, _ = _provider(use_chunk_index=True)
+        assert provider.index_name == 'chunk'
+
+    def test_get_node_ids_extracts_from_diverse_vss_elements(self):
+        provider, _, _ = _provider()
+        with patch.object(mod, 'get_diverse_vss_elements') as gd:
+            gd.return_value = [{'topic': {'topicId': 't1'}}, {'topic': {'topicId': 't2'}}]
+            result = provider._get_node_ids(QueryBundle('q'))
+        assert result == ['t1', 't2']
+
+    def test_get_chunk_content_returns_content_strings(self):
+        provider, store, _ = _provider(use_chunk_index=True)
+        store.execute_query.return_value = [{'content': 'foo'}, {'content': 'bar'}]
+        result = provider._get_chunk_content(['c1', 'c2'])
+        assert result == ['foo', 'bar']
+
+    def test_get_content_dispatches_by_index_name(self):
+        provider, store, _ = _provider(use_chunk_index=True)
+        store.execute_query.return_value = [{'content': 'hello'}]
+        assert provider._get_content(['c1']) == ['hello']
+
+    def test_get_keywords_from_content_splits_response(self):
+        provider, _, llm = _provider(llm_response='apple\norange\n')
+        keywords = provider._get_keywords_from_content('q', ['ctx'])
+        assert keywords == ['apple', 'orange']
+        assert llm.predict.call_args.kwargs['question'] == 'q'
+
+    def test_get_keywords_pipeline_chains_steps(self):
+        provider, _, llm = _provider(use_chunk_index=True, llm_response='apple\norange')
+        with patch.object(provider, '_get_node_ids', return_value=['c1']) as g1, \
+             patch.object(provider, '_get_content', return_value=['ctx']) as g2:
+            result = provider.get_keywords(QueryBundle('q'))
+        g1.assert_called_once()
+        g2.assert_called_once_with(['c1'])
+        assert result == ['apple', 'orange']

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
@@ -82,12 +82,16 @@ class TestKeywordVSSProvider:
         g2.assert_called_once_with(['c1'])
         assert result == ['apple', 'orange']
 
-    def test_get_topic_content_runs_per_topic(self):
+    def test_get_topic_content_returns_one_string_per_topic(self):
         provider, store, _ = _provider()  # topic index
         store.execute_query.return_value = [{'statement': 'fact', 'details': 'a/nb'}]
         result = provider._get_topic_content(['t1'])
-        assert isinstance(result, list)
-        store.execute_query.assert_called()
+        assert result == ['fact (a, b)']
+
+    def test_get_topic_content_skips_topics_with_no_statements(self):
+        provider, store, _ = _provider()  # topic index
+        store.execute_query.return_value = []
+        assert provider._get_topic_content(['t1']) == []
 
     def test_get_content_dispatches_to_topic_index(self):
         provider, store, _ = _provider()  # topic index

--- a/lexical-graph/tests/unit/retrieval/query_context/test_query_mode.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_query_mode.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/query_context/query_mode."""
+
+from unittest.mock import MagicMock
+
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context.query_mode import (
+    QueryMode,
+    QueryModeProvider,
+)
+from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
+
+
+def _provider(llm_response):
+    llm = MagicMock(spec=LLMCache)
+    llm.predict.return_value = llm_response
+    return QueryModeProvider(args=ProcessorArgs(no_cache=True), llm=llm), llm
+
+
+class TestQueryModeProvider:
+    def test_simple_when_response_contains_single(self):
+        provider, _ = _provider('single')
+        assert provider.get_query_mode('hello?') is QueryMode.SIMPLE
+
+    def test_complex_when_response_says_multipart(self):
+        provider, _ = _provider('multipart')
+        assert provider.get_query_mode('a and b and c?') is QueryMode.COMPLEX
+
+    def test_response_is_lowercased_and_stripped(self):
+        provider, _ = _provider('  Single  \n')
+        assert provider.get_query_mode('q') is QueryMode.SIMPLE
+
+    def test_ambiguous_response_defaults_to_complex(self):
+        provider, _ = _provider('unknown')
+        assert provider.get_query_mode('q') is QueryMode.COMPLEX

--- a/lexical-graph/tests/unit/retrieval/retrievers/__init__.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_chunk_cosine_search.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_chunk_cosine_search.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/retrievers/chunk_cosine_search."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.chunk_cosine_search import (
+    ChunkCosineSimilaritySearch,
+)
+
+
+def _retriever(chunk_results, embeddings):
+    graph_store = MagicMock()
+    vector_store = MagicMock()
+    chunk_index = MagicMock()
+    chunk_index.top_k.return_value = chunk_results
+    vector_store.get_index.return_value = chunk_index
+
+    embedding_cache = MagicMock()
+    embedding_cache.get_embeddings.return_value = embeddings
+
+    return ChunkCosineSimilaritySearch(
+        vector_store=vector_store,
+        graph_store=graph_store,
+        embedding_cache=embedding_cache,
+        top_k=2,
+    )
+
+
+class TestChunkCosineSimilaritySearch:
+    def test_returns_top_k_nodes_with_scores(self):
+        chunk_results = [
+            {'chunk': {'chunkId': 'c1'}},
+            {'chunk': {'chunkId': 'c2'}},
+            {'chunk': {'chunkId': 'c3'}},
+        ]
+        embeddings = {
+            'c1': np.array([1.0, 0.0]),
+            'c2': np.array([0.0, 1.0]),
+            'c3': np.array([1.0, 1.0]),
+        }
+        retriever = _retriever(chunk_results, embeddings)
+        query = QueryBundle(query_str='q', embedding=[1.0, 0.0])
+
+        nodes = retriever._retrieve(query)
+
+        assert len(nodes) == 2
+        # Highest similarity is 'c1' against query [1,0]
+        assert nodes[0].node.metadata['chunk']['chunkId'] == 'c1'
+
+    def test_metadata_includes_search_type(self):
+        chunk_results = [{'chunk': {'chunkId': 'c1'}}]
+        embeddings = {'c1': np.array([1.0, 0.0])}
+        retriever = _retriever(chunk_results, embeddings)
+
+        nodes = retriever._retrieve(QueryBundle(query_str='q', embedding=[1.0, 0.0]))
+
+        assert nodes[0].node.metadata['search_type'] == 'cosine_similarity'
+
+    def test_empty_chunk_results_returns_empty(self):
+        retriever = _retriever([], {})
+        nodes = retriever._retrieve(QueryBundle(query_str='q', embedding=[1.0, 0.0]))
+        assert nodes == []

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_chunk_topic_search.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_chunk_topic_search.py
@@ -1,0 +1,81 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ChunkBasedSearch and TopicBasedSearch."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.retrievers import chunk_based_search as cb_mod
+from graphrag_toolkit.lexical_graph.retrieval.retrievers import topic_based_search as tb_mod
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.chunk_based_search import (
+    ChunkBasedSearch,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.topic_based_search import (
+    TopicBasedSearch,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+
+
+def _stores():
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    vector_store = MagicMock()
+    return graph_store, vector_store
+
+
+class TestChunkBasedSearch:
+    def test_get_start_node_ids_extracts_chunk_ids(self):
+        graph_store, vector_store = _stores()
+        with patch.object(cb_mod, 'get_diverse_vss_elements') as gd:
+            gd.return_value = [{'chunk': {'chunkId': 'c1'}}, {'chunk': {'chunkId': 'c2'}}]
+            retriever = ChunkBasedSearch(graph_store, vector_store, vss_top_k=2)
+            ids = retriever.get_start_node_ids(QueryBundle('q'))
+        assert ids == ['c1', 'c2']
+
+    def test_chunk_based_graph_search_returns_statement_ids(self):
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.return_value = [
+            {'l': 'stmt-1'}, {'l': 'stmt-2'},
+        ]
+        retriever = ChunkBasedSearch(graph_store, vector_store)
+        assert retriever.chunk_based_graph_search('c1') == ['stmt-1', 'stmt-2']
+
+    def test_do_graph_search_aggregates_statement_ids_then_dedups(self):
+        graph_store, vector_store = _stores()
+        retriever = ChunkBasedSearch(graph_store, vector_store, num_workers=2)
+        with patch.object(retriever, 'chunk_based_graph_search') as cbs, \
+             patch.object(retriever, 'get_statements_by_topic_and_source') as gsts:
+            cbs.side_effect = [['s1', 's2'], ['s2', 's3']]
+            gsts.return_value = []
+            retriever.do_graph_search(QueryBundle('q'), ['c1', 'c2'])
+        passed = gsts.call_args.args[0]
+        assert sorted(passed) == ['s1', 's2', 's3']
+
+
+class TestTopicBasedSearch:
+    def test_get_start_node_ids_extracts_topic_ids(self):
+        graph_store, vector_store = _stores()
+        with patch.object(tb_mod, 'get_diverse_vss_elements') as gd:
+            gd.return_value = [{'topic': {'topicId': 't1'}}]
+            retriever = TopicBasedSearch(graph_store, vector_store)
+            assert retriever.get_start_node_ids(QueryBundle('q')) == ['t1']
+
+    def test_topic_based_graph_search_returns_statement_ids(self):
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.return_value = [{'l': 'stmt-1'}]
+        retriever = TopicBasedSearch(graph_store, vector_store)
+        assert retriever.topic_based_graph_search('t1') == ['stmt-1']
+
+    def test_do_graph_search_aggregates(self):
+        graph_store, vector_store = _stores()
+        retriever = TopicBasedSearch(graph_store, vector_store, num_workers=2)
+        with patch.object(retriever, 'topic_based_graph_search') as tbs, \
+             patch.object(retriever, 'get_statements_by_topic_and_source') as gsts:
+            tbs.side_effect = [['s1'], ['s2', 's1']]
+            gsts.return_value = []
+            retriever.do_graph_search(QueryBundle('q'), ['t1', 't2'])
+        passed = gsts.call_args.args[0]
+        assert sorted(passed) == ['s1', 's2']

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_composite_traversal_based_retriever.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_composite_traversal_based_retriever.py
@@ -5,6 +5,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 
 from graphrag_toolkit.lexical_graph.retrieval.retrievers.composite_traversal_based_retriever import (
@@ -37,6 +38,17 @@ _VALID_SEARCH_RESULT = (
 
 
 class TestCompositeTraversalBasedRetriever:
+    @pytest.fixture(autouse=True)
+    def _stub_query_decomposition(self):
+        # The constructor builds a default QueryDecomposition when none is passed,
+        # which reads GraphRAGConfig.response_llm and tries to init BedrockConverse
+        # (needs an AWS region). Stub it so these tests stay offline.
+        with patch(
+            "graphrag_toolkit.lexical_graph.retrieval.retrievers."
+            "composite_traversal_based_retriever.QueryDecomposition"
+        ):
+            yield
+
     def test_wraps_bare_retrievers_with_weight_1(self):
         gs, vs = _stores()
         sub = _sub_retriever(_VALID_SEARCH_RESULT)

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_composite_traversal_based_retriever.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_composite_traversal_based_retriever.py
@@ -1,0 +1,99 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/retrievers/composite_traversal_based_retriever."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
+
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.composite_traversal_based_retriever import (
+    CompositeTraversalBasedRetriever,
+    WeightedTraversalBasedRetriever,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import (
+    TraversalBasedBaseRetriever,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+
+
+def _stores():
+    return MagicMock(spec=DummyGraphStore), MagicMock()
+
+
+def _sub_retriever(search_result_json):
+    sub = MagicMock(spec=TraversalBasedBaseRetriever)
+    sub.retrieve.return_value = [
+        NodeWithScore(node=TextNode(text=search_result_json), score=1.0),
+    ]
+    return sub
+
+
+_VALID_SEARCH_RESULT = (
+    '{"source": {"sourceId": "s1", "metadata": {}, '
+    '"versioning": {"valid_from": 0, "valid_to": 9999999999}}, '
+    '"topics": []}'
+)
+
+
+class TestCompositeTraversalBasedRetriever:
+    def test_wraps_bare_retrievers_with_weight_1(self):
+        gs, vs = _stores()
+        sub = _sub_retriever(_VALID_SEARCH_RESULT)
+        retriever = CompositeTraversalBasedRetriever(gs, vs, retrievers=[sub])
+        assert isinstance(retriever.weighted_retrievers[0], WeightedTraversalBasedRetriever)
+        assert retriever.weighted_retrievers[0].weight == 1.0
+        assert retriever.weighted_retrievers[0].retriever is sub
+
+    def test_preserves_existing_weighted_retrievers(self):
+        gs, vs = _stores()
+        sub = _sub_retriever(_VALID_SEARCH_RESULT)
+        wr = WeightedTraversalBasedRetriever(retriever=sub, weight=0.5)
+        retriever = CompositeTraversalBasedRetriever(gs, vs, retrievers=[wr])
+        assert retriever.weighted_retrievers[0] is wr
+
+    def test_get_start_node_ids_returns_empty(self):
+        gs, vs = _stores()
+        retriever = CompositeTraversalBasedRetriever(gs, vs, retrievers=[_sub_retriever(_VALID_SEARCH_RESULT)])
+        assert retriever.get_start_node_ids(QueryBundle('q')) == []
+
+    def test_get_search_results_uses_each_retriever(self):
+        gs, vs = _stores()
+        sub1 = _sub_retriever(_VALID_SEARCH_RESULT)
+        sub2 = _sub_retriever(_VALID_SEARCH_RESULT)
+        retriever = CompositeTraversalBasedRetriever(
+            gs, vs, retrievers=[sub1, sub2], num_workers=2,
+        )
+        result = retriever._get_search_results_for_query(QueryBundle('q'))
+        assert len(result.results) == 2
+        sub1.retrieve.assert_called_once()
+        sub2.retrieve.assert_called_once()
+
+    def test_do_graph_search_with_decomposition_disabled_runs_once(self):
+        gs, vs = _stores()
+        sub = _sub_retriever(_VALID_SEARCH_RESULT)
+        retriever = CompositeTraversalBasedRetriever(
+            gs, vs, retrievers=[sub], derive_subqueries=False, num_workers=1,
+        )
+        result = retriever.do_graph_search(QueryBundle('q'), [])
+        assert len(result.results) == 1
+        sub.retrieve.assert_called_once()
+
+    def test_do_graph_search_decomposes_into_subqueries(self):
+        gs, vs = _stores()
+        sub = _sub_retriever(_VALID_SEARCH_RESULT)
+        decomposition = MagicMock()
+        decomposition.decompose_query.return_value = [
+            QueryBundle('q1'), QueryBundle('q2'),
+        ]
+        retriever = CompositeTraversalBasedRetriever(
+            gs, vs,
+            retrievers=[sub],
+            query_decomposition=decomposition,
+            derive_subqueries=True,
+            num_workers=2,
+        )
+        result = retriever.do_graph_search(QueryBundle('big q'), [])
+        decomposition.decompose_query.assert_called_once()
+        assert sub.retrieve.call_count == 2
+        assert len(result.results) == 2

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_entity_searches.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_entity_searches.py
@@ -101,6 +101,25 @@ class TestEntityBasedSearch:
         assert single.call_count == 2
         assert multi.call_count == 2
 
+    def test_single_entity_based_graph_search_handles_empty_results(self):
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.return_value = []
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        assert retriever._single_entity_based_graph_search('e1', QueryBundle('q')) == []
+
+    def test_single_entity_based_graph_search_propagates_store_exception(self):
+        import pytest
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.side_effect = RuntimeError('graph store down')
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        with pytest.raises(RuntimeError, match='graph store down'):
+            retriever._single_entity_based_graph_search('e1', QueryBundle('q'))
+
+    def test_get_start_node_ids_returns_empty_when_no_entity_contexts(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        assert retriever.get_start_node_ids(QueryBundle('q')) == []
+
 
 class TestEntityNetworkSearch:
     def test_index_name_falls_back_to_chunk(self):

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_entity_searches.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_entity_searches.py
@@ -1,0 +1,188 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for entity_based_search, entity_network_search, entity_context_search."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
+
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    Entity,
+    EntityContext,
+    EntityContexts,
+    ScoredEntity,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers import (
+    entity_network_search as ens_mod,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.entity_based_search import (
+    EntityBasedSearch,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.entity_context_search import (
+    EntityContextSearch,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.entity_network_search import (
+    EntityNetworkSearch,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.storage.vector.dummy_vector_index import (
+    DummyVectorIndex,
+)
+
+
+def _stores(use_chunk_index=False):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    vector_store = MagicMock()
+    topic_index = MagicMock() if not use_chunk_index else DummyVectorIndex(index_name='topic')
+    vector_store.get_index.side_effect = lambda index_name: {
+        'topic': topic_index,
+        'chunk': MagicMock(),
+    }[index_name]
+    return graph_store, vector_store
+
+
+def _ec(*scored_entities):
+    return EntityContexts(contexts=[EntityContext(entities=list(scored_entities))])
+
+
+def _se(entity_id, value='v', classification='c'):
+    return ScoredEntity(
+        entity=Entity(entityId=entity_id, value=value, classification=classification),
+        score=1.0,
+    )
+
+
+class TestEntityBasedSearch:
+    def test_get_start_node_ids_returns_unique_entity_ids(self):
+        graph_store, vector_store = _stores()
+        ec = _ec(_se('e1'), _se('e2'), _se('e1'))
+        retriever = EntityBasedSearch(graph_store, vector_store, entity_contexts=ec)
+        ids = retriever.get_start_node_ids(QueryBundle('q'))
+        assert sorted(ids) == ['e1', 'e2']
+
+    def test_for_each_disjoint_yields_value_plus_others(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        pairs = list(retriever._for_each_disjoint(['a', 'b', 'c']))
+        assert len(pairs) == 3
+        for value, others in pairs:
+            assert value not in others
+
+    def test_for_each_disjoint_unique_yields_upper_triangle_pairs(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        pairs = list(retriever._for_each_disjoint_unique(['a', 'b', 'c']))
+        assert pairs == [('a', ['b', 'c']), ('b', ['c'])]
+
+    def test_single_entity_based_graph_search_returns_statement_ids(self):
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.return_value = [{'l': 's1'}]
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        assert retriever._single_entity_based_graph_search('e1', QueryBundle('q')) == ['s1']
+
+    def test_multiple_entity_based_graph_search_returns_statement_ids(self):
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.return_value = [{'l': 's2'}, {'l': 's3'}]
+        retriever = EntityBasedSearch(graph_store, vector_store)
+        result = retriever._multiple_entity_based_graph_search('e1', ['e2'], QueryBundle('q'))
+        assert result == ['s2', 's3']
+
+    def test_do_graph_search_runs_both_single_and_multi(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityBasedSearch(graph_store, vector_store, num_workers=2)
+        with patch.object(retriever, '_single_entity_based_graph_search', return_value=['s1']) as single, \
+             patch.object(retriever, '_multiple_entity_based_graph_search', return_value=['s2']) as multi, \
+             patch.object(retriever, 'get_statements_by_topic_and_source', return_value=[]):
+            retriever.do_graph_search(QueryBundle('q'), ['e1', 'e2'])
+        # Single for each start id; multi for each pairing.
+        assert single.call_count == 2
+        assert multi.call_count == 2
+
+
+class TestEntityNetworkSearch:
+    def test_index_name_falls_back_to_chunk(self):
+        graph_store, vector_store = _stores(use_chunk_index=True)
+        retriever = EntityNetworkSearch(graph_store, vector_store)
+        assert retriever.index_name == 'chunk'
+
+    def test_graph_search_topic_returns_statement_ids(self):
+        graph_store, vector_store = _stores()
+        graph_store.execute_query.return_value = [{'l': 's1'}]
+        retriever = EntityNetworkSearch(graph_store, vector_store)
+        assert retriever._graph_search('t1') == ['s1']
+
+    def test_graph_search_chunk_runs_chunk_cypher(self):
+        graph_store, vector_store = _stores(use_chunk_index=True)
+        graph_store.execute_query.return_value = [{'l': 's1'}]
+        retriever = EntityNetworkSearch(graph_store, vector_store)
+        retriever._graph_search('c1')
+        cypher, _ = graph_store.execute_query.call_args.args
+        assert 'chunk' in cypher.lower()
+
+    def test_get_node_ids_extracts_from_diverse(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityNetworkSearch(graph_store, vector_store)
+        with patch.object(ens_mod, 'get_diverse_vss_elements') as gd:
+            gd.return_value = [{'topic': {'topicId': 't1'}}]
+            assert retriever._get_node_ids(QueryBundle('q')) == ['t1']
+
+    def test_get_start_node_ids_iterates_entity_contexts(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityNetworkSearch(
+            graph_store, vector_store,
+            entity_contexts=_ec(_se('e1'), _se('e2')),
+            num_workers=1,
+        )
+        with patch.object(retriever, '_get_node_ids', return_value=['t1']):
+            result = retriever.get_start_node_ids(QueryBundle('q'))
+        assert result == ['t1']
+
+    def test_do_graph_search_aggregates_then_dedups(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityNetworkSearch(graph_store, vector_store, num_workers=2)
+        with patch.object(retriever, '_graph_search') as gs, \
+             patch.object(retriever, 'get_statements_by_topic_and_source', return_value=[]) as gsts:
+            gs.side_effect = [['s1', 's2'], ['s2', 's3']]
+            retriever.do_graph_search(QueryBundle('q'), ['t1', 't2'])
+        passed = gsts.call_args.args[0]
+        assert sorted(passed) == ['s1', 's2', 's3']
+
+
+class TestEntityContextSearch:
+    def test_get_start_node_ids_returns_empty(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityContextSearch(graph_store, vector_store)
+        assert retriever.get_start_node_ids(QueryBundle('q')) == []
+
+    def test_do_graph_search_returns_empty_when_no_contexts(self):
+        graph_store, vector_store = _stores()
+        retriever = EntityContextSearch(graph_store, vector_store)
+        result = retriever.do_graph_search(QueryBundle('q'), [])
+        assert result.results == []
+
+    def test_do_graph_search_uses_sub_retriever_with_each_context(self):
+        from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import (
+            TraversalBasedBaseRetriever,
+        )
+        graph_store, vector_store = _stores()
+        sub = MagicMock(spec=TraversalBasedBaseRetriever)
+        node = NodeWithScore(node=TextNode(text='x', metadata={'result': {
+            'source': {'sourceId': 's1', 'metadata': {}, 'versioning': {'valid_from': 0, 'valid_to': 9}},
+            'topics': [],
+        }}))
+        sub.retrieve.return_value = [node]
+
+        ec = EntityContexts(contexts=[
+            EntityContext(entities=[_se('e1', 'alpha'), _se('e2', 'beta')]),
+        ])
+        retriever = EntityContextSearch(
+            graph_store, vector_store,
+            sub_retriever=sub,
+            entity_contexts=ec,
+            ec_max_contexts=5,
+        )
+        retriever.do_graph_search(QueryBundle('q'), [])
+        sub.retrieve.assert_called()

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_query_mode_retriever.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_query_mode_retriever.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/retrievers/query_mode_retriever."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
+
+from graphrag_toolkit.lexical_graph.retrieval.query_context.query_mode import QueryMode
+from graphrag_toolkit.lexical_graph.retrieval.retrievers import query_mode_retriever as mod
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.query_mode_retriever import (
+    QueryModeRetriever,
+)
+
+
+def _node(text):
+    return NodeWithScore(node=TextNode(text=text), score=1.0)
+
+
+class TestQueryModeRetriever:
+    def test_simple_mode_runs_single_retriever(self):
+        inner = MagicMock()
+        inner.retrieve.return_value = [_node('hit')]
+        retriever_fn = MagicMock(return_value=inner)
+
+        qmr = QueryModeRetriever(retriever_fn=retriever_fn, enable_multipart_queries=False)
+        result = qmr._retrieve(QueryBundle('hello?'))
+
+        retriever_fn.assert_called_once()
+        inner.retrieve.assert_called_once()
+        assert len(result) == 1
+
+    def test_multipart_simple_query_runs_single_retriever(self):
+        inner = MagicMock()
+        inner.retrieve.return_value = [_node('hit')]
+        retriever_fn = MagicMock(return_value=inner)
+
+        with patch.object(mod, 'QueryModeProvider') as qmp_cls:
+            qmp = MagicMock()
+            qmp.get_query_mode.return_value = QueryMode.SIMPLE
+            qmp_cls.return_value = qmp
+
+            qmr = QueryModeRetriever(
+                retriever_fn=retriever_fn, enable_multipart_queries=True, no_cache=True,
+            )
+            result = qmr._retrieve(QueryBundle('q'))
+
+        retriever_fn.assert_called_once()
+        assert len(result) == 1
+
+    def test_multipart_complex_query_fans_out_per_keyword(self):
+        inner = MagicMock()
+        inner.retrieve.side_effect = [[_node('a')], [_node('b')]]
+        retriever_fn = MagicMock(return_value=inner)
+
+        with patch.object(mod, 'QueryModeProvider') as qmp_cls, \
+             patch.object(mod, 'KeywordProvider') as kp_cls:
+            qmp = MagicMock()
+            qmp.get_query_mode.return_value = QueryMode.COMPLEX
+            qmp_cls.return_value = qmp
+            kp = MagicMock()
+            kp.get_keywords.return_value = ['k1', 'k2']
+            kp_cls.return_value = kp
+
+            qmr = QueryModeRetriever(
+                retriever_fn=retriever_fn, enable_multipart_queries=True,
+                no_cache=True, max_search_results=10,
+            )
+            result = qmr._retrieve(QueryBundle('q'))
+
+        assert inner.retrieve.call_count == 2
+        assert len(result) == 2
+
+    def test_complex_query_passes_passthru_keyword_provider_arg(self):
+        inner = MagicMock()
+        inner.retrieve.return_value = []
+        retriever_fn = MagicMock(return_value=inner)
+
+        with patch.object(mod, 'QueryModeProvider') as qmp_cls, \
+             patch.object(mod, 'KeywordProvider') as kp_cls:
+            qmp = MagicMock()
+            qmp.get_query_mode.return_value = QueryMode.COMPLEX
+            qmp_cls.return_value = qmp
+            kp = MagicMock()
+            kp.get_keywords.return_value = ['k1']
+            kp_cls.return_value = kp
+
+            qmr = QueryModeRetriever(
+                retriever_fn=retriever_fn, enable_multipart_queries=True,
+                no_cache=True, max_search_results=4,
+            )
+            qmr._retrieve(QueryBundle('q'))
+
+        passed = retriever_fn.call_args.kwargs
+        assert passed['ec_keyword_provider'] == 'passthru'
+        # max_search_results / len(keywords) + 1
+        assert passed['max_search_results'] == 5

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_semantic_searches.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_semantic_searches.py
@@ -1,0 +1,147 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ChunkBasedSemanticSearch and SemanticChunkBeamGraphSearch."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
+
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.chunk_based_semantic_search import (
+    ChunkBasedSemanticSearch,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.semantic_chunk_beam_search import (
+    SemanticChunkBeamGraphSearch,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+
+
+def _stores():
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    vector_store = MagicMock()
+    return graph_store, vector_store
+
+
+def _chunk_node(chunk_id):
+    return NodeWithScore(
+        node=TextNode(text='', metadata={'chunk': {'chunkId': chunk_id}}),
+        score=1.0,
+    )
+
+
+class TestChunkBasedSemanticSearch:
+    def test_creates_default_initial_and_graph_retrievers(self):
+        gs, vs = _stores()
+        retriever = ChunkBasedSemanticSearch(gs, vs)
+        assert len(retriever.initial_retrievers) >= 1
+        assert len(retriever.graph_retrievers) >= 1
+
+    def test_chunk_based_graph_search_returns_statement_ids(self):
+        gs, vs = _stores()
+        gs.execute_query.return_value = [{'l': 's1'}]
+        retriever = ChunkBasedSemanticSearch(gs, vs)
+        assert retriever.chunk_based_graph_search('c1') == ['s1']
+
+    def test_get_start_node_ids_dedups_initial_retriever_outputs(self):
+        gs, vs = _stores()
+        initial1 = MagicMock()
+        initial1.retrieve.return_value = [_chunk_node('c1'), _chunk_node('c2')]
+        initial2 = MagicMock()
+        # initial2 returns a duplicate c1; should be deduped.
+        initial2.retrieve.return_value = [_chunk_node('c1'), _chunk_node('c3')]
+
+        retriever = ChunkBasedSemanticSearch(gs, vs, retrievers=[initial1, initial2])
+        # Force no graph retrievers — both got classified as initial because they
+        # are bare MagicMocks (not SemanticChunkBeamGraphSearch instances).
+        retriever.graph_retrievers = []
+
+        result = retriever.get_start_node_ids(QueryBundle('q'))
+        assert sorted(result) == ['c1', 'c2', 'c3']
+
+    def test_get_start_node_ids_returns_empty_when_no_initial_nodes(self):
+        gs, vs = _stores()
+        initial = MagicMock()
+        initial.retrieve.return_value = []
+        retriever = ChunkBasedSemanticSearch(gs, vs, retrievers=[initial])
+        retriever.graph_retrievers = []
+        assert retriever.get_start_node_ids(QueryBundle('q')) == []
+
+    def test_do_graph_search_aggregates_chunks_then_fetches_statements(self):
+        gs, vs = _stores()
+        retriever = ChunkBasedSemanticSearch(gs, vs)
+
+        def _stmt_ids(_id):
+            return ['s1']
+
+        retriever.chunk_based_graph_search = _stmt_ids
+        retriever.get_statements_by_topic_and_source = lambda ids: []
+        result = retriever.do_graph_search(QueryBundle('q'), ['c1', 'c2'])
+        assert result.results == []
+
+
+class TestSemanticChunkBeamGraphSearch:
+    def test_get_neighbors_returns_chunk_ids_from_second_query(self):
+        gs, vs = _stores()
+        gs.execute_query.side_effect = [
+            [{'entityId': 'e1', 'count(r)': 5}],
+            [{'chunkId': 'c2'}, {'chunkId': 'c3'}],
+        ]
+        beam = SemanticChunkBeamGraphSearch(vs, gs, beam_width=3, max_depth=2)
+        result = beam.get_neighbors('c1')
+        assert result == ['c2', 'c3']
+
+    def test_beam_search_visits_initial_chunks_and_neighbours(self):
+        gs, vs = _stores()
+        cache = MagicMock()
+        cache.get_embeddings.return_value = {
+            'c1': np.array([1.0, 0.0]),
+            'c2': np.array([0.9, 0.1]),
+        }
+        beam = SemanticChunkBeamGraphSearch(
+            vs, gs, embedding_cache=cache, beam_width=2, max_depth=1,
+        )
+        beam.get_neighbors = MagicMock(return_value=['c2'])
+
+        results = beam.beam_search(np.array([1.0, 0.0]), ['c1'])
+        chunk_ids = [r[0] for r in results]
+        assert 'c1' in chunk_ids
+
+    def test_retrieve_uses_shared_nodes_when_provided(self):
+        gs, vs = _stores()
+        cache = MagicMock()
+        cache.get_embeddings.return_value = {'c1': np.array([1.0, 0.0])}
+        beam = SemanticChunkBeamGraphSearch(
+            vs, gs, embedding_cache=cache, max_depth=1, beam_width=1,
+            shared_nodes=[_chunk_node('c1')],
+        )
+        beam.get_neighbors = MagicMock(return_value=[])
+
+        nodes = beam._retrieve(QueryBundle(query_str='q', embedding=[1.0, 0.0]))
+        # Initial chunk c1 is excluded since it's in initial_ids set.
+        assert nodes == []
+
+    def test_retrieve_falls_back_to_vector_store_when_no_shared_nodes(self):
+        gs, vs = _stores()
+        chunk_index = MagicMock()
+        chunk_index.top_k.return_value = [{'chunk': {'chunkId': 'c1'}}]
+        vs.get_index.return_value = chunk_index
+        cache = MagicMock()
+        cache.get_embeddings.return_value = {'c1': np.array([1.0, 0.0])}
+        beam = SemanticChunkBeamGraphSearch(
+            vs, gs, embedding_cache=cache, max_depth=1, beam_width=1,
+        )
+        beam.get_neighbors = MagicMock(return_value=[])
+
+        beam._retrieve(QueryBundle(query_str='q', embedding=[1.0, 0.0]))
+        chunk_index.top_k.assert_called_once()
+
+    def test_retrieve_returns_empty_when_no_chunks(self):
+        gs, vs = _stores()
+        chunk_index = MagicMock()
+        chunk_index.top_k.return_value = []
+        vs.get_index.return_value = chunk_index
+        beam = SemanticChunkBeamGraphSearch(vs, gs)
+        assert beam._retrieve(QueryBundle(query_str='q', embedding=[1.0, 0.0])) == []

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_traversal_based_base_retriever.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_traversal_based_base_retriever.py
@@ -1,0 +1,183 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/retrievers/traversal_based_base_retriever."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    EntityContexts,
+    SearchResult,
+    Source,
+    Versioning,
+)
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.retrievers import (
+    traversal_based_base_retriever as mod,
+)
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import (
+    DEFAULT_FORMATTING_PROCESSORS,
+    DEFAULT_PROCESSORS,
+    TraversalBasedBaseRetriever,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+
+
+class _Concrete(TraversalBasedBaseRetriever):
+    """Minimal concrete subclass exposing the abstract methods."""
+    def get_start_node_ids(self, query_bundle):
+        return ['n1']
+
+    def do_graph_search(self, query_bundle, start_node_ids):
+        return self._to_search_results_collection([])
+
+
+def _retriever(**args):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    vector_store = MagicMock()
+    return _Concrete(
+        graph_store=graph_store, vector_store=vector_store, **args,
+    ), graph_store
+
+
+class TestInit:
+    def test_defaults_install_default_processor_lists(self):
+        retriever, _ = _retriever()
+        assert retriever.processors is DEFAULT_PROCESSORS
+        assert retriever.formatting_processors is DEFAULT_FORMATTING_PROCESSORS
+
+    def test_processor_args_override(self):
+        args = ProcessorArgs(max_keywords=99)
+        retriever, _ = _retriever(processor_args=args)
+        assert retriever.args.max_keywords == 99
+
+    def test_custom_processors_replace_defaults(self):
+        retriever, _ = _retriever(processors=[])
+        assert retriever.processors == []
+
+    def test_default_filter_config_and_entity_contexts(self):
+        retriever, _ = _retriever()
+        assert isinstance(retriever.filter_config, FilterConfig)
+        assert isinstance(retriever.entity_contexts, EntityContexts)
+
+
+class TestInitKeywordProviderDispatch:
+    def _patch_pipeline(self, monkeypatch, keyword_provider_cls):
+        kp = MagicMock()
+        kp.get_keywords.return_value = []
+        monkeypatch.setattr(mod, keyword_provider_cls, MagicMock(return_value=kp))
+
+        ep = MagicMock()
+        ep.get_entities.return_value = []
+        monkeypatch.setattr(mod, 'EntityProvider', MagicMock(return_value=ep))
+        monkeypatch.setattr(mod, 'EntityVSSProvider', MagicMock(return_value=ep))
+
+        ecp = MagicMock()
+        ecp.get_entity_contexts.return_value = EntityContexts(contexts=[], keywords=[])
+        monkeypatch.setattr(mod, 'EntityContextProvider', MagicMock(return_value=ecp))
+
+    def test_vss_keyword_provider(self, monkeypatch):
+        self._patch_pipeline(monkeypatch, 'KeywordVSSProvider')
+        retriever, _ = _retriever(ec_keyword_provider='vss', ec_entity_provider='graph')
+        retriever._init(QueryBundle('q'))
+        mod.KeywordVSSProvider.assert_called_once()
+
+    def test_llm_keyword_provider(self, monkeypatch):
+        self._patch_pipeline(monkeypatch, 'KeywordProvider')
+        retriever, _ = _retriever(ec_keyword_provider='llm', ec_entity_provider='graph')
+        retriever._init(QueryBundle('q'))
+        mod.KeywordProvider.assert_called_once()
+
+    def test_nlp_keyword_provider(self, monkeypatch):
+        self._patch_pipeline(monkeypatch, 'KeywordNLPProvider')
+        retriever, _ = _retriever(ec_keyword_provider='nlp', ec_entity_provider='graph')
+        retriever._init(QueryBundle('q'))
+        mod.KeywordNLPProvider.assert_called_once()
+
+    def test_passthru_keyword_provider(self, monkeypatch):
+        self._patch_pipeline(monkeypatch, 'PassThruKeywordProvider')
+        retriever, _ = _retriever(ec_keyword_provider='passthru', ec_entity_provider='graph')
+        retriever._init(QueryBundle('q'))
+        mod.PassThruKeywordProvider.assert_called_once()
+
+    def test_invalid_keyword_provider_raises(self):
+        retriever, _ = _retriever(ec_keyword_provider='bogus')
+        with pytest.raises(ValueError, match='ec_keyword_provider'):
+            retriever._init(QueryBundle('q'))
+
+    def test_invalid_entity_provider_raises(self, monkeypatch):
+        self._patch_pipeline(monkeypatch, 'KeywordVSSProvider')
+        retriever, _ = _retriever(ec_keyword_provider='vss', ec_entity_provider='bogus')
+        with pytest.raises(ValueError, match='ec_entity_provider'):
+            retriever._init(QueryBundle('q'))
+
+    def test_skips_init_when_keywords_already_present(self):
+        retriever, _ = _retriever(ec_keyword_provider='vss', ec_entity_provider='graph')
+        retriever.entity_contexts.keywords.append('preexisting')
+        with patch.object(mod, 'KeywordVSSProvider') as kp:
+            retriever._init(QueryBundle('q'))
+        kp.assert_not_called()
+
+
+class TestToSearchResultsCollection:
+    def test_passes_through_existing_search_results(self):
+        retriever, _ = _retriever()
+        sr = SearchResult(
+            source=Source(
+                sourceId='s1',
+                metadata={},
+                versioning=Versioning(valid_from=0, valid_to=9999999999),
+            ),
+            topics=[],
+        )
+        result = retriever._to_search_results_collection([sr])
+        assert len(result.results) == 1
+
+    def test_validates_dict_with_source(self):
+        retriever, _ = _retriever()
+        raw = {
+            'result': {
+                'source': {
+                    'sourceId': 's1',
+                    'metadata': {},
+                    'versioning': {'valid_from': 0, 'valid_to': 9999999999},
+                },
+                'topics': [],
+            }
+        }
+        result = retriever._to_search_results_collection([raw])
+        assert len(result.results) == 1
+
+    def test_filters_dict_without_source(self):
+        retriever, _ = _retriever()
+        result = retriever._to_search_results_collection([{'result': {'topics': []}}])
+        assert result.results == []
+
+
+class TestGetStatementsByTopicAndSource:
+    def test_passes_params_and_attaches_facts(self):
+        retriever, store = _retriever(intermediate_limit=20, query_limit=5)
+        store.execute_query.side_effect = [
+            [{'result': {
+                'source': {'sourceId': 's1'},
+                'topics': [{
+                    'topic': 'T',
+                    'topicId': 't1',
+                    'chunks': [],
+                    'statements': [{'statementId': 'stmt-1', 'score': 0, 'facts': []}],
+                }],
+                'score': 1,
+            }}],
+            [{'statementId': 'stmt-1', 'facts': ['f1', 'f2']}],
+        ]
+        result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+        topic = result[0]['result']['topics'][0]
+        statement = topic['statements'][0]
+        assert statement['facts'] == ['f1', 'f2']
+        assert statement['score'] == 2

--- a/lexical-graph/tests/unit/retrieval/test_graph_summary.py
+++ b/lexical-graph/tests/unit/retrieval/test_graph_summary.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/summary/graph_summary."""
+
+import time
+from unittest.mock import MagicMock
+
+from graphrag_toolkit.lexical_graph import TenantId
+from graphrag_toolkit.lexical_graph.retrieval.summary.graph_summary import (
+    GraphSummary,
+    get_domain,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
+
+
+def _summary(llm_response='Domain: x', cached=None):
+    graph_store = MagicMock(spec=DummyGraphStore)
+    graph_store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    llm = MagicMock(spec=LLMCache)
+    llm.predict.return_value = llm_response
+    summary = GraphSummary(graph_store=graph_store, llm=llm)
+    return summary, graph_store, llm
+
+
+class TestGetDomain:
+    def test_extracts_domain_line(self):
+        assert get_domain('Domain: Networking\nScope: x') == 'Networking'
+
+    def test_returns_none_when_absent(self):
+        assert get_domain('Scope: only this') is None
+
+
+class TestGetCachedSummary:
+    def test_returns_none_when_no_rows(self):
+        s, store, _ = _summary()
+        store.execute_query.return_value = []
+        assert s._get_cached_summary(TenantId(value='t1')) is None
+
+    def test_returns_none_when_stale(self):
+        s, store, _ = _summary()
+        store.execute_query.return_value = [{
+            'summary': 'old',
+            'last_updated_datetime': 0,  # 1970 = stale
+        }]
+        assert s._get_cached_summary(TenantId(value='t1')) is None
+
+    def test_returns_fresh_cached_summary(self):
+        s, store, _ = _summary()
+        store.execute_query.return_value = [{
+            'summary': 'recent',
+            'last_updated_datetime': int(time.time()),
+        }]
+        assert s._get_cached_summary(TenantId(value='t1')) == 'recent'
+
+
+class TestCreateGraphSummary:
+    def test_returns_cached_summary_when_available(self):
+        s, store, llm = _summary()
+        store.execute_query.return_value = [{
+            'summary': 'cached', 'last_updated_datetime': int(time.time()),
+        }]
+        result = s.create_graph_summary(tenant_id='t1')
+        assert result == 'cached'
+        llm.predict.assert_not_called()
+
+    def test_generates_summary_when_no_cache(self):
+        s, store, llm = _summary(llm_response='Domain: fresh')
+        # cache lookup is the only direct execute_query call (the entity/path
+        # lookups go through MultiTenantGraphStore.execute_query_with_retry).
+        store.execute_query.return_value = []
+        store.execute_query_with_retry.side_effect = [
+            [{'entity': 'apple [fruit]'}],
+            [{'path': '(a)-[r]->(b)'}],
+            None,  # cache write
+        ]
+        result = s.create_graph_summary(tenant_id='t1')
+        assert result == 'Domain: fresh'
+        llm.predict.assert_called_once()
+
+    def test_returns_none_when_no_entities_or_paths(self):
+        s, store, _ = _summary()
+        store.execute_query.return_value = []
+        store.execute_query_with_retry.side_effect = [[], []]
+        assert s.create_graph_summary(tenant_id='t1') is None
+
+    def test_refresh_bypasses_cache(self):
+        s, store, llm = _summary(llm_response='Domain: latest')
+        store.execute_query_with_retry.side_effect = [
+            [{'entity': 'a [x]'}],
+            [{'path': '(a)-[r]->(b)'}],
+            None,
+        ]
+        result = s.create_graph_summary(tenant_id='t1', refresh=True)
+        assert result == 'Domain: latest'

--- a/lexical-graph/tests/unit/retrieval/utils/test_chunk_utils.py
+++ b/lexical-graph/tests/unit/retrieval/utils/test_chunk_utils.py
@@ -1,0 +1,121 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/utils/chunk_utils."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.retrieval.utils.chunk_utils import (
+    SharedChunkEmbeddingCache,
+    cosine_similarity,
+    get_chunks_query,
+    get_top_k,
+)
+
+
+class TestCosineSimilarity:
+    def test_empty_embeddings_returns_empty(self):
+        sims, ids = cosine_similarity([1.0, 0.0], {})
+        assert sims.size == 0
+        assert ids == []
+
+    def test_identical_vectors_score_one(self):
+        sims, ids = cosine_similarity([1.0, 0.0], {'c1': [1.0, 0.0]})
+        assert ids == ('c1',)
+        assert pytest.approx(sims[0]) == 1.0
+
+    def test_orthogonal_vectors_score_zero(self):
+        sims, _ = cosine_similarity([1.0, 0.0], {'c1': [0.0, 1.0]})
+        assert pytest.approx(sims[0]) == 0.0
+
+
+class TestGetTopK:
+    def test_empty_returns_empty_list(self):
+        assert get_top_k([1.0, 0.0], {}, top_k=3) == []
+
+    def test_descending_score_order(self):
+        emb = {'a': [1.0, 0.0], 'b': [0.0, 1.0], 'c': [1.0, 1.0]}
+        result = get_top_k([1.0, 0.0], emb, top_k=3)
+        scores = [s for s, _ in result]
+        assert scores == sorted(scores, reverse=True)
+        assert result[0][1] == 'a'
+
+    def test_caps_at_available_results(self):
+        result = get_top_k([1.0, 0.0], {'a': [1.0, 0.0]}, top_k=99)
+        assert len(result) == 1
+
+
+class TestGetChunksQuery:
+    def _store(self, returned):
+        store = MagicMock()
+        store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+        store.execute_query.return_value = returned
+        return store
+
+    def test_returns_matches_in_input_order(self):
+        store = self._store([
+            {'result': {'chunk': {'chunkId': 'c2'}, 'value': 'two'}},
+            {'result': {'chunk': {'chunkId': 'c1'}, 'value': 'one'}},
+        ])
+        result = get_chunks_query(store, ['c1', 'c2'])
+        assert [r['result']['value'] for r in result] == ['one', 'two']
+
+    def test_drops_ids_with_no_match(self):
+        store = self._store([
+            {'result': {'chunk': {'chunkId': 'c1'}, 'value': 'one'}},
+        ])
+        result = get_chunks_query(store, ['c1', 'missing'])
+        assert len(result) == 1
+
+    def test_passes_chunk_ids_as_query_param(self):
+        store = self._store([])
+        get_chunks_query(store, ['c1', 'c2'])
+        _, params = store.execute_query.call_args.args
+        assert params == {'chunk_ids': ['c1', 'c2']}
+
+
+class TestSharedChunkEmbeddingCache:
+    def _vs(self, embeddings):
+        index = MagicMock()
+        index.get_embeddings.return_value = [
+            {'chunk': {'chunkId': cid}, 'embedding': vec}
+            for cid, vec in embeddings.items()
+        ]
+        vs = MagicMock()
+        vs.get_index.return_value = index
+        return vs, index
+
+    def test_hits_cache_when_all_ids_present(self):
+        vs, index = self._vs({})
+        cache = SharedChunkEmbeddingCache(vs)
+        cache._cache = {'c1': np.array([1.0]), 'c2': np.array([2.0])}
+        result = cache.get_embeddings(['c1', 'c2'])
+        assert set(result) == {'c1', 'c2'}
+        index.get_embeddings.assert_not_called()
+
+    def test_fetches_missing_and_populates_cache(self):
+        vs, index = self._vs({'c2': [0.5, 0.5]})
+        cache = SharedChunkEmbeddingCache(vs)
+        cache._cache = {'c1': np.array([1.0, 0.0])}
+        result = cache.get_embeddings(['c1', 'c2'])
+        assert set(result) == {'c1', 'c2'}
+        index.get_embeddings.assert_called_once_with(['c2'])
+        assert 'c2' in cache._cache
+
+    def test_returns_cached_on_fetch_failure(self):
+        cache = SharedChunkEmbeddingCache(MagicMock())
+        cache._cache = {'c1': np.array([1.0])}
+        cache._fetch_embeddings = lambda _ids: (_ for _ in ()).throw(RuntimeError('down'))
+        result = cache.get_embeddings(['c1', 'c2'])
+        assert set(result) == {'c1'}
+
+    def test_fetch_embeddings_shapes_response(self):
+        vs, _ = self._vs({'c1': [0.1], 'c2': [0.2]})
+        cache = SharedChunkEmbeddingCache(vs)
+        result = cache._fetch_embeddings.__wrapped__(cache, ['c1', 'c2'])
+        assert set(result) == {'c1', 'c2'}
+        assert isinstance(result['c1'], np.ndarray)

--- a/lexical-graph/tests/unit/retrieval/utils/test_entity_utils.py
+++ b/lexical-graph/tests/unit/retrieval/utils/test_entity_utils.py
@@ -1,0 +1,106 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/utils/entity_utils."""
+
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.model import Entity, ScoredEntity
+from graphrag_toolkit.lexical_graph.retrieval.utils import entity_utils
+from graphrag_toolkit.lexical_graph.retrieval.utils.entity_utils import (
+    _get_entity_token,
+    _get_reranked_entities,
+    _get_reranked_entity_tokens,
+    _get_reranked_entity_tokens_tfidf,
+    rerank_entities,
+)
+
+
+def _scored_entity(entity_id, value, classification, score):
+    return ScoredEntity(
+        entity=Entity(entityId=entity_id, value=value, classification=classification),
+        score=score,
+    )
+
+
+class TestGetEntityToken:
+    def test_lowercases_value_and_classification(self):
+        e = _scored_entity('e1', 'Apple', 'Company', 0.5)
+        assert _get_entity_token(e) == 'apple (company)'
+
+    def test_preserves_already_lowercase(self):
+        e = _scored_entity('e1', 'beta', 'noun', 0.5)
+        assert _get_entity_token(e) == 'beta (noun)'
+
+
+class TestGetRerankedEntityTokensTfidf:
+    def test_returns_score_per_entity_token(self):
+        entities = [
+            _scored_entity('e1', 'apple', 'fruit', 0.9),
+            _scored_entity('e2', 'orange', 'fruit', 0.8),
+        ]
+        with patch.object(entity_utils, 'score_values_with_tfidf') as m:
+            m.return_value = {'apple (fruit)': 0.7, 'orange (fruit)': 0.3}
+            result = _get_reranked_entity_tokens_tfidf(entities, ['apple'])
+        assert result == {'apple (fruit)': 0.7, 'orange (fruit)': 0.3}
+        passed_tokens, passed_keywords = m.call_args.args
+        assert passed_tokens == ['apple (fruit)', 'orange (fruit)']
+        assert passed_keywords == ['apple']
+
+
+class TestGetRerankedEntityTokens:
+    def test_rounds_scores_to_four_decimals(self):
+        entities = [_scored_entity('e1', 'a', 'x', 0.9)]
+        with patch.object(entity_utils, 'score_values_with_tfidf') as m:
+            m.return_value = {'a (x)': 0.123456789}
+            result = _get_reranked_entity_tokens(entities, ['kw'], reranker='tfidf')
+        assert result == {'a (x)': 0.1235}
+
+
+class TestGetRerankedEntities:
+    def test_assigns_reranking_score_and_sorts_descending(self):
+        e1 = _scored_entity('e1', 'apple', 'fruit', 0.5)
+        e2 = _scored_entity('e2', 'orange', 'fruit', 0.9)
+        tokens = {'apple (fruit)': 0.8, 'orange (fruit)': 0.2}
+
+        result = _get_reranked_entities([e1, e2], tokens)
+
+        assert result[0].entity.entityId == 'e1'
+        assert result[0].reranking_score == 0.8
+        assert result[1].reranking_score == 0.2
+
+    def test_sort_tiebreaks_on_base_score(self):
+        e1 = _scored_entity('e1', 'a', 'x', 0.4)
+        e2 = _scored_entity('e2', 'b', 'x', 0.9)
+        tokens = {'a (x)': 0.5, 'b (x)': 0.5}
+
+        result = _get_reranked_entities([e1, e2], tokens)
+        assert [r.entity.entityId for r in result] == ['e2', 'e1']
+
+    def test_duplicate_token_only_assigns_once(self):
+        e1 = _scored_entity('e1', 'apple', 'fruit', 0.5)
+        e2 = _scored_entity('e1', 'apple', 'fruit', 0.5)
+        tokens = {'apple (fruit)': 0.7}
+
+        result = _get_reranked_entities([e1, e2], tokens)
+        scores = [r.reranking_score for r in result]
+        assert scores.count(0.7) == 1
+
+
+class TestRerankEntities:
+    def test_passes_query_str_with_keywords_to_token_reranker(self):
+        e1 = _scored_entity('e1', 'apple', 'fruit', 0.5)
+        with patch.object(entity_utils, '_get_reranked_entity_tokens') as m:
+            m.return_value = {'apple (fruit)': 0.9}
+            result = rerank_entities(
+                [e1],
+                QueryBundle(query_str='find fruit'),
+                ['apple'],
+                reranker='tfidf',
+            )
+        passed_entities, passed_keywords, passed_reranker = m.call_args.args
+        assert passed_keywords == ['find fruit', 'apple']
+        assert passed_reranker == 'tfidf'
+        assert result[0].reranking_score == 0.9

--- a/lexical-graph/tests/unit/retrieval/utils/test_query_decomposition.py
+++ b/lexical-graph/tests/unit/retrieval/utils/test_query_decomposition.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/utils/query_decomposition."""
+
+from unittest.mock import MagicMock
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.utils.query_decomposition import (
+    SINGLE_QUESTION_THRESHOLD,
+    QueryDecomposition,
+)
+
+
+def _decomposer(llm_response):
+    args = ProcessorArgs(no_cache=True)
+    llm = MagicMock()
+    llm.predict.return_value = llm_response
+    # Bypass LLMCache wrapping by injecting a pre-built MagicMock that already
+    # quacks like LLMCache from the decomposer's perspective.
+    from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
+    llm_cache = MagicMock(spec=LLMCache)
+    llm_cache.predict = llm.predict
+    return QueryDecomposition(args=args, llm=llm_cache), llm
+
+
+class TestDecomposeQuery:
+    def test_short_query_returns_single_bundle(self):
+        decomposer, llm = _decomposer('whatever')
+        result = decomposer.decompose_query(QueryBundle('short question'))
+        assert len(result) == 1
+        assert result[0].query_str == 'short question'
+        llm.predict.assert_not_called()
+
+    def test_long_non_multipart_query_returns_original(self):
+        long_q = ' '.join(['word'] * (SINGLE_QUESTION_THRESHOLD + 1))
+        decomposer, _ = _decomposer('yes, this is one question')
+        result = decomposer.decompose_query(QueryBundle(long_q))
+        assert len(result) == 1
+        assert result[0].query_str == long_q
+
+    def test_long_multipart_query_is_decomposed(self):
+        long_q = ' '.join(['word'] * (SINGLE_QUESTION_THRESHOLD + 1))
+        decomposer, llm = _decomposer('no, multipart')
+        llm.predict.side_effect = [
+            'no, multipart',
+            'subquery one\nsubquery two\n',
+        ]
+        result = decomposer.decompose_query(QueryBundle(long_q))
+        assert [r.query_str for r in result] == ['subquery one', 'subquery two']
+
+    def test_extract_subqueries_drops_blank_lines(self):
+        decomposer, llm = _decomposer('')
+        llm.predict.return_value = 'a\n\nb\n'
+        result = decomposer._extract_subqueries('q')
+        assert [r.query_str for r in result] == ['a', 'b']
+
+    def test_is_multipart_question_true_when_response_starts_with_no(self):
+        decomposer, llm = _decomposer('No, this asks several things')
+        assert decomposer._is_multipart_question('q') is True
+
+    def test_is_multipart_question_false_when_response_starts_with_yes(self):
+        decomposer, llm = _decomposer('Yes, single question')
+        assert decomposer._is_multipart_question('q') is False

--- a/lexical-graph/tests/unit/retrieval/utils/test_statement_utils.py
+++ b/lexical-graph/tests/unit/retrieval/utils/test_statement_utils.py
@@ -1,0 +1,191 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/utils/statement_utils."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from graphrag_toolkit.lexical_graph.retrieval.utils import statement_utils
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.retrieval.utils.statement_utils import (
+    SharedEmbeddingCache,
+    cosine_similarity,
+    get_free_memory,
+    get_statements_query,
+    get_top_free_gpus,
+    get_top_k,
+)
+
+
+class TestCosineSimilarity:
+    def test_empty_embeddings_returns_empty(self):
+        sims, ids = cosine_similarity([1.0, 0.0], {})
+        assert isinstance(sims, np.ndarray)
+        assert sims.size == 0
+        assert ids == []
+
+    def test_identical_vectors_score_one(self):
+        emb = {'s1': [1.0, 0.0]}
+        sims, ids = cosine_similarity([1.0, 0.0], emb)
+        assert ids == ('s1',)
+        assert pytest.approx(sims[0]) == 1.0
+
+    def test_orthogonal_vectors_score_zero(self):
+        emb = {'s1': [0.0, 1.0]}
+        sims, _ = cosine_similarity([1.0, 0.0], emb)
+        assert pytest.approx(sims[0]) == 0.0
+
+    def test_opposite_vectors_score_minus_one(self):
+        emb = {'s1': [-1.0, 0.0]}
+        sims, _ = cosine_similarity([1.0, 0.0], emb)
+        assert pytest.approx(sims[0]) == -1.0
+
+    def test_multiple_statements_preserve_order(self):
+        emb = {'a': [1.0, 0.0], 'b': [0.0, 1.0], 'c': [1.0, 1.0]}
+        sims, ids = cosine_similarity([1.0, 0.0], emb)
+        assert ids == ('a', 'b', 'c')
+        assert pytest.approx(sims[0]) == 1.0
+        assert pytest.approx(sims[1]) == 0.0
+        assert pytest.approx(sims[2], rel=1e-3) == 1 / np.sqrt(2)
+
+
+class TestGetTopK:
+    def test_empty_embeddings_returns_empty_list(self):
+        assert get_top_k([1.0, 0.0], {}, top_k=5) == []
+
+    def test_returns_top_k_in_descending_order(self):
+        emb = {
+            'a': [1.0, 0.0],
+            'b': [0.0, 1.0],
+            'c': [1.0, 1.0],
+        }
+        result = get_top_k([1.0, 0.0], emb, top_k=2)
+        assert len(result) == 2
+        scores = [s for s, _ in result]
+        assert scores == sorted(scores, reverse=True)
+        assert result[0][1] == 'a'
+
+    def test_top_k_caps_at_available_results(self):
+        emb = {'a': [1.0, 0.0]}
+        result = get_top_k([1.0, 0.0], emb, top_k=10)
+        assert len(result) == 1
+
+
+class TestGetStatementsQuery:
+    def _store(self, returned_statements):
+        store = MagicMock()
+        store.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+        store.execute_query.return_value = returned_statements
+        return store
+
+    def test_returns_matches_in_input_order(self):
+        statements = [
+            {'result': {'statement': {'statementId': 's2'}, 'value': 'two'}},
+            {'result': {'statement': {'statementId': 's1'}, 'value': 'one'}},
+        ]
+        store = self._store(statements)
+        result = get_statements_query(store, ['s1', 's2'])
+        assert [r['result']['value'] for r in result] == ['one', 'two']
+
+    def test_drops_ids_with_no_match(self):
+        statements = [
+            {'result': {'statement': {'statementId': 's1'}, 'value': 'one'}},
+        ]
+        store = self._store(statements)
+        result = get_statements_query(store, ['s1', 'missing'])
+        assert len(result) == 1
+        assert result[0]['result']['value'] == 'one'
+
+    def test_passes_statement_ids_as_query_param(self):
+        store = self._store([])
+        get_statements_query(store, ['s1', 's2'])
+        _, params = store.execute_query.call_args.args
+        assert params == {'statement_ids': ['s1', 's2']}
+
+
+class TestGetFreeMemory:
+    def test_missing_pynvml_raises_import_error(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, 'pynvml', None)
+        with pytest.raises(ImportError, match='pynvml package not found'):
+            get_free_memory(0)
+
+    def test_returns_free_memory_in_mb(self, monkeypatch):
+        fake_pynvml = SimpleNamespace(
+            nvmlInit=MagicMock(),
+            nvmlDeviceGetHandleByIndex=MagicMock(return_value='handle'),
+            nvmlDeviceGetMemoryInfo=MagicMock(
+                return_value=SimpleNamespace(free=4 * 1024 * 1024)
+            ),
+        )
+        monkeypatch.setitem(sys.modules, 'pynvml', fake_pynvml)
+        assert get_free_memory(0) == 4
+        fake_pynvml.nvmlDeviceGetHandleByIndex.assert_called_once_with(0)
+
+
+class TestGetTopFreeGpus:
+    def test_missing_torch_raises_import_error(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, 'torch', None)
+        with pytest.raises(ImportError, match='torch package not found'):
+            get_top_free_gpus()
+
+    def test_returns_top_n_gpu_indices_by_free_memory(self, monkeypatch):
+        fake_torch = SimpleNamespace(
+            cuda=SimpleNamespace(device_count=lambda: 3),
+        )
+        monkeypatch.setitem(sys.modules, 'torch', fake_torch)
+        free = {0: 100, 1: 500, 2: 250}
+        monkeypatch.setattr(statement_utils, 'get_free_memory', lambda i: free[i])
+        assert get_top_free_gpus(n=2) == [1, 2]
+
+
+class TestSharedEmbeddingCache:
+    def _vector_store(self, embeddings):
+        index = MagicMock()
+        index.get_embeddings.return_value = [
+            {'statement': {'statementId': sid}, 'embedding': vec}
+            for sid, vec in embeddings.items()
+        ]
+        vs = MagicMock()
+        vs.get_index.return_value = index
+        return vs, index
+
+    def test_hits_cache_when_all_ids_present(self):
+        vs, index = self._vector_store({})
+        cache = SharedEmbeddingCache(vs)
+        cache._cache = {'s1': np.array([1.0]), 's2': np.array([2.0])}
+        result = cache.get_embeddings(['s1', 's2'])
+        assert set(result) == {'s1', 's2'}
+        index.get_embeddings.assert_not_called()
+
+    def test_fetches_missing_and_populates_cache(self):
+        vs, index = self._vector_store({'s2': [0.5, 0.5]})
+        cache = SharedEmbeddingCache(vs)
+        cache._cache = {'s1': np.array([1.0, 0.0])}
+        result = cache.get_embeddings(['s1', 's2'])
+        assert set(result) == {'s1', 's2'}
+        index.get_embeddings.assert_called_once_with(['s2'])
+        assert 's2' in cache._cache
+
+    def test_returns_cached_on_fetch_failure(self):
+        vs = MagicMock()
+        cache = SharedEmbeddingCache(vs)
+        cache._cache = {'s1': np.array([1.0])}
+
+        def boom(_ids):
+            raise RuntimeError('upstream down')
+
+        cache._fetch_embeddings = boom
+        result = cache.get_embeddings(['s1', 's2'])
+        assert set(result) == {'s1'}
+
+    def test_fetch_embeddings_shapes_vector_store_response(self):
+        vs, _ = self._vector_store({'s1': [0.1, 0.2], 's2': [0.3, 0.4]})
+        cache = SharedEmbeddingCache(vs)
+        result = cache._fetch_embeddings.__wrapped__(cache, ['s1', 's2'])
+        assert set(result) == {'s1', 's2'}
+        assert isinstance(result['s1'], np.ndarray)

--- a/lexical-graph/tests/unit/retrieval/utils/test_vector_utils.py
+++ b/lexical-graph/tests/unit/retrieval/utils/test_vector_utils.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval/utils/vector_utils."""
+
+from unittest.mock import MagicMock
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.utils.vector_utils import (
+    get_diverse_vss_elements,
+)
+
+
+def _vector_store(elements):
+    index = MagicMock()
+    index.top_k.return_value = elements
+    vs = MagicMock()
+    vs.get_index.return_value = index
+    return vs, index
+
+
+class TestGetDiverseVssElements:
+    def test_no_diversity_returns_top_k_directly(self):
+        elements = [{'source': {'sourceId': 's1'}}]
+        vs, index = _vector_store(elements)
+        result = get_diverse_vss_elements(
+            'chunk', QueryBundle('q'), vs,
+            diversity_factor=0, vss_top_k=5, filter_config=None,
+        )
+        assert result == elements
+        index.top_k.assert_called_once()
+        assert index.top_k.call_args.kwargs['top_k'] == 5
+
+    def test_negative_diversity_factor_returns_top_k_directly(self):
+        vs, index = _vector_store([])
+        get_diverse_vss_elements(
+            'chunk', QueryBundle('q'), vs,
+            diversity_factor=-1, vss_top_k=3, filter_config=None,
+        )
+        assert index.top_k.call_args.kwargs['top_k'] == 3
+
+    def test_diversity_factor_expands_fetch_window(self):
+        vs, index = _vector_store([])
+        get_diverse_vss_elements(
+            'chunk', QueryBundle('q'), vs,
+            diversity_factor=4, vss_top_k=2, filter_config=None,
+        )
+        assert index.top_k.call_args.kwargs['top_k'] == 8
+
+    def test_round_robins_across_sources(self):
+        # Two sources, each with multiple chunks. Diversity should interleave them.
+        elements = [
+            {'source': {'sourceId': 's1'}, 'chunk': {'chunkId': 'c1'}},
+            {'source': {'sourceId': 's1'}, 'chunk': {'chunkId': 'c2'}},
+            {'source': {'sourceId': 's1'}, 'chunk': {'chunkId': 'c3'}},
+            {'source': {'sourceId': 's2'}, 'chunk': {'chunkId': 'c4'}},
+            {'source': {'sourceId': 's2'}, 'chunk': {'chunkId': 'c5'}},
+        ]
+        vs, _ = _vector_store(elements)
+        result = get_diverse_vss_elements(
+            'chunk', QueryBundle('q'), vs,
+            diversity_factor=2, vss_top_k=4, filter_config=None,
+        )
+        assert len(result) == 4
+        sources = [e['source']['sourceId'] for e in result]
+        # First two picks must come from distinct sources, given two sources available.
+        assert sources[0] != sources[1]
+
+    def test_caps_at_vss_top_k(self):
+        elements = [
+            {'source': {'sourceId': f's{i}'}, 'chunk': {'chunkId': f'c{i}'}}
+            for i in range(10)
+        ]
+        vs, _ = _vector_store(elements)
+        result = get_diverse_vss_elements(
+            'chunk', QueryBundle('q'), vs,
+            diversity_factor=2, vss_top_k=3, filter_config=None,
+        )
+        assert len(result) == 3

--- a/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
+++ b/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
@@ -1,0 +1,330 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for storage.graph.graph_utils helpers.
+
+Covers string/label normalisation, node_result formatting, the
+FilterOperator → OpenCypher mapping, and the recursive MetadataFilters →
+OpenCypher filter conversion used by retrievers and the visualisation module.
+"""
+
+from datetime import datetime
+
+import pytest
+from llama_index.core.vector_stores.types import (
+    FilterCondition,
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+)
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import (
+    filter_config_to_opencypher_filters,
+    formatter_for_type,
+    label_from,
+    new_query_var,
+    node_result,
+    parse_metadata_filters_recursive,
+    relationship_name_from,
+    search_string_from,
+    to_opencypher_operator,
+)
+
+
+class TestNewQueryVar:
+    """Tests for new_query_var."""
+
+    def test_starts_with_n_prefix(self):
+        assert new_query_var().startswith('n')
+
+    def test_is_unique(self):
+        assert new_query_var() != new_query_var()
+
+    def test_hex_body(self):
+        var = new_query_var()
+        # 'n' + 32 hex chars
+        assert len(var) == 33
+        int(var[1:], 16)  # parses as hex
+
+
+class TestSearchStringFrom:
+    """Tests for search_string_from."""
+
+    def test_lowercases(self):
+        assert search_string_from('Hello') == 'hello'
+
+    def test_strips_punctuation(self):
+        assert search_string_from('hello, world!') == 'hello world'
+
+    def test_collapses_multiple_spaces(self):
+        assert search_string_from('a    b     c') == 'a b c'
+
+    def test_strips_underscores(self):
+        assert search_string_from('foo_bar_baz') == 'foo bar baz'
+
+    def test_trims_outer_whitespace(self):
+        assert search_string_from('   padded   ') == 'padded'
+
+    def test_empty_string(self):
+        assert search_string_from('') == ''
+
+    def test_only_punctuation(self):
+        assert search_string_from('!!!---???') == ''
+
+
+class TestLabelFrom:
+    """Tests for label_from."""
+
+    def test_capwords_and_joins(self):
+        assert label_from('source document') == 'SourceDocument'
+
+    def test_dunder_passthrough(self):
+        assert label_from('__internal__') == '__internal__'
+
+    def test_strips_punctuation(self):
+        assert label_from('aws::graph::index') == 'AwsGraphIndex'
+
+    def test_single_word(self):
+        assert label_from('chunk') == 'Chunk'
+
+
+class TestRelationshipNameFrom:
+    """Tests for relationship_name_from."""
+
+    def test_uppercases(self):
+        assert relationship_name_from('next') == 'NEXT'
+
+    def test_replaces_non_alnum_with_underscore(self):
+        assert relationship_name_from('mentioned in') == 'MENTIONED_IN'
+
+    def test_dashes_become_underscores(self):
+        assert relationship_name_from('belongs-to') == 'BELONGS_TO'
+
+    def test_keeps_digits(self):
+        assert relationship_name_from('rev2 of') == 'REV2_OF'
+
+
+class TestNodeResult:
+    """Tests for node_result formatter."""
+
+    def test_default_star_properties(self):
+        result = node_result('source')
+        assert result == 'source: source{.*}'
+
+    def test_custom_key_name(self):
+        result = node_result('source', key_name='src')
+        assert result == 'src: source{.*}'
+
+    def test_explicit_properties(self):
+        result = node_result('chunk', properties=['value', 'text'])
+        assert result == 'chunk: chunk{.value, .text}'
+
+    def test_property_based_node_id_in_star_properties(self):
+        # is_property_based=True and '*' in properties -> no extra selector for key
+        node_id = NodeId('chunkId', 'c.chunkId', is_property_based=True)
+        result = node_result('chunk', node_id=node_id, properties=['*'])
+        assert result == 'chunk: chunk{.*}'
+
+    def test_property_based_node_id_missing_from_explicit_properties(self):
+        # is_property_based and key not in properties -> prepend .key
+        node_id = NodeId('chunkId', 'c.chunkId', is_property_based=True)
+        result = node_result('chunk', node_id=node_id, properties=['text'])
+        assert result == 'chunk: chunk{.chunkId, .text}'
+
+    def test_non_property_based_node_id(self):
+        # is_property_based=False -> 'key: value' selector
+        node_id = NodeId('id', 'abc', is_property_based=False)
+        result = node_result('chunk', node_id=node_id, properties=['text'])
+        assert result == 'chunk: chunk{id: abc, .text}'
+
+
+class TestToOpencypherOperator:
+    """Tests for to_opencypher_operator mapping."""
+
+    @pytest.mark.parametrize(
+        'op,expected',
+        [
+            (FilterOperator.EQ, '='),
+            (FilterOperator.GT, '>'),
+            (FilterOperator.LT, '<'),
+            (FilterOperator.NE, '<>'),
+            (FilterOperator.GTE, '>='),
+            (FilterOperator.LTE, '<='),
+            (FilterOperator.TEXT_MATCH, 'CONTAINS'),
+            (FilterOperator.TEXT_MATCH_INSENSITIVE, 'CONTAINS'),
+            (FilterOperator.IS_EMPTY, 'IS NULL'),
+        ],
+    )
+    def test_maps_supported_operators(self, op, expected):
+        operator, _ = to_opencypher_operator(op)
+        assert operator == expected
+
+    def test_default_value_formatter_is_identity(self):
+        _, formatter = to_opencypher_operator(FilterOperator.EQ)
+        assert formatter('Foo') == 'Foo'
+
+    def test_text_match_insensitive_lowercases(self):
+        _, formatter = to_opencypher_operator(FilterOperator.TEXT_MATCH_INSENSITIVE)
+        assert formatter('Hello World') == 'hello world'
+
+    def test_unsupported_operator_raises(self):
+        with pytest.raises(ValueError, match='Unsupported filter operator'):
+            to_opencypher_operator(FilterOperator.IN)
+
+
+class TestFormatterForType:
+    """Tests for formatter_for_type."""
+
+    def test_text_wraps_in_quotes(self):
+        assert formatter_for_type('text')('hello') == "'hello'"
+
+    def test_number_passthrough(self):
+        assert formatter_for_type('number')(42) == 42
+
+    def test_int_alias(self):
+        assert formatter_for_type('int')(7) == 7
+
+    def test_float_alias(self):
+        assert formatter_for_type('float')(3.14) == 3.14
+
+    def test_timestamp_wraps_in_datetime_call(self):
+        result = formatter_for_type('timestamp')('2024-01-15T10:30:00')
+        assert result.startswith("datetime('2024-01-15T10:30:00")
+        assert result.endswith("')")
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match='Unsupported type name'):
+            formatter_for_type('boolean')
+
+
+def _eq_filter(key: str, value):
+    return MetadataFilter(key=key, value=value, operator=FilterOperator.EQ)
+
+
+class TestParseMetadataFiltersRecursive:
+    """Tests for parse_metadata_filters_recursive."""
+
+    def test_single_eq_filter_and(self):
+        filters = MetadataFilters(
+            filters=[_eq_filter('category', 'tech')],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert result == "((source.category = 'tech'))"
+
+    def test_numeric_value_not_quoted(self):
+        filters = MetadataFilters(
+            filters=[MetadataFilter(key='count', value=5, operator=FilterOperator.GT)],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert "source.count > 5" in result
+
+    def test_float_value_not_quoted(self):
+        filters = MetadataFilters(
+            filters=[MetadataFilter(key='ratio', value=0.5, operator=FilterOperator.LTE)],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert "source.ratio <= 0.5" in result
+
+    def test_and_joins_with_AND(self):
+        filters = MetadataFilters(
+            filters=[_eq_filter('category', 'tech'), _eq_filter('lang', 'en')],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert ' AND ' in result
+        assert "source.category = 'tech'" in result
+        assert "source.lang = 'en'" in result
+
+    def test_or_joins_with_OR(self):
+        filters = MetadataFilters(
+            filters=[_eq_filter('category', 'tech'), _eq_filter('category', 'science')],
+            condition=FilterCondition.OR,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert ' OR ' in result
+
+    def test_not_wraps_nested_filters(self):
+        inner = MetadataFilters(
+            filters=[_eq_filter('category', 'tech')],
+            condition=FilterCondition.AND,
+        )
+        outer = MetadataFilters(filters=[inner], condition=FilterCondition.NOT)
+        result = parse_metadata_filters_recursive(outer)
+        assert result.startswith('(NOT ')
+
+    def test_not_rejects_bare_metadata_filter(self):
+        # FilterCondition.NOT must wrap a MetadataFilters, not a bare MetadataFilter
+        filters = MetadataFilters(
+            filters=[_eq_filter('category', 'tech')],
+            condition=FilterCondition.NOT,
+        )
+        with pytest.raises(ValueError, match='Expected MetadataFilters for FilterCondition.NOT'):
+            parse_metadata_filters_recursive(filters)
+
+    def test_is_empty_emits_is_null(self):
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(key='archived_at', value=None, operator=FilterOperator.IS_EMPTY)
+            ],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert 'source.archived_at IS NULL' in result
+
+    def test_text_match_insensitive_lowercases_value_and_key(self):
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key='title',
+                    value='Hello',
+                    operator=FilterOperator.TEXT_MATCH_INSENSITIVE,
+                )
+            ],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert 'source.title.toLower() CONTAINS' in result
+        assert "'hello'" in result
+
+    def test_nested_filters_recurse(self):
+        inner = MetadataFilters(
+            filters=[_eq_filter('lang', 'en'), _eq_filter('lang', 'fr')],
+            condition=FilterCondition.OR,
+        )
+        outer = MetadataFilters(
+            filters=[_eq_filter('category', 'tech'), inner],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(outer)
+        assert 'source.category' in result
+        assert 'source.lang' in result
+        # outer AND wraps both, inner OR appears as a sub-expression
+        assert ' AND ' in result
+        assert ' OR ' in result
+
+
+class TestFilterConfigToOpencypherFilters:
+    """Tests for filter_config_to_opencypher_filters."""
+
+    def test_none_config_returns_empty_string(self):
+        assert filter_config_to_opencypher_filters(None) == ''
+
+    def test_empty_source_filters_returns_empty_string(self):
+        # FilterConfig with no filters specified -> source_filters is None
+        config = FilterConfig()
+        assert filter_config_to_opencypher_filters(config) == ''
+
+    def test_passes_through_to_recursive_parser(self):
+        config = FilterConfig(
+            source_filters=MetadataFilters(
+                filters=[_eq_filter('category', 'tech')],
+                condition=FilterCondition.AND,
+            )
+        )
+        result = filter_config_to_opencypher_filters(config)
+        assert "source.category = 'tech'" in result

--- a/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
+++ b/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
@@ -30,9 +30,6 @@ class TestNewQueryVar:
     def test_starts_with_n_prefix(self):
         assert new_query_var().startswith('n')
 
-    def test_is_unique(self):
-        assert new_query_var() != new_query_var()
-
     def test_hex_body(self):
         var = new_query_var()
         # 'n' + 32 hex chars

--- a/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
+++ b/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
@@ -1,14 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for storage.graph.graph_utils helpers.
-
-Covers string/label normalisation, node_result formatting, the
-FilterOperator → OpenCypher mapping, and the recursive MetadataFilters →
-OpenCypher filter conversion used by retrievers and the visualisation module.
-"""
-
-from datetime import datetime
+"""Tests for graph_utils."""
 
 import pytest
 from llama_index.core.vector_stores.types import (
@@ -34,8 +27,6 @@ from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import (
 
 
 class TestNewQueryVar:
-    """Tests for new_query_var."""
-
     def test_starts_with_n_prefix(self):
         assert new_query_var().startswith('n')
 
@@ -46,12 +37,10 @@ class TestNewQueryVar:
         var = new_query_var()
         # 'n' + 32 hex chars
         assert len(var) == 33
-        int(var[1:], 16)  # parses as hex
+        int(var[1:], 16)
 
 
 class TestSearchStringFrom:
-    """Tests for search_string_from."""
-
     def test_lowercases(self):
         assert search_string_from('Hello') == 'hello'
 
@@ -75,8 +64,6 @@ class TestSearchStringFrom:
 
 
 class TestLabelFrom:
-    """Tests for label_from."""
-
     def test_capwords_and_joins(self):
         assert label_from('source document') == 'SourceDocument'
 
@@ -91,15 +78,11 @@ class TestLabelFrom:
 
 
 class TestRelationshipNameFrom:
-    """Tests for relationship_name_from."""
-
     def test_uppercases(self):
         assert relationship_name_from('next') == 'NEXT'
 
     def test_replaces_non_alnum_with_underscore(self):
         assert relationship_name_from('mentioned in') == 'MENTIONED_IN'
-
-    def test_dashes_become_underscores(self):
         assert relationship_name_from('belongs-to') == 'BELONGS_TO'
 
     def test_keeps_digits(self):
@@ -107,8 +90,6 @@ class TestRelationshipNameFrom:
 
 
 class TestNodeResult:
-    """Tests for node_result formatter."""
-
     def test_default_star_properties(self):
         result = node_result('source')
         assert result == 'source: source{.*}'
@@ -121,13 +102,13 @@ class TestNodeResult:
         result = node_result('chunk', properties=['value', 'text'])
         assert result == 'chunk: chunk{.value, .text}'
 
-    def test_property_based_node_id_in_star_properties(self):
+    def test_property_based_node_id_with_star_omits_key(self):
         # is_property_based=True and '*' in properties -> no extra selector for key
         node_id = NodeId('chunkId', 'c.chunkId', is_property_based=True)
         result = node_result('chunk', node_id=node_id, properties=['*'])
         assert result == 'chunk: chunk{.*}'
 
-    def test_property_based_node_id_missing_from_explicit_properties(self):
+    def test_property_based_node_id_prepends_key_when_absent(self):
         # is_property_based and key not in properties -> prepend .key
         node_id = NodeId('chunkId', 'c.chunkId', is_property_based=True)
         result = node_result('chunk', node_id=node_id, properties=['text'])
@@ -141,8 +122,6 @@ class TestNodeResult:
 
 
 class TestToOpencypherOperator:
-    """Tests for to_opencypher_operator mapping."""
-
     @pytest.mark.parametrize(
         'op,expected',
         [
@@ -175,8 +154,6 @@ class TestToOpencypherOperator:
 
 
 class TestFormatterForType:
-    """Tests for formatter_for_type."""
-
     def test_text_wraps_in_quotes(self):
         assert formatter_for_type('text')('hello') == "'hello'"
 
@@ -204,9 +181,7 @@ def _eq_filter(key: str, value):
 
 
 class TestParseMetadataFiltersRecursive:
-    """Tests for parse_metadata_filters_recursive."""
-
-    def test_single_eq_filter_and(self):
+    def test_single_eq_filter_with_and_condition(self):
         filters = MetadataFilters(
             filters=[_eq_filter('category', 'tech')],
             condition=FilterCondition.AND,
@@ -230,7 +205,7 @@ class TestParseMetadataFiltersRecursive:
         result = parse_metadata_filters_recursive(filters)
         assert "source.ratio <= 0.5" in result
 
-    def test_and_joins_with_AND(self):
+    def test_and_condition_joins_with_and_keyword(self):
         filters = MetadataFilters(
             filters=[_eq_filter('category', 'tech'), _eq_filter('lang', 'en')],
             condition=FilterCondition.AND,
@@ -240,7 +215,7 @@ class TestParseMetadataFiltersRecursive:
         assert "source.category = 'tech'" in result
         assert "source.lang = 'en'" in result
 
-    def test_or_joins_with_OR(self):
+    def test_or_condition_joins_with_or_keyword(self):
         filters = MetadataFilters(
             filters=[_eq_filter('category', 'tech'), _eq_filter('category', 'science')],
             condition=FilterCondition.OR,
@@ -258,7 +233,6 @@ class TestParseMetadataFiltersRecursive:
         assert result.startswith('(NOT ')
 
     def test_not_rejects_bare_metadata_filter(self):
-        # FilterCondition.NOT must wrap a MetadataFilters, not a bare MetadataFilter
         filters = MetadataFilters(
             filters=[_eq_filter('category', 'tech')],
             condition=FilterCondition.NOT,
@@ -276,7 +250,7 @@ class TestParseMetadataFiltersRecursive:
         result = parse_metadata_filters_recursive(filters)
         assert 'source.archived_at IS NULL' in result
 
-    def test_text_match_insensitive_lowercases_value_and_key(self):
+    def test_text_match_insensitive_emits_tolower_on_key_and_lowercased_value(self):
         filters = MetadataFilters(
             filters=[
                 MetadataFilter(
@@ -303,19 +277,15 @@ class TestParseMetadataFiltersRecursive:
         result = parse_metadata_filters_recursive(outer)
         assert 'source.category' in result
         assert 'source.lang' in result
-        # outer AND wraps both, inner OR appears as a sub-expression
         assert ' AND ' in result
         assert ' OR ' in result
 
 
 class TestFilterConfigToOpencypherFilters:
-    """Tests for filter_config_to_opencypher_filters."""
-
     def test_none_config_returns_empty_string(self):
         assert filter_config_to_opencypher_filters(None) == ''
 
     def test_empty_source_filters_returns_empty_string(self):
-        # FilterConfig with no filters specified -> source_filters is None
         config = FilterConfig()
         assert filter_config_to_opencypher_filters(config) == ''
 

--- a/lexical-graph/tests/unit/storage/graph/test_multi_tenant_graph_store.py
+++ b/lexical-graph/tests/unit/storage/graph/test_multi_tenant_graph_store.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for storage/graph/multi_tenant_graph_store."""
+
+from unittest.mock import MagicMock
+
+from graphrag_toolkit.lexical_graph import TenantId
+from graphrag_toolkit.lexical_graph.storage.graph.dummy_graph_store import DummyGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.multi_tenant_graph_store import (
+    MultiTenantGraphStore,
+)
+
+
+def _wrap(tenant_value=None, labels=None):
+    inner = MagicMock(spec=DummyGraphStore)
+    tenant_id = TenantId() if tenant_value is None else TenantId(value=tenant_value)
+    return MultiTenantGraphStore(
+        inner=inner,
+        tenant_id=tenant_id,
+        labels=labels or ['Source', 'Chunk'],
+    ), inner
+
+
+class TestWrap:
+    def test_returns_existing_multi_tenant_store_unchanged(self):
+        inner = MagicMock(spec=DummyGraphStore)
+        existing = MultiTenantGraphStore(inner=inner, tenant_id=TenantId(value='t1'))
+        result = MultiTenantGraphStore.wrap(existing, TenantId(value='t2'))
+        assert result is existing
+
+    def test_wraps_plain_graph_store(self):
+        inner = MagicMock(spec=DummyGraphStore)
+        wrapped = MultiTenantGraphStore.wrap(inner, TenantId(value='acme'))
+        assert isinstance(wrapped, MultiTenantGraphStore)
+        assert wrapped.inner is inner
+
+
+class TestRewriteQuery:
+    def test_default_tenant_passes_query_through(self):
+        store, _ = _wrap(tenant_value=None)
+        cypher = 'MATCH (n:`Source`) RETURN n'
+        assert store._rewrite_query(cypher) == cypher
+
+    def test_non_default_tenant_appends_tenant_to_labels(self):
+        store, _ = _wrap(tenant_value='acme', labels=['Source', 'Chunk'])
+        cypher = 'MATCH (s:`Source`)-[]->(c:`Chunk`) RETURN s, c'
+        rewritten = store._rewrite_query(cypher)
+        assert '`Sourceacme__`' in rewritten
+        assert '`Chunkacme__`' in rewritten
+        assert '`Source`' not in rewritten
+
+    def test_only_labels_in_list_are_rewritten(self):
+        store, _ = _wrap(tenant_value='acme', labels=['Source'])
+        cypher = 'MATCH (s:`Source`), (o:`Other`) RETURN s, o'
+        rewritten = store._rewrite_query(cypher)
+        assert '`Sourceacme__`' in rewritten
+        assert '`Other`' in rewritten
+
+
+class TestDelegation:
+    def test_execute_query_with_retry_rewrites_and_delegates(self):
+        store, inner = _wrap(tenant_value='acme', labels=['Source'])
+        store.execute_query_with_retry('MATCH (n:`Source`)', {'k': 1})
+        called_query = inner.execute_query_with_retry.call_args.kwargs['query']
+        assert '`Sourceacme__`' in called_query
+        assert inner.execute_query_with_retry.call_args.kwargs['parameters'] == {'k': 1}
+
+    def test_execute_query_rewrites_and_delegates(self):
+        store, inner = _wrap(tenant_value='acme', labels=['Source'])
+        store._execute_query('MATCH (n:`Source`)', {'k': 1})
+        assert '`Sourceacme__`' in inner._execute_query.call_args.kwargs['cypher']
+
+    def test_node_id_delegates(self):
+        store, inner = _wrap()
+        store.node_id('n.id')
+        inner.node_id.assert_called_once_with(id_name='n.id')
+
+    def test_property_assigment_fn_delegates(self):
+        store, inner = _wrap()
+        store.property_assigment_fn('k', 'v')
+        inner.property_assigment_fn.assert_called_with('k', 'v')
+
+    def test_logging_prefix_delegates(self):
+        store, inner = _wrap()
+        store._logging_prefix('q1', correlation_id='c1')
+        inner._logging_prefix.assert_called_once_with(query_id='q1', correlation_id='c1')
+
+    def test_init_passes_outer_store_as_self(self):
+        store, inner = _wrap()
+        store.init()
+        inner.init.assert_called_once_with(store)
+
+    def test_init_uses_provided_store(self):
+        store, inner = _wrap()
+        explicit = MagicMock()
+        store.init(graph_store=explicit)
+        inner.init.assert_called_once_with(explicit)

--- a/lexical-graph/tests/unit/storage/graph/test_neptune_graph_stores.py
+++ b/lexical-graph/tests/unit/storage/graph/test_neptune_graph_stores.py
@@ -345,5 +345,79 @@ class TestNeptuneGraphStoreConfiguration:
         log_formatting = RedactedGraphQueryLogFormatting()
         
         store = factory.try_create("neptune-graph://test-graph", log_formatting=log_formatting)
-        
+
         assert store.log_formatting == log_formatting
+
+
+from graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores import (
+    DEFAULT_MAX_POOL_CONNECTIONS,
+    NEPTUNE_DB_DNS,
+    NeptuneDatabaseClient,
+    create_config,
+    create_property_assigment_fn_for_neptune,
+    format_id_for_neptune,
+)
+import json as _json
+
+
+class TestFormatIdForNeptune:
+    def test_single_part_uses_id_pseudo_property(self):
+        node_id = format_id_for_neptune('chunkId')
+        assert node_id.key == 'chunkId'
+        assert node_id.value == '`~id`'
+        assert node_id.is_property_based is False
+
+    def test_two_parts_use_id_function(self):
+        node_id = format_id_for_neptune('chunk.chunkId')
+        assert node_id.key == 'chunkId'
+        assert node_id.value == 'id(chunk)'
+
+
+class TestCreateConfig:
+    def test_defaults_max_pool_connections(self):
+        cfg = create_config()
+        assert cfg.max_pool_connections == DEFAULT_MAX_POOL_CONNECTIONS
+
+    def test_user_args_override_default(self):
+        cfg = create_config(_json.dumps({'max_pool_connections': 100}))
+        assert cfg.max_pool_connections == 100
+
+    def test_user_agent_set(self):
+        cfg = create_config()
+        assert 'graphrag-lexical-graph' in cfg.user_agent_appid
+
+
+class TestCreatePropertyAssignmentFn:
+    def test_non_datetime_key_returns_identity(self):
+        fn = create_property_assigment_fn_for_neptune('value', 'hello')
+        assert fn('x') == 'x'
+
+    def test_datetime_key_with_valid_value_wraps_in_datetime(self):
+        fn = create_property_assigment_fn_for_neptune('extract_date', '2024-01-15')
+        assert fn('$x') == 'datetime($x)'
+
+    def test_datetime_key_with_invalid_value_falls_back_to_identity(self):
+        fn = create_property_assigment_fn_for_neptune('extract_date', 'not-a-date')
+        assert fn('y') == 'y'
+
+
+class TestNeptuneDatabaseFactoryEndpointHandling:
+    def test_neptune_db_prefix_creates_client_with_default_port(self):
+        result = NeptuneDatabaseGraphStoreFactory().try_create(
+            f'neptune-db://cluster.abc.{NEPTUNE_DB_DNS}',
+        )
+        assert isinstance(result, NeptuneDatabaseClient)
+        assert ':8182' in result.endpoint_url
+
+    def test_uri_ending_in_neptune_dns_creates_client(self):
+        result = NeptuneDatabaseGraphStoreFactory().try_create(
+            f'cluster.abc.{NEPTUNE_DB_DNS}',
+        )
+        assert isinstance(result, NeptuneDatabaseClient)
+
+    def test_explicit_endpoint_url_kwarg_wins(self):
+        result = NeptuneDatabaseGraphStoreFactory().try_create(
+            f'neptune-db://cluster.abc.{NEPTUNE_DB_DNS}',
+            endpoint_url='https://override.example.com',
+        )
+        assert result.endpoint_url == 'https://override.example.com'

--- a/lexical-graph/tests/unit/storage/graph/test_neptune_graph_stores.py
+++ b/lexical-graph/tests/unit/storage/graph/test_neptune_graph_stores.py
@@ -356,6 +356,7 @@ from graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores import (
     create_config,
     create_property_assigment_fn_for_neptune,
     format_id_for_neptune,
+    intercept_before_parse,
 )
 import json as _json
 
@@ -421,3 +422,80 @@ class TestNeptuneDatabaseFactoryEndpointHandling:
             endpoint_url='https://override.example.com',
         )
         assert result.endpoint_url == 'https://override.example.com'
+
+
+class TestInterceptBeforeParse:
+    def test_non_200_status_returns_early(self):
+        resp = {'status_code': 500, 'body': b'irrelevant'}
+        assert intercept_before_parse(Mock(), resp) is None
+
+    def test_valid_json_populates_customized_response(self):
+        body = _json.dumps({'results': [{'a': 1}]}).encode('utf-8')
+        resp = {'status_code': 200, 'body': body}
+        customized = {}
+        intercept_before_parse(Mock(), resp, customized_response_dict=customized)
+        assert customized['results'] == [{'a': 1}]
+        assert resp['body'] == b'{"results":[]}'
+
+    @patch('graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores.boto3')
+    def test_matched_error_pattern_raises_internal_failure(self, mock_boto3):
+        class FakeError(Exception):
+            pass
+        mock_boto3.client.return_value.exceptions.from_code.return_value = FakeError
+
+        error_block = (
+            '{"code":"InternalFailureException","detailedMessage":"d",'
+            '"requestId":"r","message":"m"}'
+        )
+        # Leading junk makes the whole body invalid JSON while the trailing
+        # block still matches the streamed-error pattern.
+        resp = {'status_code': 200, 'body': ('garbage' + error_block).encode('utf-8')}
+        with pytest.raises(FakeError):
+            intercept_before_parse(Mock(), resp, customized_response_dict={})
+        assert resp['status_code'] == 500
+
+    @patch('graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores.boto3')
+    def test_unmatched_invalid_json_raises_generic_failure(self, mock_boto3):
+        class FakeError(Exception):
+            pass
+        mock_boto3.client.return_value.exceptions.from_code.return_value = FakeError
+
+        resp = {'status_code': 200, 'body': b'totally broken not json'}
+        with pytest.raises(FakeError):
+            intercept_before_parse(Mock(), resp, customized_response_dict={})
+        assert resp['status_code'] == 500
+
+
+class TestNeptuneDatabaseClient:
+    def _db_client(self, mock_config):
+        mock_session = Mock()
+        mock_client = Mock()
+        mock_session.client.return_value = mock_client
+        mock_config.session = mock_session
+        store = NeptuneDatabaseGraphStoreFactory().try_create(
+            f'neptune-db://cluster.abc.{NEPTUNE_DB_DNS}',
+        )
+        return store, mock_client
+
+    @patch('graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores.GraphRAGConfig')
+    def test_execute_query_returns_results(self, mock_config):
+        store, mock_client = self._db_client(mock_config)
+        mock_client.execute_open_cypher_query.return_value = {'results': [{'n': 1}]}
+
+        results = store.execute_query('MATCH (n) RETURN n', {'k': 'v'})
+
+        assert results == [{'n': 1}]
+        mock_client.execute_open_cypher_query.assert_called_once()
+        assert mock_client.meta.events.register.called
+
+    @patch('graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores.GraphRAGConfig')
+    def test_unretriable_exception_types_pulls_from_client(self, mock_config):
+        store, _ = self._db_client(mock_config)
+        types = store.unretriable_exception_types()
+        assert len(types) == 13
+
+    @patch('graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores.GraphRAGConfig')
+    def test_node_id_and_property_fn(self, mock_config):
+        store, _ = self._db_client(mock_config)
+        assert store.node_id('chunk.chunkId').value == 'id(chunk)'
+        assert store.property_assigment_fn('value', 'x')('y') == 'y'

--- a/lexical-graph/tests/unit/storage/graph/test_query_tree.py
+++ b/lexical-graph/tests/unit/storage/graph/test_query_tree.py
@@ -1,12 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for storage.graph.query_tree.
-
-Covers the default params adapter (dict / list / generator / invalid),
-Query construction defaults, Job.run delegation, and QueryTree iteration
-over child queries and yielded leaf results.
-"""
+"""Tests for query_tree."""
 
 from unittest.mock import MagicMock
 
@@ -22,8 +17,6 @@ from graphrag_toolkit.lexical_graph.storage.graph.query_tree import (
 
 
 class TestDefaultParamsAdapter:
-    """Tests for _default_params_adapter."""
-
     def test_dict_passthrough(self):
         assert _default_params_adapter({'a': 1}) == {'a': 1}
 
@@ -36,7 +29,7 @@ class TestDefaultParamsAdapter:
         result = _default_params_adapter(['Foo', 'foo', 'BAR'])
         assert result == {'params': ['foo', 'BAR']}
 
-    def test_generator_drained_and_dedupd(self):
+    def test_generator_drained_and_deduped(self):
         def gen():
             yield 'Foo'
             yield 'foo'
@@ -52,13 +45,11 @@ class TestDefaultParamsAdapter:
         with pytest.raises(ValueError, match='Invalid input parameters'):
             _default_params_adapter('not-a-list')
 
-    def test_default_constant_is_function(self):
+    def test_default_constant_aliases_underscore_function(self):
         assert DEFAULT_PARAMS_ADAPTER is _default_params_adapter
 
 
 class TestQuery:
-    """Tests for Query construction."""
-
     def test_defaults(self):
         q = Query('MATCH (n) RETURN n')
         assert q.query == 'MATCH (n) RETURN n'
@@ -77,8 +68,6 @@ class TestQuery:
 
 
 class TestJob:
-    """Tests for Job.run delegation."""
-
     def test_run_invokes_store_with_adapted_params(self):
         q = Query('MATCH (n) RETURN n')
         job = Job(q, params=['Foo', 'foo'])
@@ -101,8 +90,6 @@ class TestJob:
 
 
 class TestQueryTree:
-    """Tests for QueryTree.run end-to-end iteration."""
-
     def test_id_is_prefixed(self):
         tree = QueryTree('lookup', Query('MATCH (n)'))
         assert tree.id == 'query-tree-lookup'
@@ -114,7 +101,6 @@ class TestQueryTree:
 
         results = list(tree.run({'k': 'v'}, store))
 
-        # dict params pass through unchanged
         store.assert_called_once_with('MATCH (n) RETURN n', {'k': 'v'})
         assert results == [{'n': 1}, {'n': 2}, {'n': 3}]
 
@@ -122,19 +108,14 @@ class TestQueryTree:
         child = Query('MATCH (c)')
         root = Query('MATCH (n)', child_queries=[child])
 
-        # Root returns a list; the child query is invoked with that list as its params,
-        # which the default adapter wraps under 'params'.
         store = MagicMock(side_effect=[['Foo', 'foo', 'Bar'], [{'c': 'final'}]])
         tree = QueryTree('with-child', root)
 
         results = list(tree.run({'k': 'v'}, store))
 
         assert store.call_count == 2
-        # First call uses root's dict params verbatim
         assert store.call_args_list[0].args == ('MATCH (n)', {'k': 'v'})
-        # Second call uses the deduped+lowered parent results
         assert store.call_args_list[1].args == ('MATCH (c)', {'params': ['foo', 'Bar']})
-        # Only leaf-level results yield
         assert results == [{'c': 'final'}]
 
     def test_multiple_child_queries_all_run(self):
@@ -144,9 +125,9 @@ class TestQueryTree:
 
         store = MagicMock(
             side_effect=[
-                [{'r': 1}],  # root
-                [{'b': 'leaf-b'}],  # child_b runs first (LIFO via pop())
-                [{'a': 'leaf-a'}],  # then child_a
+                [{'r': 1}],
+                [{'b': 'leaf-b'}],
+                [{'a': 'leaf-a'}],
             ]
         )
         tree = QueryTree('multi-child', root)

--- a/lexical-graph/tests/unit/storage/graph/test_query_tree.py
+++ b/lexical-graph/tests/unit/storage/graph/test_query_tree.py
@@ -1,0 +1,158 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for storage.graph.query_tree.
+
+Covers the default params adapter (dict / list / generator / invalid),
+Query construction defaults, Job.run delegation, and QueryTree iteration
+over child queries and yielded leaf results.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.storage.graph.query_tree import (
+    DEFAULT_PARAMS_ADAPTER,
+    Job,
+    Query,
+    QueryTree,
+    _default_params_adapter,
+)
+
+
+class TestDefaultParamsAdapter:
+    """Tests for _default_params_adapter."""
+
+    def test_dict_passthrough(self):
+        assert _default_params_adapter({'a': 1}) == {'a': 1}
+
+    def test_list_wrapped_under_params_key(self):
+        result = _default_params_adapter(['x', 'y'])
+        assert result == {'params': ['x', 'y']}
+
+    def test_list_dedups_case_insensitive(self):
+        # Duplicates keyed by str(p).lower() are collapsed; later wins.
+        result = _default_params_adapter(['Foo', 'foo', 'BAR'])
+        assert result == {'params': ['foo', 'BAR']}
+
+    def test_generator_drained_and_dedupd(self):
+        def gen():
+            yield 'Foo'
+            yield 'foo'
+            yield 'baz'
+
+        result = _default_params_adapter(gen())
+        assert result == {'params': ['foo', 'baz']}
+
+    def test_empty_list(self):
+        assert _default_params_adapter([]) == {'params': []}
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError, match='Invalid input parameters'):
+            _default_params_adapter('not-a-list')
+
+    def test_default_constant_is_function(self):
+        assert DEFAULT_PARAMS_ADAPTER is _default_params_adapter
+
+
+class TestQuery:
+    """Tests for Query construction."""
+
+    def test_defaults(self):
+        q = Query('MATCH (n) RETURN n')
+        assert q.query == 'MATCH (n) RETURN n'
+        assert q.params_adapter is DEFAULT_PARAMS_ADAPTER
+        assert q.child_queries == []
+
+    def test_custom_adapter_kept(self):
+        adapter = lambda v: {'custom': v}
+        q = Query('MATCH (n)', params_adapter=adapter)
+        assert q.params_adapter is adapter
+
+    def test_child_queries_kept(self):
+        child = Query('MATCH (c)')
+        q = Query('MATCH (n)', child_queries=[child])
+        assert q.child_queries == [child]
+
+
+class TestJob:
+    """Tests for Job.run delegation."""
+
+    def test_run_invokes_store_with_adapted_params(self):
+        q = Query('MATCH (n) RETURN n')
+        job = Job(q, params=['Foo', 'foo'])
+        store = MagicMock(return_value=[{'n': 1}])
+
+        result = job.run(store)
+
+        store.assert_called_once_with('MATCH (n) RETURN n', {'params': ['foo']})
+        assert result == [{'n': 1}]
+
+    def test_run_uses_custom_adapter(self):
+        adapter = lambda v: {'wrapped': v}
+        q = Query('MATCH (n)', params_adapter=adapter)
+        job = Job(q, params='raw')
+        store = MagicMock(return_value=[])
+
+        job.run(store)
+
+        store.assert_called_once_with('MATCH (n)', {'wrapped': 'raw'})
+
+
+class TestQueryTree:
+    """Tests for QueryTree.run end-to-end iteration."""
+
+    def test_id_is_prefixed(self):
+        tree = QueryTree('lookup', Query('MATCH (n)'))
+        assert tree.id == 'query-tree-lookup'
+
+    def test_leaf_query_yields_each_result(self):
+        root = Query('MATCH (n) RETURN n')
+        store = MagicMock(return_value=[{'n': 1}, {'n': 2}, {'n': 3}])
+        tree = QueryTree('leaf', root)
+
+        results = list(tree.run({'k': 'v'}, store))
+
+        # dict params pass through unchanged
+        store.assert_called_once_with('MATCH (n) RETURN n', {'k': 'v'})
+        assert results == [{'n': 1}, {'n': 2}, {'n': 3}]
+
+    def test_child_query_consumes_parent_results(self):
+        child = Query('MATCH (c)')
+        root = Query('MATCH (n)', child_queries=[child])
+
+        # Root returns a list; the child query is invoked with that list as its params,
+        # which the default adapter wraps under 'params'.
+        store = MagicMock(side_effect=[['Foo', 'foo', 'Bar'], [{'c': 'final'}]])
+        tree = QueryTree('with-child', root)
+
+        results = list(tree.run({'k': 'v'}, store))
+
+        assert store.call_count == 2
+        # First call uses root's dict params verbatim
+        assert store.call_args_list[0].args == ('MATCH (n)', {'k': 'v'})
+        # Second call uses the deduped+lowered parent results
+        assert store.call_args_list[1].args == ('MATCH (c)', {'params': ['foo', 'Bar']})
+        # Only leaf-level results yield
+        assert results == [{'c': 'final'}]
+
+    def test_multiple_child_queries_all_run(self):
+        child_a = Query('MATCH (a)')
+        child_b = Query('MATCH (b)')
+        root = Query('MATCH (n)', child_queries=[child_a, child_b])
+
+        store = MagicMock(
+            side_effect=[
+                [{'r': 1}],  # root
+                [{'b': 'leaf-b'}],  # child_b runs first (LIFO via pop())
+                [{'a': 'leaf-a'}],  # then child_a
+            ]
+        )
+        tree = QueryTree('multi-child', root)
+
+        results = list(tree.run({}, store))
+
+        assert store.call_count == 3
+        # Order is LIFO because the implementation uses list.pop() with no index.
+        assert results == [{'b': 'leaf-b'}, {'a': 'leaf-a'}]

--- a/lexical-graph/tests/unit/storage/vector/test_neptune_vector_indexes.py
+++ b/lexical-graph/tests/unit/storage/vector/test_neptune_vector_indexes.py
@@ -31,7 +31,13 @@ def _make_index(index_name='chunk', tenant_value=None):
     client = _stub_neptune_client()
     with patch.object(mod, 'GraphStoreFactory') as factory:
         factory.for_graph_store.return_value = client
-        idx = NeptuneIndex.for_index(index_name, f'{NEPTUNE_ANALYTICS}my-graph')
+        # Inject embed_model/dimensions so for_index doesn't fall back to
+        # GraphRAGConfig.embed_model, which builds a real BedrockEmbedding
+        # (and needs an AWS region) — keeps the test offline.
+        idx = NeptuneIndex.for_index(
+            index_name, f'{NEPTUNE_ANALYTICS}my-graph',
+            embed_model=MagicMock(), dimensions=1024,
+        )
     if tenant_value is not None:
         idx.tenant_id = TenantId(value=tenant_value)
     return idx, client
@@ -71,7 +77,10 @@ class TestForIndex:
         with patch.object(mod, 'GraphStoreFactory') as factory:
             factory.for_graph_store.return_value = client
             with pytest.raises(ValueError, match='Invalid index name'):
-                NeptuneIndex.for_index('bogus', f'{NEPTUNE_ANALYTICS}g')
+                NeptuneIndex.for_index(
+                    'bogus', f'{NEPTUNE_ANALYTICS}g',
+                    embed_model=MagicMock(), dimensions=1024,
+                )
 
 
 class TestNeptuneClientWrapping:

--- a/lexical-graph/tests/unit/storage/vector/test_neptune_vector_indexes.py
+++ b/lexical-graph/tests/unit/storage/vector/test_neptune_vector_indexes.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for storage/vector/neptune_vector_indexes."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from llama_index.core.schema import QueryBundle, TextNode
+
+from graphrag_toolkit.lexical_graph import TenantId
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
+from graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores import (
+    NeptuneAnalyticsClient,
+)
+from graphrag_toolkit.lexical_graph.storage.vector import neptune_vector_indexes as mod
+from graphrag_toolkit.lexical_graph.storage.vector.neptune_vector_indexes import (
+    NEPTUNE_ANALYTICS,
+    NeptuneAnalyticsVectorIndexFactory,
+    NeptuneIndex,
+)
+
+
+def _stub_neptune_client():
+    client = MagicMock(spec=NeptuneAnalyticsClient)
+    client.node_id.side_effect = lambda s: NodeId('id', s, is_property_based=False)
+    return client
+
+
+def _make_index(index_name='chunk', tenant_value=None):
+    client = _stub_neptune_client()
+    with patch.object(mod, 'GraphStoreFactory') as factory:
+        factory.for_graph_store.return_value = client
+        idx = NeptuneIndex.for_index(index_name, f'{NEPTUNE_ANALYTICS}my-graph')
+    if tenant_value is not None:
+        idx.tenant_id = TenantId(value=tenant_value)
+    return idx, client
+
+
+class TestNeptuneAnalyticsVectorIndexFactory:
+    def test_returns_none_when_uri_unmatched(self):
+        factory = NeptuneAnalyticsVectorIndexFactory()
+        assert factory.try_create(['chunk'], 'other://x') is None
+
+    def test_creates_indexes_for_each_name(self):
+        factory = NeptuneAnalyticsVectorIndexFactory()
+        with patch.object(NeptuneIndex, 'for_index') as for_idx:
+            for_idx.return_value = MagicMock()
+            result = factory.try_create(['chunk', 'topic'], f'{NEPTUNE_ANALYTICS}g')
+        assert len(result) == 2
+        assert for_idx.call_count == 2
+
+
+class TestForIndex:
+    def test_chunk_index_sets_source_join_path(self):
+        idx, _ = _make_index('chunk')
+        assert idx.label == '__Chunk__'
+        assert 'EXTRACTED_FROM' in idx.path
+
+    def test_statement_index_sets_statement_path(self):
+        idx, _ = _make_index('statement')
+        assert idx.label == '__Statement__'
+        assert 'MENTIONED_IN' in idx.path
+
+    def test_topic_index_sets_topic_path(self):
+        idx, _ = _make_index('topic')
+        assert idx.label == '__Topic__'
+
+    def test_invalid_index_name_raises(self):
+        client = _stub_neptune_client()
+        with patch.object(mod, 'GraphStoreFactory') as factory:
+            factory.for_graph_store.return_value = client
+            with pytest.raises(ValueError, match='Invalid index name'):
+                NeptuneIndex.for_index('bogus', f'{NEPTUNE_ANALYTICS}g')
+
+
+class TestNeptuneClientWrapping:
+    def test_default_tenant_returns_unwrapped_client(self):
+        idx, client = _make_index('chunk')
+        assert idx._neptune_client() is client
+
+    def test_non_default_tenant_returns_multi_tenant_wrapper(self):
+        idx, client = _make_index('chunk', tenant_value='acme')
+        wrapper = idx._neptune_client()
+        from graphrag_toolkit.lexical_graph.storage.graph.multi_tenant_graph_store import (
+            MultiTenantGraphStore,
+        )
+        assert isinstance(wrapper, MultiTenantGraphStore)
+        assert wrapper.inner is client
+
+
+class TestAddEmbeddings:
+    def test_read_only_index_raises(self):
+        idx, _ = _make_index('chunk')
+        idx.writeable = False
+        with pytest.raises(IndexError, match='read-only'):
+            idx.add_embeddings([])
+
+    def test_executes_upsert_per_node(self):
+        idx, client = _make_index('chunk')
+        node_a = TextNode(id_='n1', text='hi', embedding=[0.1, 0.2])
+        node_b = TextNode(id_='n2', text='bye', embedding=[0.3, 0.4])
+        with patch.object(mod, 'embed_nodes', return_value={
+            'n1': [0.1, 0.2], 'n2': [0.3, 0.4],
+        }):
+            idx.add_embeddings([node_a, node_b])
+        assert client.execute_query_with_retry.call_count == 2
+
+
+class TestTopK:
+    def test_returns_result_field_from_each_row(self):
+        idx, client = _make_index('chunk')
+        client.execute_query.return_value = [
+            {'result': {'score': 0.9, 'chunk': {'chunkId': 'c1'}}},
+            {'result': {'score': 0.8, 'chunk': {'chunkId': 'c2'}}},
+        ]
+        with patch.object(mod, 'to_embedded_query') as q:
+            q.return_value = QueryBundle(query_str='q', embedding=[0.1, 0.2])
+            result = idx.top_k(QueryBundle('q'), top_k=2)
+        assert [r['chunk']['chunkId'] for r in result] == ['c1', 'c2']
+
+
+class TestGetEmbeddings:
+    def test_runs_one_query_per_unique_id(self):
+        idx, client = _make_index('chunk')
+        client.execute_query.return_value = [
+            {'result': {'embedding': [0.1], 'chunk': {'chunkId': 'c1'}}},
+        ]
+        idx.get_embeddings(['c1', 'c1', 'c2'])
+        assert client.execute_query.call_count == 2
+
+
+class TestDeferredMethods:
+    def test_update_versioning_returns_empty(self):
+        idx, _ = _make_index('chunk')
+        assert idx.update_versioning(0) == []
+
+    def test_enable_for_versioning_returns_empty(self):
+        idx, _ = _make_index('chunk')
+        assert idx.enable_for_versioning() == []
+
+    def test_delete_embeddings_returns_empty(self):
+        idx, _ = _make_index('chunk')
+        assert idx.delete_embeddings() == []

--- a/lexical-graph/tests/unit/storage/vector/test_s3_vector_helpers.py
+++ b/lexical-graph/tests/unit/storage/vector/test_s3_vector_helpers.py
@@ -1,0 +1,176 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the pure helpers in storage/vector/s3_vector_indexes."""
+
+import json
+
+import pytest
+from llama_index.core.schema import TextNode
+from llama_index.core.vector_stores.types import (
+    FilterCondition,
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+)
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.storage.vector.s3_vector_indexes import (
+    _node_to_s3_vector,
+    filter_config_to_s3_filters,
+    formatter_for_type,
+    node_to_s3_vector,
+    parse_metadata_filters_recursive,
+    s3_vector_to_dict,
+    to_s3_operator,
+    validate_metadata_limits,
+)
+
+
+def _eq(key, value):
+    return MetadataFilter(key=key, value=value, operator=FilterOperator.EQ)
+
+
+class TestToS3Operator:
+    @pytest.mark.parametrize('op,expected', [
+        (FilterOperator.EQ, '$eq'),
+        (FilterOperator.GT, '$gt'),
+        (FilterOperator.LT, '$lt'),
+        (FilterOperator.NE, '$ne'),
+        (FilterOperator.GTE, '$gte'),
+        (FilterOperator.LTE, '$lte'),
+        (FilterOperator.IS_EMPTY, '$exists'),
+    ])
+    def test_known_operators(self, op, expected):
+        operator, _ = to_s3_operator(op)
+        assert operator == expected
+
+    def test_unsupported_operator_raises(self):
+        with pytest.raises(ValueError, match='Unsupported filter operator'):
+            to_s3_operator(FilterOperator.TEXT_MATCH)
+
+
+class TestFormatterForType:
+    def test_text_wraps_in_double_quotes(self):
+        assert formatter_for_type('text')('hello') == '"hello"'
+
+    def test_numeric_passthrough(self):
+        assert formatter_for_type('int')(5) == 5
+        assert formatter_for_type('float')(2.5) == 2.5
+
+    def test_timestamp_wraps_in_quotes(self):
+        result = formatter_for_type('timestamp')('2024-01-15T10:30:00')
+        assert result.startswith('"2024-01-15')
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match='Unsupported type name'):
+            formatter_for_type('boolean')
+
+
+class TestParseMetadataFiltersRecursive:
+    def test_eq_filter_produces_eq_clause(self):
+        result = parse_metadata_filters_recursive(MetadataFilters(
+            filters=[_eq('category', 'tech')], condition=FilterCondition.AND,
+        ))
+        # The text formatter writes "tech" with embedded quotes; json.loads unwraps them.
+        assert result == {'$and': [{'source.metadata.category': {'$eq': 'tech'}}]}
+
+    def test_and_condition(self):
+        result = parse_metadata_filters_recursive(MetadataFilters(
+            filters=[_eq('a', 'x'), _eq('b', 'y')], condition=FilterCondition.AND,
+        ))
+        assert '$and' in result
+
+    def test_or_condition(self):
+        result = parse_metadata_filters_recursive(MetadataFilters(
+            filters=[_eq('a', 'x'), _eq('b', 'y')], condition=FilterCondition.OR,
+        ))
+        assert '$or' in result
+
+    def test_not_condition_with_bare_filter_raises(self):
+        filters = MetadataFilters(filters=[_eq('a', 'x')], condition=FilterCondition.NOT)
+        with pytest.raises(ValueError, match='Expected MetadataFilters'):
+            parse_metadata_filters_recursive(filters)
+
+    def test_unsupported_condition_raises(self):
+        filters = MetadataFilters(filters=[_eq('a', 'x')], condition=FilterCondition.NOT)
+        # NOT is not supported in S3-style filters, even with nested MetadataFilters.
+        inner = MetadataFilters(filters=[_eq('a', 'x')], condition=FilterCondition.AND)
+        outer = MetadataFilters(filters=[inner], condition=FilterCondition.NOT)
+        with pytest.raises(ValueError, match='Unsupported filters condition'):
+            parse_metadata_filters_recursive(outer)
+
+
+class TestFilterConfigToS3Filters:
+    def test_none_returns_none(self):
+        assert filter_config_to_s3_filters(None) is None
+
+    def test_no_source_filters_returns_none(self):
+        assert filter_config_to_s3_filters(FilterConfig()) is None
+
+    def test_passes_through_to_recursive(self):
+        config = FilterConfig(source_filters=MetadataFilters(
+            filters=[_eq('a', 'x')], condition=FilterCondition.AND,
+        ))
+        result = filter_config_to_s3_filters(config)
+        assert '$and' in result
+
+
+class TestNodeToS3Vector:
+    def test_extracts_versioning_into_top_level_keys(self):
+        node = TextNode(id_='n1', text='hi', metadata={
+            'source': {
+                'versioning': {'valid_from': 100, 'valid_to': 200},
+                'metadata': {'category': 'tech'},
+            },
+        })
+        result = node_to_s3_vector(node, [0.1, 0.2])
+        meta = result['metadata']
+        assert meta['source.versioning.valid_from'] == 100
+        assert meta['source.versioning.valid_to'] == 200
+        assert meta['source.metadata.category'] == 'tech'
+        assert result['key'] == 'n1'
+        assert result['data']['float32'] == [0.1, 0.2]
+
+    def test_missing_versioning_uses_default_bounds(self):
+        result = _node_to_s3_vector('id', 'text', [0.0], {})
+        meta = result['metadata']
+        # Default valid_from is TIMESTAMP_LOWER_BOUND, valid_to is TIMESTAMP_UPPER_BOUND.
+        assert isinstance(meta['source.versioning.valid_from'], int)
+        assert isinstance(meta['source.versioning.valid_to'], int)
+
+
+class TestS3VectorToDict:
+    def test_round_trip_recovers_versioning_and_metadata(self):
+        node = TextNode(id_='n1', text='hi', metadata={
+            'source': {
+                'versioning': {'valid_from': 100, 'valid_to': 200},
+                'metadata': {'category': 'tech'},
+            },
+        })
+        s3 = node_to_s3_vector(node, [0.1, 0.2])
+        out = s3_vector_to_dict(s3)
+        assert out['id'] == 'n1'
+        assert out['embedding'] == [0.1, 0.2]
+        assert out['source']['versioning']['valid_from'] == 100
+        assert out['source']['metadata']['category'] == 'tech'
+
+    def test_handles_missing_metadata_key(self):
+        s3 = {'key': 'n1', 'data': {}, 'metadata': {}}
+        out = s3_vector_to_dict(s3)
+        assert out['id'] == 'n1'
+        assert out['source']['metadata'] == {}
+
+
+class TestValidateMetadataLimits:
+    def test_non_dict_raises_type_error(self):
+        with pytest.raises(TypeError):
+            validate_metadata_limits([], max_tags=50, vector_id='n1')
+
+    def test_under_limit_passes(self):
+        validate_metadata_limits({'k': 'v'}, max_tags=50, vector_id='n1')
+
+    def test_over_limit_raises_value_error(self):
+        meta = {f'k{i}': i for i in range(60)}
+        with pytest.raises(ValueError):
+            validate_metadata_limits(meta, max_tags=50, vector_id='n1')

--- a/lexical-graph/tests/unit/storage/vector/test_vector_stores.py
+++ b/lexical-graph/tests/unit/storage/vector/test_vector_stores.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for VectorStore base + MultiTenantVectorStore + ReadOnlyVectorStore."""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph import TenantId
+from graphrag_toolkit.lexical_graph.storage.vector.dummy_vector_index import (
+    DummyVectorIndex,
+)
+from graphrag_toolkit.lexical_graph.storage.vector.multi_tenant_vector_store import (
+    MultiTenantVectorStore,
+)
+from graphrag_toolkit.lexical_graph.storage.vector.read_only_vector_store import (
+    ReadOnlyVectorStore,
+)
+from graphrag_toolkit.lexical_graph.storage.vector.vector_store import VectorStore
+
+
+class TestVectorStore:
+    def test_unknown_index_name_raises(self):
+        store = VectorStore()
+        with pytest.raises(ValueError, match='Invalid index name'):
+            store.get_index('bogus')
+
+    def test_missing_known_index_returns_dummy(self):
+        store = VectorStore()
+        result = store.get_index('chunk')
+        assert isinstance(result, DummyVectorIndex)
+
+    def test_registered_index_is_returned(self):
+        index = DummyVectorIndex(index_name='chunk')
+        store = VectorStore(indexes={'chunk': index})
+        assert store.get_index('chunk') is index
+
+    def test_all_indexes_returns_registered_values(self):
+        a = DummyVectorIndex(index_name='chunk')
+        b = DummyVectorIndex(index_name='statement')
+        store = VectorStore(indexes={'chunk': a, 'statement': b})
+        result = store.all_indexes()
+        assert len(result) == 2
+        assert a in result and b in result
+
+    def test_context_manager_yields_self(self):
+        store = VectorStore()
+        with store as ctx:
+            assert ctx is store
+
+
+class TestMultiTenantVectorStore:
+    def test_wrap_returns_existing_wrapper_unchanged(self):
+        inner = VectorStore()
+        existing = MultiTenantVectorStore(inner=inner, tenant_id=TenantId(value='a'))
+        result = MultiTenantVectorStore.wrap(existing, TenantId(value='b'))
+        assert result is existing
+
+    def test_wrap_wraps_plain_store(self):
+        inner = VectorStore()
+        wrapped = MultiTenantVectorStore.wrap(inner, TenantId(value='acme'))
+        assert isinstance(wrapped, MultiTenantVectorStore)
+        assert wrapped.inner is inner
+
+    def test_get_index_stamps_tenant_id(self):
+        index = DummyVectorIndex(index_name='chunk')
+        inner = VectorStore(indexes={'chunk': index})
+        wrapped = MultiTenantVectorStore(inner=inner, tenant_id=TenantId(value='acme'))
+        out = wrapped.get_index('chunk')
+        assert out.tenant_id.value == 'acme'
+
+    def test_all_indexes_returns_tenant_stamped_indexes(self):
+        a = DummyVectorIndex(index_name='chunk')
+        b = DummyVectorIndex(index_name='statement')
+        inner = VectorStore(indexes={'chunk': a, 'statement': b})
+        wrapped = MultiTenantVectorStore(inner=inner, tenant_id=TenantId(value='acme'))
+        result = wrapped.all_indexes()
+        assert len(result) == 2
+        assert all(idx.tenant_id.value == 'acme' for idx in result)
+
+
+class TestReadOnlyVectorStore:
+    def test_wrap_returns_existing_wrapper_unchanged(self):
+        inner = VectorStore()
+        existing = ReadOnlyVectorStore(inner=inner)
+        result = ReadOnlyVectorStore.wrap(existing)
+        assert result is existing
+
+    def test_wrap_wraps_plain_store(self):
+        inner = VectorStore()
+        wrapped = ReadOnlyVectorStore.wrap(inner)
+        assert isinstance(wrapped, ReadOnlyVectorStore)
+
+    def test_get_index_marks_index_not_writeable(self):
+        index = DummyVectorIndex(index_name='chunk')
+        index.writeable = True
+        inner = VectorStore(indexes={'chunk': index})
+        wrapped = ReadOnlyVectorStore(inner=inner)
+        out = wrapped.get_index('chunk')
+        assert out.writeable is False
+
+    def test_all_indexes_marks_each_not_writeable(self):
+        a = DummyVectorIndex(index_name='chunk')
+        b = DummyVectorIndex(index_name='statement')
+        a.writeable = True
+        b.writeable = True
+        inner = VectorStore(indexes={'chunk': a, 'statement': b})
+        wrapped = ReadOnlyVectorStore(inner=inner)
+        for idx in wrapped.all_indexes():
+            assert idx.writeable is False

--- a/lexical-graph/tests/unit/utils/test_bedrock_utils.py
+++ b/lexical-graph/tests/unit/utils/test_bedrock_utils.py
@@ -1,0 +1,169 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for utils/bedrock_utils."""
+
+import io
+import json
+import pickle
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.utils import bedrock_utils
+from graphrag_toolkit.lexical_graph.utils.bedrock_utils import (
+    Nova2MultimodalEmbedding,
+    _create_retry_decorator,
+)
+
+
+def _embedder(client=None, **kwargs):
+    e = Nova2MultimodalEmbedding(
+        model_name='amazon.nova-2-multimodal-embeddings-v1:0', **kwargs,
+    )
+    if client is not None:
+        e._client = client
+    return e
+
+
+def _stub_response(embedding):
+    body = io.BytesIO(json.dumps({'embeddings': [{'embedding': embedding}]}).encode())
+    return {'body': body}
+
+
+class TestBuildRequestBody:
+    def test_includes_default_params(self):
+        body = _embedder()._build_request_body('hello')
+        assert body['taskType'] == 'SINGLE_EMBEDDING'
+        assert body['singleEmbeddingParams']['embeddingDimension'] == 3072
+        assert body['singleEmbeddingParams']['embeddingPurpose'] == 'TEXT_RETRIEVAL'
+        assert body['singleEmbeddingParams']['text']['truncationMode'] == 'END'
+        assert body['singleEmbeddingParams']['text']['value'] == 'hello'
+
+    def test_respects_custom_dimensions_and_purpose(self):
+        body = _embedder(
+            embed_dimensions=1024, embed_purpose='CLASSIFICATION', truncation_mode='NONE',
+        )._build_request_body('x')
+        assert body['singleEmbeddingParams']['embeddingDimension'] == 1024
+        assert body['singleEmbeddingParams']['embeddingPurpose'] == 'CLASSIFICATION'
+        assert body['singleEmbeddingParams']['text']['truncationMode'] == 'NONE'
+
+
+class TestIsRetryableError:
+    @pytest.mark.parametrize(
+        'name',
+        ['ThrottlingException', 'ServiceUnavailableException', 'InternalServerException',
+         'ServiceException', 'ModelErrorException'],
+    )
+    def test_named_retryable_exceptions(self, name):
+        err = type(name, (Exception,), {})('boom')
+        assert _embedder()._is_retryable_error(err) is True
+
+    @pytest.mark.parametrize(
+        'msg', ['throttling, try later', 'Service unavailable', 'internal server error',
+                'try your request again later', 'unexpected error during processing'],
+    )
+    def test_message_matches_transient_keywords(self, msg):
+        assert _embedder()._is_retryable_error(RuntimeError(msg)) is True
+
+    def test_unrelated_error_not_retryable(self):
+        assert _embedder()._is_retryable_error(ValueError('bad input')) is False
+
+
+class TestGetEmbedding:
+    def test_empty_text_raises_value_error(self):
+        with pytest.raises(ValueError, match='empty or whitespace'):
+            _embedder()._get_embedding('')
+
+    def test_whitespace_only_text_raises_value_error(self):
+        with pytest.raises(ValueError, match='empty or whitespace'):
+            _embedder()._get_embedding('   \n\t')
+
+    def test_returns_first_embedding_from_response(self):
+        client = MagicMock()
+        client.invoke_model.return_value = _stub_response([0.1, 0.2, 0.3])
+        result = _embedder(client=client)._get_embedding('hi')
+        assert result == [0.1, 0.2, 0.3]
+
+    def test_empty_embeddings_array_returns_empty_list(self):
+        client = MagicMock()
+        body = io.BytesIO(json.dumps({'embeddings': []}).encode())
+        client.invoke_model.return_value = {'body': body}
+        result = _embedder(client=client)._get_embedding('hi')
+        assert result == []
+
+    def test_non_retryable_error_propagates(self):
+        client = MagicMock()
+        client.invoke_model.side_effect = ValueError('bad request')
+        with pytest.raises(ValueError):
+            _embedder(client=client)._get_embedding('hi')
+
+    def test_retryable_error_then_success(self):
+        client = MagicMock()
+        client.invoke_model.side_effect = [
+            RuntimeError('ThrottlingException - slow down'),
+            _stub_response([1.0]),
+        ]
+        with patch.object(bedrock_utils, 'time') as mock_time:
+            mock_time.sleep = MagicMock()
+            result = _embedder(client=client)._get_embedding('hi')
+        assert result == [1.0]
+        assert client.invoke_model.call_count == 2
+
+    def test_exhausted_retries_reraises_last_error(self):
+        client = MagicMock()
+        client.invoke_model.side_effect = RuntimeError('ThrottlingException')
+        with patch.object(bedrock_utils, 'time') as mock_time:
+            mock_time.sleep = MagicMock()
+            with pytest.raises(RuntimeError, match='ThrottlingException'):
+                _embedder(client=client)._get_embedding('hi')
+        assert client.invoke_model.call_count == bedrock_utils.MAX_RETRIES
+
+
+class TestEmbeddingApi:
+    def test_get_text_embedding_delegates(self):
+        client = MagicMock()
+        client.invoke_model.return_value = _stub_response([0.5])
+        result = _embedder(client=client)._get_text_embedding('q')
+        assert result == [0.5]
+
+    def test_get_query_embedding_delegates(self):
+        client = MagicMock()
+        client.invoke_model.return_value = _stub_response([0.7])
+        result = _embedder(client=client)._get_query_embedding('q')
+        assert result == [0.7]
+
+
+class TestClassName:
+    def test_returns_class_name(self):
+        assert Nova2MultimodalEmbedding.class_name() == 'Nova2MultimodalEmbedding'
+
+
+class TestPickleSupport:
+    def test_client_excluded_from_pickle(self):
+        e = _embedder(client=MagicMock())
+        state = e.__getstate__()
+        private = state.get('__pydantic_private__', {})
+        # Parent __getstate__ may strip _client; either way the live client is gone.
+        assert private.get('_client') in (None,)
+
+    def test_unpickle_resets_client(self):
+        e = _embedder(client=MagicMock())
+        restored = pickle.loads(pickle.dumps(e))
+        assert restored._client is None
+
+
+class TestCreateRetryDecorator:
+    def test_returns_callable_with_attached_retry(self):
+        class _ClientExceptions:
+            ThrottlingException = type('ThrottlingException', (Exception,), {})
+            InternalServerException = type('InternalServerException', (Exception,), {})
+            ServiceUnavailableException = type('ServiceUnavailableException', (Exception,), {})
+            ModelTimeoutException = type('ModelTimeoutException', (Exception,), {})
+            ModelErrorException = type('ModelErrorException', (Exception,), {})
+
+        client = MagicMock()
+        client.exceptions = _ClientExceptions()
+
+        decorator = _create_retry_decorator(client, max_retries=2)
+        assert callable(decorator)

--- a/lexical-graph/tests/unit/utils/test_llm_cache.py
+++ b/lexical-graph/tests/unit/utils/test_llm_cache.py
@@ -141,3 +141,110 @@ class TestLLMCacheConfiguration:
         assert cache.enable_cache == True
         assert cache.verbose_prompt == True
         assert cache.verbose_response == True
+
+
+def _llm_with_spy(response='hello'):
+    from llama_index.core.llms.mock import MockLLM
+    llm = MockLLM()
+    predict_mock = Mock(return_value=response)
+    stream_mock = Mock(return_value=iter([response]))
+    object.__setattr__(llm, 'predict', predict_mock)
+    object.__setattr__(llm, 'stream', stream_mock)
+    return llm
+
+
+class TestPredictNoCache:
+    def test_calls_llm_predict_and_returns_response(self):
+        from llama_index.core.prompts import PromptTemplate
+        llm = _llm_with_spy('answer')
+        cache = LLMCache(llm=llm, enable_cache=False)
+        result = cache.predict(PromptTemplate('Q: {q}'), q='ping')
+        assert result == 'answer'
+        llm.predict.assert_called_once()
+
+    def test_llm_exception_wrapped_in_model_error(self):
+        from llama_index.core.prompts import PromptTemplate
+        llm = _llm_with_spy()
+        llm.predict.side_effect = RuntimeError('upstream gone')
+        cache = LLMCache(llm=llm, enable_cache=False)
+        with pytest.raises(ModelError, match='upstream gone'):
+            cache.predict(PromptTemplate('q: {q}'), q='x')
+
+
+class TestPredictWithCache:
+    def test_cache_miss_writes_then_returns(self, tmp_path, monkeypatch):
+        from llama_index.core.prompts import PromptTemplate
+        monkeypatch.chdir(tmp_path)
+        llm = _llm_with_spy('fresh')
+        cache = LLMCache(llm=llm, enable_cache=True)
+
+        result = cache.predict(PromptTemplate('Q: {q}'), q='ping')
+
+        assert result == 'fresh'
+        cache_dir = tmp_path / 'cache' / 'llm'
+        assert cache_dir.exists()
+        files = list(cache_dir.glob('*.txt'))
+        assert len(files) == 1
+        assert files[0].read_text() == 'fresh'
+
+    def test_cache_hit_skips_llm(self, tmp_path, monkeypatch):
+        from llama_index.core.prompts import PromptTemplate
+        monkeypatch.chdir(tmp_path)
+        llm = _llm_with_spy('fresh')
+        cache = LLMCache(llm=llm, enable_cache=True)
+
+        cache.predict(PromptTemplate('Q: {q}'), q='ping')
+        llm.predict.reset_mock()
+
+        result = cache.predict(PromptTemplate('Q: {q}'), q='ping')
+        assert result == 'fresh'
+        llm.predict.assert_not_called()
+
+    def test_exclude_cache_keys_removed_from_hash(self, tmp_path, monkeypatch):
+        from llama_index.core.prompts import PromptTemplate
+        monkeypatch.chdir(tmp_path)
+        llm = _llm_with_spy('r1')
+        cache = LLMCache(llm=llm, enable_cache=True)
+
+        cache.predict(
+            PromptTemplate('Q: {q}'),
+            q='ping',
+            exclude_cache_keys=['session'],
+            session='abc',
+        )
+        llm.predict.reset_mock()
+        result = cache.predict(
+            PromptTemplate('Q: {q}'),
+            q='ping',
+            exclude_cache_keys=['session'],
+            session='xyz',
+        )
+        assert result == 'r1'
+        llm.predict.assert_not_called()
+
+    def test_cache_miss_llm_exception_wrapped_in_model_error(self, tmp_path, monkeypatch):
+        from llama_index.core.prompts import PromptTemplate
+        monkeypatch.chdir(tmp_path)
+        llm = _llm_with_spy()
+        llm.predict.side_effect = RuntimeError('boom')
+        cache = LLMCache(llm=llm, enable_cache=True)
+        with pytest.raises(ModelError, match='boom'):
+            cache.predict(PromptTemplate('Q: {q}'), q='x')
+
+
+class TestStream:
+    def test_stream_calls_llm_stream_and_returns_response(self):
+        from llama_index.core.prompts import PromptTemplate
+        llm = _llm_with_spy()
+        object.__setattr__(llm, 'stream', Mock(return_value=iter(['tok1', 'tok2'])))
+        cache = LLMCache(llm=llm, enable_cache=False)
+        result = cache.stream(PromptTemplate('Q: {q}'), q='x')
+        assert list(result) == ['tok1', 'tok2']
+
+    def test_stream_exception_wrapped_in_model_error(self):
+        from llama_index.core.prompts import PromptTemplate
+        llm = _llm_with_spy()
+        object.__setattr__(llm, 'stream', Mock(side_effect=RuntimeError('stream failure')))
+        cache = LLMCache(llm=llm, enable_cache=False)
+        with pytest.raises(ModelError, match='stream failure'):
+            cache.stream(PromptTemplate('Q: {q}'), q='x')

--- a/lexical-graph/tests/unit/utils/test_reranker_utils.py
+++ b/lexical-graph/tests/unit/utils/test_reranker_utils.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for utils/reranker_utils."""
+
+from unittest.mock import patch
+
+import numpy
+import pandas as pd
+
+from graphrag_toolkit.lexical_graph.utils import reranker_utils
+from graphrag_toolkit.lexical_graph.utils.reranker_utils import (
+    score_values_with_tfidf,
+    to_float,
+)
+
+
+class TestToFloat:
+    def test_numpy_float64_unwraps(self):
+        v = numpy.float64(1.5)
+        result = to_float(v)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_numpy_float32_unwraps(self):
+        v = numpy.float32(2.5)
+        result = to_float(v)
+        assert result == 2.5
+
+    def test_plain_float_passthrough(self):
+        assert to_float(3.14) == 3.14
+
+    def test_int_passthrough(self):
+        assert to_float(7) == 7
+
+
+def _matcher_df(rows):
+    """Build a DataFrame shaped like tm.matcher output: column 0 is the
+    original name, then triples (Lookup, Confidence, ???) per match."""
+    return pd.DataFrame(rows)
+
+
+class TestScoreValuesWithTfidf:
+    def test_value_error_falls_back_to_zero_scores(self):
+        with patch.object(reranker_utils.tm, 'matcher', side_effect=ValueError):
+            result = score_values_with_tfidf(['a', 'b'], ['x'])
+        assert result == {'a': 0.0, 'b': 0.0}
+
+    def test_value_error_drops_empty_padding(self):
+        # Internal code pads values_to_score with '' to reach max_num_values_to_score.
+        # The fallback excludes those padded blanks.
+        with patch.object(reranker_utils.tm, 'matcher', side_effect=ValueError):
+            result = score_values_with_tfidf(['a'], ['x', 'y'])
+        assert '' not in result
+        assert result == {'a': 0.0}
+
+    def test_results_sorted_descending_by_score(self):
+        df = _matcher_df([
+            ['x', 'a', 0.3, None],
+            ['y', 'b', 0.9, None],
+        ])
+        with patch.object(reranker_utils.tm, 'matcher', return_value=df):
+            result = score_values_with_tfidf(['a', 'b'], ['x', 'y'])
+        assert list(result.keys()) == ['b', 'a']
+        assert result['b'] > result['a']
+
+    def test_secondary_match_score_is_dampened(self):
+        # num_primary_match_values=1 means row 0 keeps full score, row 1 gets *0.9.
+        df = _matcher_df([
+            ['x', 'a', 1.0, None],
+            ['y', 'b', 1.0, None],
+        ])
+        with patch.object(reranker_utils.tm, 'matcher', return_value=df):
+            result = score_values_with_tfidf(
+                ['a', 'b'], ['x', 'y'], num_primary_match_values=1,
+            )
+        assert result['a'] == 1.0
+        assert result['b'] == 0.9
+
+    def test_zero_base_score_skips_multiplier(self):
+        df = _matcher_df([
+            ['x', 'a', 0.0, None],
+        ])
+        with patch.object(reranker_utils.tm, 'matcher', return_value=df):
+            result = score_values_with_tfidf(
+                ['a'], ['x'], num_primary_match_values=0,
+            )
+        assert result['a'] == 0.0
+
+    def test_repeated_value_averages_scores(self):
+        df = _matcher_df([
+            ['x', 'a', 0.4, None],
+            ['y', 'a', 0.8, None],
+        ])
+        with patch.object(reranker_utils.tm, 'matcher', return_value=df):
+            result = score_values_with_tfidf(['a'], ['x', 'y'])
+        import pytest
+        assert result['a'] == pytest.approx(0.6)

--- a/lexical-graph/tests/unit/utils/test_reranker_utils.py
+++ b/lexical-graph/tests/unit/utils/test_reranker_utils.py
@@ -96,3 +96,18 @@ class TestScoreValuesWithTfidf:
             result = score_values_with_tfidf(['a'], ['x', 'y'])
         import pytest
         assert result['a'] == pytest.approx(0.6)
+
+    def test_ranks_matching_content_higher_with_real_tfidf(self):
+        # End-to-end against the real tfidf_matcher backend (no mocks),
+        # confirming relevance ranking on plain English input.
+        values = [
+            'Python is a programming language',
+            'The weather is sunny today',
+        ]
+        match_values = ['Python programming']
+        result = score_values_with_tfidf(values, match_values)
+        assert (
+            result['Python is a programming language']
+            > result['The weather is sunny today']
+        )
+        assert result['The weather is sunny today'] == 0.0


### PR DESCRIPTION
## Description

Adds unit tests across the lexical-graph package and raises the CI coverage
gate to lock in the gain. Mostly tests, plus one small source fix in
`keyword_vss_provider`.

## Changes

* Full-suite coverage: 46.10% → 59.48%
* Tests: 1,235 → 1,644
* CI gate `--cov-fail-under` for `lexical-graph`: **45 → 56**
* One source fix: `KeywordVSSProvider._get_topic_content` was iterating each
  topic's joined statement string character-by-character and returning a list
  of single characters; now appends one content string per topic and skips
  topics with no statements.

### Modules covered by new tests

* **retrieval/utils**: `statement_utils`, `chunk_utils`, `entity_utils`,
  `vector_utils`, `query_decomposition`
* **retrieval/processors**: `zero_scores`, `truncate_statements`,
  `update_chunk_metadata`, `rerank_statements`
* **retrieval/query_context**: `query_mode`, `keyword_provider`,
  `keyword_nlp_provider`, `keyword_vss_provider`, `entity_provider`,
  `entity_from_top_statement_provider`, `entity_vss_provider`,
  `entity_context_provider`
* **retrieval/retrievers**: `query_mode_retriever`, `chunk_cosine_search`,
  `chunk_based_search`, `topic_based_search`, `entity_based_search`,
  `entity_network_search`, `entity_context_search`,
  `composite_traversal_based_retriever`, `chunk_based_semantic_search`,
  `semantic_chunk_beam_search`, `traversal_based_base_retriever`
* **retrieval/summary**: `graph_summary`
* **storage/graph**: `multi_tenant_graph_store`, `neptune_graph_stores`
  (helpers and factories), plus `graph_utils` (21.5% → 97.5%) and
  `query_tree` (25.6% → 100%)
* **storage/vector**: `vector_store`, `multi_tenant_vector_store`,
  `read_only_vector_store`, `neptune_vector_indexes`, `s3_vector_indexes`
  helpers
* **utils**: `reranker_utils`, `bedrock_utils`, `llm_cache`
  (predict / stream / cache paths)

External services (graph stores, LLMs, boto3 clients, embedding caches) are
mocked. No infrastructure is required to run the suite.

## Out of scope

* `pg_vector_indexes` and `opensearch_vector_indexes` (~485 statements) are
  not covered because `psycopg2-binary` and
  `llama-index-vector-stores-opensearch` are not in the test env. These
  would push coverage to ~62% once installable.
* `indexing/*` pipeline modules (~600 statements) are untouched.
* `visualisation/graph_notebook_visualisation` (212 statements) is
  notebook-only viz.

## Backward Compatibility

The `KeywordVSSProvider._get_topic_content` fix changes returned values from
a list of single characters to a list of per-topic content strings. Any
caller that relied on the previous broken shape would have been getting
unusable data; the corrected shape matches the method's docstring and the
rest of the keyword-provider contract.

The CI gate change is internal to this repo's pipeline and has no runtime
impact.

## Testing

Ran the full lexical-graph suite locally with the new 56% gate:

```
1644 passed, 9 warnings
Required test coverage of 56% reached. Total coverage: 59.48%
```

Matches the CI invocation (Python 3.12, `HYPOTHESIS_PROFILE=ci`, same
pytest invocation as `.github/workflows/lexical-graph-tests.yml`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
