### PR TITLE
[FIX] Validate s3_path and escape Cypher labels in Neptune graph stores

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -3,6 +3,7 @@
 
 import boto3
 import os
+import re
 from urllib.parse import urlparse
 import json
 import logging
@@ -16,6 +17,32 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 
 logger = logging.getLogger(__name__)
+
+# CALL neptune.load() can't take bound parameters; allowlist s3_path to
+# block Cypher injection.
+_S3_PATH_PATTERN = re.compile(r'^s3://[a-zA-Z0-9.\-_/+=!@()*]+$')
+
+
+def _validate_s3_path(s3_path):
+    if s3_path is None:
+        return
+    if not _S3_PATH_PATTERN.match(s3_path):
+        raise ValueError(
+            f"Invalid s3_path format: '{s3_path}'. "
+            "Must be a valid S3 URI (s3://bucket/key)."
+        )
+
+
+# Escape backticks before a label is interpolated into a backtick-quoted Cypher
+# identifier. Doubling is Cypher's escape rule; without it a label containing a
+# backtick could break out of the identifier and inject Cypher.
+def _escape_cypher_label(label):
+    if not isinstance(label, str):
+        raise TypeError(
+            f'Cypher label must be a string, got {type(label).__name__}'
+        )
+    return label.replace('`', '``')
+
 
 class BaseNeptuneGraphStore(GraphStore):
     def _upload_to_s3(self, s3_path, local_path=None, file_contents=None):
@@ -82,7 +109,7 @@ class BaseNeptuneGraphStore(GraphStore):
             '''
         else:
             query = f'''
-                    MATCH (n:`{node_type}`)
+                    MATCH (n:`{_escape_cypher_label(node_type)}`)
                     '''
         if self.node_type_to_property_mapping:
             query += '''
@@ -265,6 +292,7 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
         """
 
         assert format in ['NTRIPLES', 'CSV', 'OPEN_CYPHER'], "format must be either 'NTRIPLES' or 'CSV' or 'OPEN_CYPHER'"
+        _validate_s3_path(s3_path)
 
         if csv_file is not None:
             assert s3_path is not None, "s3 path should be passed with local csv path for data import"
@@ -364,7 +392,7 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
         ids, texts_to_embed = ({}, {}) if group_by_node_label else ([], [])
         for node_type, node_properties in node_embedding_text_props.items():
             gather_nodes_query = f'''
-                                MATCH (n:`{node_type}`)
+                                MATCH (n:`{_escape_cypher_label(node_type)}`)
                                 RETURN properties(n) as properties, ID(n) as node
                                 '''
             response = self.execute_query(gather_nodes_query)
@@ -419,6 +447,7 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         """
 
         assert format in ['CSV', 'OPEN_CYPHER'], "format must be either or 'CSV' or 'OPEN_CYPHER'"
+        _validate_s3_path(s3_path)
 
         if csv_file is not None:
             assert s3_path is not None, "s3 path should be passed with local csv path for data import"
@@ -452,8 +481,8 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         """
         propertyGraphSummary["edgeLabelDetails"] = {}
         for label in propertyGraphSummary["edgeLabels"]:
-            q = edge_properties_query.format(e_label=label)
-            data = {"label": label, "properties": self.execute_query(q)} 
+            q = edge_properties_query.format(e_label=_escape_cypher_label(label))
+            data = {"label": label, "properties": self.execute_query(q)}
             prop_types = {}
             for p in data["properties"]:
                 from typing import cast
@@ -482,7 +511,7 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         n_labels = propertyGraphSummary["nodeLabels"]
         propertyGraphSummary["nodeLabelDetails"] = {}
         for label in n_labels:
-            q = node_properties_query.format(n_label=label)
+            q = node_properties_query.format(n_label=_escape_cypher_label(label))
             data = {"label": label, "properties": self.execute_query(q)}
             prop_types = {}
             for p in data["properties"]:
@@ -507,10 +536,9 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         RETURN DISTINCT labels(a) AS from, type(e) AS edge, labels(b) AS to
         LIMIT 10
         """
-        triple_template = "(:`{a}`)-[:`{e}`]->(:`{b}`)"
         triple_schema = []
-        for label in propertyGraphSummary["edgeLabels"]:     
-            q = triple_query.format(e_label=label)
+        for label in propertyGraphSummary["edgeLabels"]:
+            q = triple_query.format(e_label=_escape_cypher_label(label))
             data = self.execute_query(q)
             for d in data:         
                 triple = {}

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -13,7 +13,9 @@ import json
 from graphrag_toolkit.byokg_rag.graphstore.neptune import (
     NeptuneAnalyticsGraphStore,
     NeptuneDBGraphStore,
-    BaseNeptuneGraphStore
+    BaseNeptuneGraphStore,
+    _validate_s3_path,
+    _escape_cypher_label,
 )
 
 
@@ -1236,3 +1238,577 @@ class TestNeptuneReadOnlyPropagation:
         call_args = mock_neptune_data_client.execute_open_cypher_query.call_args[1]
         assert 'readOnly' not in call_args
         assert call_args['openCypherQuery'] == "MATCH (n) RETURN n"
