### PR TITLE
[CHORE] Add triage_needed label to all new issues created

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
 title: "[BUG] "
-labels: ["bug", "triage_needed"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or enhancement
 title: "[FEATURE] "
-labels: ["enhancement", "triage_needed"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,21 @@
+name: Auto-label new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['triage_needed']
+            });


### PR DESCRIPTION
## Description
[CHORE] Add triage_needed label to all new issues via GitHub Actions workflow

## Changes
- Added a new GitHub Actions workflow (`auto-label-issues.yml`) that automatically applies the `triage_needed` label to all newly opened issues
- Removed `triage_needed` from the static labels in `bug_report.yml` and `feature_request.yml` issue templates to avoid duplication

## Problem
Previously, the `triage_needed` label was only applied to issues created through the bug report or feature request templates. Issues created without a template (e.g., blank issues) would not receive the label, making them easy to miss during triage.

Related issue (if any): N/A

## Testing
- [x] Tested manually (describe below)

Test: The `triage_needed` label will now be applied uniformly to all new issues regardless of how they are created.

## Checklist
- [x] Code follows existing style and conventions
- [x] License headers present on new files
- N/A Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.