+
+
+class TestValidateS3Path:
+    """s3_path must be validated before interpolation into the
+    CALL neptune.load() Cypher string, which does not accept bound parameters."""
+
+    def test_none_is_allowed_through(self):
+        # Existing callers may pass None and rely on later assertions.
+        _validate_s3_path(None)
+
+    def test_accepts_canonical_s3_uri(self):
+        _validate_s3_path('s3://my-bucket/path/to/file.csv')
+
+    @pytest.mark.parametrize('path', [
+        pytest.param('s3://my-bucket/year=2024/month=01/data.csv',
+                     id='hive-partition'),
+        pytest.param('s3://my-bucket/path/file+name.csv',
+                     id='plus-in-filename'),
+        pytest.param('s3://my-bucket/data!@()*.csv',
+                     id='other-valid-key-chars'),
+    ])
+    def test_accepts_valid_s3_key_characters(self, path):
+        # =, +, !, @, (, ), * are valid S3 key characters and cannot break out
+        # of a single-quoted Cypher literal, so they must not be rejected.
+        _validate_s3_path(path)
+
+    def test_rejects_quote_breakout_payload(self):
+        payload = "s3://b/k', region:'x'}) DETACH DELETE n //"
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            _validate_s3_path(payload)
+
+    def test_rejects_missing_scheme(self):
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            _validate_s3_path('my-bucket/key.csv')
+
+    def test_rejects_wrong_scheme(self):
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            _validate_s3_path('https://my-bucket/key.csv')
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            _validate_s3_path('')
+
+
+class TestReadFromCsvValidatesS3Path:
+    """Both read_from_csv overloads must reject malicious s3_path
+    before any side effect (S3 upload, Cypher execution, loader job)."""
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_analytics_rejects_injection_before_execute(
+        self, mock_session, mock_neptune_client, mock_s3_client,
+    ):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client,
+        }[service]
+
+        store = NeptuneAnalyticsGraphStore(
+            graph_identifier='test-graph-id', region='us-west-2',
+        )
+        payload = "s3://b/k', region:'x'}) DETACH DELETE n //"
+
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            store.read_from_csv(s3_path=payload)
+
+        mock_neptune_client.execute_query.assert_not_called()
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_db_rejects_injection_before_loader_job(
+        self, mock_session, mock_neptune_data_client, mock_s3_client,
+    ):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client,
+        }[service]
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://example.cluster-xyz.us-east-1.neptune.amazonaws.com:8182',
+            region='us-east-1',
+        )
+        payload = "s3://b/k'; DROP DATABASE;"
+
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            store.read_from_csv(s3_path=payload)
+
+        mock_neptune_data_client.start_loader_job.assert_not_called()
+
+
+# Red-state proof: if the validator does not fire, the attacker payload
+# reaches the Cypher string sent to execute_query. Pins the mitigation to
+# the validator and catches a future refactor that drops the call.
+@patch('graphrag_toolkit.byokg_rag.graphstore.neptune._validate_s3_path')
+@patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+def test_payload_reaches_execute_query_when_validator_disabled(
+    mock_session, mock_validator, mock_neptune_client, mock_s3_client,
+):
+    mock_validator.return_value = None
+    mock_session_instance = Mock()
+    mock_session.return_value = mock_session_instance
+    mock_session_instance.client.side_effect = lambda service, **kwargs: {
+        'neptune-graph': mock_neptune_client,
+        's3': mock_s3_client,
+    }[service]
+    mock_neptune_client.execute_query.return_value = {
+        'payload': Mock(read=lambda: json.dumps({'results': []}).encode()),
+    }
+
+    store = NeptuneAnalyticsGraphStore(
+        graph_identifier='test-graph-id', region='us-west-2',
+    )
+    payload = "s3://b/k', region:'x'}) DETACH DELETE n //"
+
+    store.read_from_csv(s3_path=payload)
+
+    sent_query = mock_neptune_client.execute_query.call_args[1]['queryString']
+    assert 'DETACH DELETE n' in sent_query
+
+
+@patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+def test_valid_s3_uri_reaches_execute_query_unchanged(
+    mock_session, mock_neptune_client, mock_s3_client,
+):
+    """The guard must let canonical S3 URIs through to execute_query."""
+    mock_session_instance = Mock()
+    mock_session.return_value = mock_session_instance
+    mock_session_instance.client.side_effect = lambda service, **kwargs: {
+        'neptune-graph': mock_neptune_client,
+        's3': mock_s3_client,
+    }[service]
+    mock_neptune_client.execute_query.return_value = {
+        'payload': Mock(read=lambda: json.dumps({'results': []}).encode()),
+    }
+
+    store = NeptuneAnalyticsGraphStore(
+        graph_identifier='test-graph-id', region='us-west-2',
+    )
+
+    store.read_from_csv(s3_path='s3://my-bucket/path/to/file.csv')
+
+    mock_neptune_client.execute_query.assert_called_once()
+    sent_query = mock_neptune_client.execute_query.call_args[1]['queryString']
+    assert 's3://my-bucket/path/to/file.csv' in sent_query
+
+
+@patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+def test_upload_not_invoked_when_s3_path_is_malicious(
+    mock_session, mock_neptune_client, mock_s3_client,
+):
+    """Validator runs before _upload_to_s3, so an attacker cannot
+    cause a write to an attacker-shaped key by supplying csv_file too."""
+    mock_session_instance = Mock()
+    mock_session.return_value = mock_session_instance
+    mock_session_instance.client.side_effect = lambda service, **kwargs: {
+        'neptune-graph': mock_neptune_client,
+        's3': mock_s3_client,
+    }[service]
+
+    store = NeptuneAnalyticsGraphStore(
+        graph_identifier='test-graph-id', region='us-west-2',
+    )
+
+    with patch.object(store, '_upload_to_s3') as mock_upload:
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            store.read_from_csv(
+                csv_file='/tmp/local.csv',
+                s3_path="s3://b/k', DETACH DELETE n //",
+            )
+        mock_upload.assert_not_called()
+
+    mock_neptune_client.execute_query.assert_not_called()
+
+
+@patch('graphrag_toolkit.byokg_rag.graphstore.neptune.NeptuneAnalyticsGraphStoreIndex')
+@patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+def test_as_embedding_index_rejects_malicious_save_location(
+    mock_session, mock_index_cls, mock_neptune_client, mock_s3_client,
+):
+    """Indirect path through as_embedding_index also hits the guard
+    once it dispatches into read_from_csv."""
+    mock_session_instance = Mock()
+    mock_session.return_value = mock_session_instance
+    mock_session_instance.client.side_effect = lambda service, **kwargs: {
+        'neptune-graph': mock_neptune_client,
+        's3': mock_s3_client,
+    }[service]
+
+    store = NeptuneAnalyticsGraphStore(
+        graph_identifier='test-graph-id', region='us-west-2',
+    )
+
+    with patch.object(store, '_s3_file_exists', return_value=True):
+        with pytest.raises(ValueError, match='Invalid s3_path'):
+            store.as_embedding_index(
+                embedding=Mock(),
+                embedding_s3_save_location="s3://b/k'; DROP",
+            )
+
+    mock_neptune_client.execute_query.assert_not_called()
+
+
+@pytest.mark.parametrize('payload', [
+    pytest.param('s3://bucket/key\x00', id='null-byte'),
+    pytest.param('s3://bucket/key\nDETACH', id='newline-injection'),
+    pytest.param('s3://bucket/key%27', id='url-encoded-quote'),
+    pytest.param('s3://bucket/key’', id='unicode-curly-quote'),
+    pytest.param('s3://bucket/key ', id='trailing-space'),
+    pytest.param('S3://bucket/key', id='uppercase-scheme'),
+])
+def test_validator_rejects_diverse_payloads(payload):
+    """Payload-diversity coverage for the allowlist regex."""
+    with pytest.raises(ValueError, match='Invalid s3_path'):
+        _validate_s3_path(payload)
+
+
+class TestEscapeCypherLabel:
+    """Unit tests for the label-escaping helper."""
+
+    def test_plain_label_unchanged(self):
+        assert _escape_cypher_label('Person') == 'Person'
+
+    def test_empty_string_unchanged(self):
+        assert _escape_cypher_label('') == ''
+
+    @pytest.mark.parametrize('bad', [
+        pytest.param(None, id='none'),
+        pytest.param(123, id='int'),
+        pytest.param(b'Person', id='bytes'),
+        pytest.param(['Person'], id='list'),
+    ])
+    def test_non_string_raises_type_error(self, bad):
+        with pytest.raises(TypeError):
+            _escape_cypher_label(bad)
+
+    @pytest.mark.parametrize('raw,escaped', [
+        pytest.param('a`b', 'a``b', id='backtick-in-middle'),
+        pytest.param('`evil', '``evil', id='backtick-at-start'),
+        pytest.param('evil`', 'evil``', id='backtick-at-end'),
+        pytest.param('a``b', 'a````b', id='already-doubled'),
+        pytest.param('`) DETACH DELETE n //', '``) DETACH DELETE n //',
+                     id='full-cypher-breakout'),
+        pytest.param('```', '``````', id='triple-backtick'),
+    ])
+    def test_backticks_are_doubled(self, raw, escaped):
+        assert _escape_cypher_label(raw) == escaped
+
+
+def _captured_queries(mock_client):
+    """Return every cypher string passed to execute_open_cypher_query."""
+    return [
+        call.kwargs.get('openCypherQuery') or call.args[0]
+        for call in mock_client.execute_open_cypher_query.call_args_list
+    ]
+
+
+# Breakout payload: closes the backtick-quoted label and appends a destructive
+# clause if the escape does not fire. The "evil" prefix keeps the escaped
+# signature ("evil``") distinct from the raw one ("evil`") in assertions.
+_BREAKOUT_LABEL = 'evil`) MATCH (x) DETACH DELETE x //'
+_RAW_BREAKOUT_FRAGMENT = 'evil`) MATCH'
+_ESCAPED_BREAKOUT_FRAGMENT = 'evil``) MATCH'
+
+
+class TestSchemaDiscoveryEscapesLabels:
+    """Each schema-discovery method must escape backticks in dynamic labels
+    before sending Cypher to Neptune. Covers all three sinks."""
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def _store(self, mock_session, mock_neptune_data_client, mock_s3_client):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client,
+        }[service]
+        return NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2',
+        )
+
+    def test_get_edge_properties_escapes_backtick(
+        self, mock_neptune_data_client, mock_s3_client,
+    ):
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [],
+        }
+        store = self._store(
+            mock_neptune_data_client=mock_neptune_data_client,
+            mock_s3_client=mock_s3_client,
+        )
+        summary = {'edgeLabels': [_BREAKOUT_LABEL]}
+
+        store._get_edge_properties(summary, {'str': 'STRING'})
+
+        sent = _captured_queries(mock_neptune_data_client)
+        assert len(sent) == 1
+        assert _ESCAPED_BREAKOUT_FRAGMENT in sent[0]
+        assert _RAW_BREAKOUT_FRAGMENT not in sent[0]
+        # Raw label is kept as the dict key, not in the cypher.
+        assert _BREAKOUT_LABEL in summary['edgeLabelDetails']
+
+    def test_get_node_properties_escapes_backtick(
+        self, mock_neptune_data_client, mock_s3_client,
+    ):
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [],
+        }
+        store = self._store(
+            mock_neptune_data_client=mock_neptune_data_client,
+            mock_s3_client=mock_s3_client,
+        )
+        summary = {'nodeLabels': [_BREAKOUT_LABEL]}
+
+        store._get_node_properties(summary, {'str': 'STRING'})
+
+        sent = _captured_queries(mock_neptune_data_client)
+        assert len(sent) == 1
+        assert _ESCAPED_BREAKOUT_FRAGMENT in sent[0]
+        assert _RAW_BREAKOUT_FRAGMENT not in sent[0]
+        assert _BREAKOUT_LABEL in summary['nodeLabelDetails']
+
+    def test_get_triples_escapes_backtick(
+        self, mock_neptune_data_client, mock_s3_client,
+    ):
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [],
+        }
+        store = self._store(
+            mock_neptune_data_client=mock_neptune_data_client,
+            mock_s3_client=mock_s3_client,
+        )
+        summary = {'edgeLabels': [_BREAKOUT_LABEL]}
+
+        store._get_triples(summary)
+
+        sent = _captured_queries(mock_neptune_data_client)
+        assert len(sent) == 1
+        assert _ESCAPED_BREAKOUT_FRAGMENT in sent[0]
+        assert _RAW_BREAKOUT_FRAGMENT not in sent[0]
+
+    def test_plain_label_flows_unchanged(
+        self, mock_neptune_data_client, mock_s3_client,
+    ):
+        """Positive path: a canonical label reaches the cypher in
+        backtick-quoted form without modification."""
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [],
+        }
+        store = self._store(
+            mock_neptune_data_client=mock_neptune_data_client,
+            mock_s3_client=mock_s3_client,
+        )
+        summary = {'nodeLabels': ['Person']}
+
+        store._get_node_properties(summary, {'str': 'STRING'})
+
+        sent = _captured_queries(mock_neptune_data_client)
+        assert '`Person`' in sent[0]
+
+
+class TestSchemaDiscoveryIndirectCaller:
+    """get_schema -> _refresh_schema dispatches into all three sinks. The
+    guard must fire on the public entry point, not just the helpers."""
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_get_schema_escapes_backtick_in_every_sink(
+        self, mock_session, mock_neptune_data_client, mock_s3_client,
+    ):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client,
+        }[service]
+
+        mock_neptune_data_client.get_propertygraph_summary.return_value = {
+            'payload': {
+                'graphSummary': {
+                    'nodeLabels': [_BREAKOUT_LABEL],
+                    'edgeLabels': [_BREAKOUT_LABEL],
+                },
+            },
+        }
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [],
+        }
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2',
+        )
+
+        store.get_schema()
+
+        sent = _captured_queries(mock_neptune_data_client)
+        # _refresh_schema fans out to triples + node_properties + edge_properties.
+        assert len(sent) >= 3
+        for cypher in sent:
+            assert _ESCAPED_BREAKOUT_FRAGMENT in cypher
+            assert _RAW_BREAKOUT_FRAGMENT not in cypher
+
+
+class TestSchemaDiscoveryRedState:
+    """Red-state proof: with the escape helper patched to identity, the
+    breakout payload reaches execute_open_cypher_query unescaped. Pins the
+    mitigation to the helper and catches a future refactor that drops the
+    call."""
+
+    @patch(
+        'graphrag_toolkit.byokg_rag.graphstore.neptune._escape_cypher_label',
+        side_effect=lambda label: label,
+    )
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_payload_reaches_cypher_when_escape_disabled(
+        self, mock_session, mock_escape, mock_neptune_data_client, mock_s3_client,
+    ):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client,
+        }[service]
+        mock_neptune_data_client.execute_open_cypher_query.return_value = {
+            'results': [],
+        }
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2',
+        )
+        summary = {'edgeLabels': [_BREAKOUT_LABEL]}
+
+        store._get_edge_properties(summary, {'str': 'STRING'})
+
+        sent = _captured_queries(mock_neptune_data_client)
+        assert _RAW_BREAKOUT_FRAGMENT in sent[0]
+        assert _ESCAPED_BREAKOUT_FRAGMENT not in sent[0]
+        assert 'DETACH DELETE x' in sent[0]
+
+
+def _captured_analytics_queries(mock_client):
+    """Return every cypher string passed to the neptune-graph execute_query."""
+    return [
+        call.kwargs.get('queryString') or call.args[0]
+        for call in mock_client.execute_query.call_args_list
+    ]
+
+
+class TestAnalyticsLabelSinksEscapeBacktick:
+    """nodes() and get_node_text_for_embedding_input() also interpolate a
+    label into a backtick-quoted identifier. Both must escape it."""
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def _store(self, mock_session, mock_neptune_client, mock_s3_client):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client,
+        }[service]
+        return NeptuneAnalyticsGraphStore(
+            graph_identifier='test-graph-id',
+            region='us-west-2',
+        )
+
+    def test_nodes_escapes_backtick_in_node_type(
+        self, mock_neptune_client, mock_s3_client,
+    ):
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode()),
+        }
+        store = self._store(
+            mock_neptune_client=mock_neptune_client,
+            mock_s3_client=mock_s3_client,
+        )
+
+        store.nodes(node_type=_BREAKOUT_LABEL)
+
+        sent = _captured_analytics_queries(mock_neptune_client)
+        assert _ESCAPED_BREAKOUT_FRAGMENT in sent[0]
+        assert _RAW_BREAKOUT_FRAGMENT not in sent[0]
+
+    def test_get_node_text_for_embedding_escapes_backtick(
+        self, mock_neptune_client, mock_s3_client,
+    ):
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode()),
+        }
+        store = self._store(
+            mock_neptune_client=mock_neptune_client,
+            mock_s3_client=mock_s3_client,
+        )
+
+        ids, _ = store.get_node_text_for_embedding_input(
+            node_embedding_text_props={_BREAKOUT_LABEL: ['name']},
+            group_by_node_label=True,
+        )
+
+        sent = _captured_analytics_queries(mock_neptune_client)
+        assert _ESCAPED_BREAKOUT_FRAGMENT in sent[0]
+        assert _RAW_BREAKOUT_FRAGMENT not in sent[0]
+        # Raw label is kept as the dict key, not in the cypher.
+        assert _BREAKOUT_LABEL in ids
+
+    def test_nodes_plain_label_flows_unchanged(
+        self, mock_neptune_client, mock_s3_client,
+    ):
+        """Positive path: a canonical node_type reaches the cypher in
+        backtick-quoted form without modification."""
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode()),
+        }
+        store = self._store(
+            mock_neptune_client=mock_neptune_client,
+            mock_s3_client=mock_s3_client,
+        )
+
+        store.nodes(node_type='Person')
+
+        sent = _captured_analytics_queries(mock_neptune_client)
+        assert '`Person`' in sent[0]
+
+
+class TestNoUnescapedLabelSinks:
+    """Regression guard: every value interpolated into a backtick-quoted
+    identifier in neptune.py must route through _escape_cypher_label, inline in
+    an f-string or bound at a .format() call. A new unescaped sink fails CI.
+
+    Heuristic and line-based: the .format() check matches the placeholder name
+    against any binding in the file, so the per-sink behavioral tests above
+    remain the authoritative coverage."""
+
+    def test_every_backtick_label_sink_is_escaped(self):
+        import inspect
+        import re as _re
+        from graphrag_toolkit.byokg_rag.graphstore import neptune
+
+        source = inspect.getsource(neptune)
+        # A value interpolated inside a single backtick-quoted span:
+        #   `{expr}`  (f-string)  or  `{name}`  (.format placeholder)
+        sink_re = _re.compile(r'`[^`\n]*\{([^{}]+)\}[^`\n]*`')
+
+        offenders = []
+        sinks_seen = 0
+        for lineno, line in enumerate(source.splitlines(), 1):
+            if line.lstrip().startswith('#'):
+                continue
+            for match in sink_re.finditer(line):
+                sinks_seen += 1
+                inner = match.group(1).strip()
+                # f-string sink: helper applied inline.
+                if '_escape_cypher_label' in inner:
+                    continue
+                # .format placeholder: helper applied at the binding site,
+                # e.g. .format(e_label=_escape_cypher_label(label)).
+                bind_re = _re.compile(
+                    _re.escape(inner) + r'\s*=\s*_escape_cypher_label'
+                )
+                if bind_re.search(source):
+                    continue
+                offenders.append(f'{lineno}: {line.strip()}')
+
+        # Guard against a vacuous pass: the regex must still be finding sinks.
+        assert sinks_seen >= 5, (
+            f'Expected to find the known backtick-label sinks, saw '
+            f'{sinks_seen}. The sink regex may be stale.'
+        )
+        assert not offenders, (
+            'Value interpolated into a backtick-quoted identifier without '
+            '_escape_cypher_label:\n' + '\n'.join(offenders)
+        )

--- a/integration-tests/byokg.all
+++ b/integration-tests/byokg.all
@@ -1,2 +1,3 @@
 byokg_setup.LoadBYOKGGraph
 byokg_cypher_safety.CypherSafetyCheck
+byokg_cypher_safety.BYOKGCypherInjectionSafety

--- a/integration-tests/byokg.all
+++ b/integration-tests/byokg.all
@@ -1,3 +1,4 @@
 byokg_setup.LoadBYOKGGraph
 byokg_cypher_safety.CypherSafetyCheck
 byokg_cypher_safety.BYOKGCypherInjectionSafety
+byokg_cypher_safety.BYOKGS3PathInjectionSafety

--- a/integration-tests/byokg.short
+++ b/integration-tests/byokg.short
@@ -1,2 +1,4 @@
 byokg_setup.LoadBYOKGGraph
 byokg_cypher_safety.CypherSafetyCheck
+byokg_cypher_safety.BYOKGCypherInjectionSafety
+byokg_cypher_safety.BYOKGS3PathInjectionSafety

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
@@ -7,7 +7,11 @@ from typing import Dict, Any
 from graphrag_toolkit_tests.integration_test_base import IntegrationTestBase
 from graphrag_toolkit_tests.integration_test_handler import IntegrationTestHandler
 
-from graphrag_toolkit.byokg_rag.graphstore import NeptuneAnalyticsGraphStore
+from graphrag_toolkit.byokg_rag.graphstore import (
+    NeptuneAnalyticsGraphStore,
+    NeptuneDBGraphStore,
+)
+from graphrag_toolkit.byokg_rag.graphstore.neptune import _escape_cypher_label
 from graphrag_toolkit.byokg_rag.graph_retrievers.graph_retrievers import GraphQueryRetriever
 
 
@@ -156,3 +160,152 @@ class CypherSafetyCheck(IntegrationTestBase):
                 self.assertEqual(self._malicious_count, 0)
 
         handler.run_assertions(CypherSafetyAssertions)
+
+
+# A node label and relationship type carrying a Cypher breakout payload. If a
+# sink interpolates one into a backtick-quoted identifier without escaping, the
+# appended clause deletes the canary; with escaping the canary survives.
+CANARY_LABEL = '__CypherSafetyCanary__'
+CANARY_ID = 'cypher-safety-canary'
+MALICIOUS_NODE_LABEL = (
+    'EvilNode`) MATCH (c:`__CypherSafetyCanary__`) DETACH DELETE c //'
+)
+MALICIOUS_EDGE_TYPE = (
+    'EvilEdge`]->() MATCH (c:`__CypherSafetyCanary__`) DETACH DELETE c //'
+)
+_TMP_IDS = [CANARY_ID, 'evil-node', 'evil-edge-a', 'evil-edge-b']
+
+
+class BYOKGCypherInjectionSafety(IntegrationTestBase):
+    """Insert a backtick-bearing label into a live Neptune graph, run the
+    schema-discovery path, and confirm no injected clause executes."""
+
+    @property
+    def description(self):
+        return 'Schema discovery escapes backticks in dynamic Cypher labels'
+
+    def _make_graph_store(self):
+        region = os.environ['AWS_REGION_NAME']
+        graph_store_id = os.environ['GRAPH_STORE']
+
+        if graph_store_id.startswith('neptune-graph://'):
+            graph_identifier = graph_store_id[len('neptune-graph://'):]
+            store = NeptuneAnalyticsGraphStore(
+                graph_identifier=graph_identifier, region=region
+            )
+            return 'analytics', store
+
+        if graph_store_id.startswith('neptune-db://'):
+            endpoint = graph_store_id[len('neptune-db://'):]
+            if not endpoint.startswith('https://'):
+                endpoint = f'https://{endpoint}'
+            return 'db', NeptuneDBGraphStore(endpoint_url=endpoint, region=region)
+
+        raise ValueError(
+            "Invalid graph store id. Expected 'neptune-graph://' or "
+            f"'neptune-db://', but received {graph_store_id}."
+        )
+
+    def _canary_count(self, graph_store):
+        rows = graph_store.execute_query(
+            f'MATCH (c:`{CANARY_LABEL}`) RETURN count(c) AS n'
+        )
+        return rows[0]['n'] if rows else 0
+
+    def _seed_payload(self, graph_store):
+        # The label/type are escaped here on the write path so the payload is
+        # stored as data; the read path (under test) is what must re-escape it.
+        graph_store.execute_query(
+            f'CREATE (c:`{CANARY_LABEL}` {{id: $id}})',
+            parameters={'id': CANARY_ID},
+        )
+        graph_store.execute_query(
+            f'CREATE (n:`{_escape_cypher_label(MALICIOUS_NODE_LABEL)}` {{id: $id}})',
+            parameters={'id': 'evil-node'},
+        )
+        graph_store.execute_query(
+            f'CREATE (a:`__CypherSafetyTmp__` {{id: $aid}})'
+            f'-[:`{_escape_cypher_label(MALICIOUS_EDGE_TYPE)}`]->'
+            f'(b:`__CypherSafetyTmp__` {{id: $bid}})',
+            parameters={'aid': 'evil-edge-a', 'bid': 'evil-edge-b'},
+        )
+
+    def _exercise_sinks(self, engine, graph_store):
+        """Drive the escaped schema-discovery sinks for this engine and return
+        the labels the path observed."""
+        if engine == 'db':
+            # get_schema() -> _refresh_schema() -> _get_node_properties /
+            # _get_edge_properties / _get_triples, each interpolating a label
+            # read back from the graph (including the payload labels seeded above).
+            schema = graph_store.get_schema()
+            return list(schema.get('nodeLabels', []))
+
+        # Analytics: pg_schema() does not interpolate labels, so the payload
+        # flows in as the node_type argument to the shared sinks instead.
+        graph_store.nodes(node_type=MALICIOUS_NODE_LABEL)
+        graph_store.get_node_text_for_embedding_input(
+            node_embedding_text_props={MALICIOUS_NODE_LABEL: ['name']},
+            group_by_node_label=True,
+        )
+        return [MALICIOUS_NODE_LABEL]
+
+    def _run_test(self, handler: IntegrationTestHandler, params: Dict[str, Any]):
+
+        engine, graph_store = self._make_graph_store()
+
+        self._seed_payload(graph_store)
+        canary_before = self._canary_count(graph_store)
+
+        schema_error = None
+        discovered_labels = []
+        try:
+            discovered_labels = self._exercise_sinks(engine, graph_store)
+        except Exception as e:
+            schema_error = e
+
+        canary_after = self._canary_count(graph_store)
+
+        # Best-effort cleanup; matching by id is label-agnostic.
+        try:
+            graph_store.execute_query(
+                'MATCH (n) WHERE n.id IN $ids DETACH DELETE n',
+                parameters={'ids': _TMP_IDS},
+            )
+        except Exception as e:
+            handler.add_exception(e)
+
+        handler.add_output('engine', engine)
+        handler.add_output('canary_before', canary_before)
+        handler.add_output('canary_after', canary_after)
+        handler.add_output(
+            'schema_error', str(schema_error) if schema_error else None
+        )
+        handler.add_output('discovered_labels', discovered_labels)
+
+        class CypherInjectionSafetyAssertions(unittest.TestCase):
+
+            @classmethod
+            def setUpClass(cls):
+                cls._engine = engine
+                cls._canary_before = canary_before
+                cls._canary_after = canary_after
+                cls._schema_error = schema_error
+                cls._discovered_labels = discovered_labels
+
+            def test_setup_created_canary(self):
+                """Canary node exists before schema discovery runs"""
+                self.assertEqual(self._canary_before, 1)
+
+            def test_schema_discovery_did_not_error(self):
+                """Schema discovery completes without raising"""
+                self.assertIsNone(self._schema_error)
+
+            def test_canary_survives_injection_payload(self):
+                """Canary still present: no injected DETACH DELETE executed"""
+                self.assertEqual(self._canary_after, 1)
+
+            def test_payload_label_flowed_through_discovery(self):
+                """The backtick-bearing label was processed as data, not code"""
+                self.assertIn(MALICIOUS_NODE_LABEL, self._discovered_labels)
+
+        handler.run_assertions(CypherInjectionSafetyAssertions)

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
@@ -309,3 +309,128 @@ class BYOKGCypherInjectionSafety(IntegrationTestBase):
                 self.assertIn(MALICIOUS_NODE_LABEL, self._discovered_labels)
 
         handler.run_assertions(CypherInjectionSafetyAssertions)
+
+
+# A breakout s3_path aimed at the CALL neptune.load(source: '...') sink. Its
+# quote/space/backtick/')' fall outside the allowlist, so it is rejected before
+# reaching the sink; if the validator were dropped, it would delete the canary.
+MALICIOUS_S3_PATH = (
+    "s3://b/k', region:'x'}) "
+    f"MATCH (c:`{CANARY_LABEL}`) DETACH DELETE c //"
+)
+
+
+class BYOKGS3PathInjectionSafety(IntegrationTestBase):
+    """Call read_from_csv with an s3_path carrying a Cypher breakout payload
+    and confirm the validator rejects it before any CALL neptune.load() or
+    bulk-loader job runs, leaving a seeded canary node untouched."""
+
+    @property
+    def description(self):
+        return 'read_from_csv rejects a breakout s3_path before the load sink'
+
+    def _make_graph_store(self):
+        region = os.environ['AWS_REGION_NAME']
+        graph_store_id = os.environ['GRAPH_STORE']
+
+        if graph_store_id.startswith('neptune-graph://'):
+            graph_identifier = graph_store_id[len('neptune-graph://'):]
+            store = NeptuneAnalyticsGraphStore(
+                graph_identifier=graph_identifier, region=region
+            )
+            return 'analytics', store
+
+        if graph_store_id.startswith('neptune-db://'):
+            endpoint = graph_store_id[len('neptune-db://'):]
+            if not endpoint.startswith('https://'):
+                endpoint = f'https://{endpoint}'
+            return 'db', NeptuneDBGraphStore(endpoint_url=endpoint, region=region)
+
+        raise ValueError(
+            "Invalid graph store id. Expected 'neptune-graph://' or "
+            f"'neptune-db://', but received {graph_store_id}."
+        )
+
+    def _canary_count(self, graph_store):
+        rows = graph_store.execute_query(
+            f'MATCH (c:`{CANARY_LABEL}`) RETURN count(c) AS n'
+        )
+        return rows[0]['n'] if rows else 0
+
+    def _run_test(self, handler: IntegrationTestHandler, params: Dict[str, Any]):
+
+        engine, graph_store = self._make_graph_store()
+
+        # Canary survival proves no injection reached the analytics Cypher sink;
+        # on db the operative proof is the validator raising before the load job.
+        graph_store.execute_query(
+            f'CREATE (c:`{CANARY_LABEL}` {{id: $id}})',
+            parameters={'id': CANARY_ID},
+        )
+        canary_before = self._canary_count(graph_store)
+
+        rejected = False
+        rejection_message = None
+        unexpected_error = None
+        try:
+            graph_store.read_from_csv(s3_path=MALICIOUS_S3_PATH)
+        except ValueError as e:
+            rejected = True
+            rejection_message = str(e)
+        except Exception as e:
+            # Non-ValueError => payload slipped past the validator to a sink.
+            unexpected_error = e
+
+        canary_after = self._canary_count(graph_store)
+
+        # Best-effort cleanup by id.
+        try:
+            graph_store.execute_query(
+                'MATCH (n) WHERE n.id IN $ids DETACH DELETE n',
+                parameters={'ids': [CANARY_ID]},
+            )
+        except Exception as e:
+            handler.add_exception(e)
+
+        handler.add_output('engine', engine)
+        handler.add_output('canary_before', canary_before)
+        handler.add_output('canary_after', canary_after)
+        handler.add_output('rejected', rejected)
+        handler.add_output('rejection_message', rejection_message)
+        handler.add_output(
+            'unexpected_error',
+            str(unexpected_error) if unexpected_error else None,
+        )
+
+        class S3PathInjectionSafetyAssertions(unittest.TestCase):
+
+            @classmethod
+            def setUpClass(cls):
+                cls._engine = engine
+                cls._canary_before = canary_before
+                cls._canary_after = canary_after
+                cls._rejected = rejected
+                cls._rejection_message = rejection_message
+                cls._unexpected_error = unexpected_error
+
+            def test_setup_created_canary(self):
+                """Canary node exists before read_from_csv runs"""
+                self.assertEqual(self._canary_before, 1)
+
+            def test_no_unexpected_error(self):
+                """read_from_csv failed only via the s3_path validator, not a
+                downstream sink"""
+                self.assertIsNone(self._unexpected_error)
+
+            def test_breakout_s3_path_rejected(self):
+                """Malicious s3_path raised ValueError before the load sink"""
+                self.assertTrue(self._rejected)
+                self.assertIn(
+                    'Invalid s3_path', self._rejection_message or ''
+                )
+
+            def test_canary_survives_injection_payload(self):
+                """Canary still present: no injected DETACH DELETE executed"""
+                self.assertEqual(self._canary_after, 1)
+
+        handler.run_assertions(S3PathInjectionSafetyAssertions)


### PR DESCRIPTION
## Description

Two related Cypher-injection fixes in the byokg-rag Neptune graph stores, on top of #291.

1. `read_from_csv` interpolates the user-controlled `s3_path` into a `CALL neptune.load(...)` Cypher string. `CALL neptune.load()` takes no bound parameters, so a crafted `s3_path` containing a single quote can break out and inject Cypher. This validates `s3_path` against a strict allowlist before use.
2. Schema discovery and the node/embedding sinks interpolate label names into backtick-quoted identifiers. A label containing a backtick can break out of the identifier. This escapes backticks before interpolation at every such sink.

Both surfaces are distinct from the `is_query_safe` / blocklist work in #291 and complement it. The schema-discovery queries call the graph store's `execute_query` directly, so they do not route through the retriever-level safety check.

## Changes

- New module-level `_validate_s3_path` (allowlist regex) called at the top of both `read_from_csv` overloads, before any side effect (`_upload_to_s3`, loader job, `execute_query`). `None` passes through to preserve existing caller semantics (for example `as_embedding_index` with no save location). The allowlist accepts valid S3 key characters that cannot break out of a single-quoted Cypher literal.
- New module-level `_escape_cypher_label` that doubles backticks and raises `TypeError` on non-string input. Applied at all five label sinks: `_get_edge_properties`, `_get_node_properties`, `_get_triples`, `BaseNeptuneGraphStore.nodes()`, and `NeptuneAnalyticsGraphStore.get_node_text_for_embedding_input()`. The raw label is still used as the Python-side dict key, so returned schema/grouping dicts keep the original name.
- Removed a dead `triple_template` variable in `_get_triples`.
- Extends the `byokg_cypher_safety.py` integration suite added in #291 with two live canary checks, registered in `byokg.all`: `BYOKGCypherInjectionSafety` (schema-discovery / dynamic-label sinks) and `BYOKGS3PathInjectionSafety` (a breakout `s3_path` is rejected by `read_from_csv` before any `CALL neptune.load()` / bulk-loader job runs, leaving a seeded canary untouched).

## Problem

`s3_path` and dynamic label names reach Cypher positions that cannot be parameterized — `CALL neptune.load()` arguments and backtick-quoted identifiers — so a crafted value can break out and inject Cypher. Escaping (labels) and allowlisting (`s3_path`) are the available mitigations.

Related issue (if any): #

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Unit: validator and escape suites with red-state proofs (each mitigation patched to a no-op lets the payload reach the sink), payload-diversity parametrization, positive paths, indirect callers, and a source-scanning regression guard that fails if a new backtick sink is added unescaped. Local `pytest byokg-rag/tests/unit/graphstore/` — 109 passed.

Integration Test Result:
<img width="515" height="482" alt="image" src="https://github.com/user-attachments/assets/f2d6414e-5c2a-4b12-b0f1-cca64b8dc503" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


