### PR TITLE
[Benchmarking]: Add VPC reuse support to integration test infrastructure

### DIFF
--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -93,7 +93,7 @@
       "Default": ""
     },
     "ExistingSubnetIds": {
-      "Description": "Optional comma-separated list of existing subnet IDs (minimum 2, spanning at least 2 AZs). If provided, ExistingVpcId must also be provided. Leave empty to create new subnets.",
+      "Description": "Optional comma-separated list of existing subnet IDs (minimum 2, spanning at least 2 AZs). The first subnet must have outbound internet access (e.g. public subnet with IGW or private subnet with NAT) as it is used for the SageMaker notebook. If provided, ExistingVpcId must also be provided. Leave empty to create new subnets.",
       "Type": "CommaDelimitedList",
       "Default": ""
     }

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -86,6 +86,87 @@
       "Description": "Bedrock model id or profile for extraction and response LLMs",
       "Type": "String",
       "Default": "global.anthropic.claude-sonnet-4-6"
+    },
+    "ExistingVpcId": {
+      "Description": "Optional existing VPC ID to reuse. If provided, ExistingSubnetIds must also be provided. Leave empty to create a new VPC.",
+      "Type": "String",
+      "Default": ""
+    },
+    "ExistingSubnetIds": {
+      "Description": "Optional comma-separated list of existing subnet IDs (minimum 2, spanning at least 2 AZs). If provided, ExistingVpcId must also be provided. Leave empty to create new subnets.",
+      "Type": "CommaDelimitedList",
+      "Default": ""
+    }
+  },
+  "Rules": {
+    "VpcAndSubnetsBothOrNeither": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Or": [
+              {
+                "Fn::And": [
+                  {
+                    "Fn::Equals": [
+                      {
+                        "Ref": "ExistingVpcId"
+                      },
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::Equals": [
+                      {
+                        "Fn::Select": [
+                          0,
+                          {
+                            "Ref": "ExistingSubnetIds"
+                          }
+                        ]
+                      },
+                      ""
+                    ]
+                  }
+                ]
+              },
+              {
+                "Fn::And": [
+                  {
+                    "Fn::Not": [
+                      {
+                        "Fn::Equals": [
+                          {
+                            "Ref": "ExistingVpcId"
+                          },
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Fn::Not": [
+                      {
+                        "Fn::Equals": [
+                          {
+                            "Fn::Select": [
+                              0,
+                              {
+                                "Ref": "ExistingSubnetIds"
+                              }
+                            ]
+                          },
+                          ""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "Both ExistingVpcId and ExistingSubnetIds must be provided together, or both must be left empty."
+        }
+      ]
     }
   },
   "Metadata": {
@@ -128,11 +209,28 @@
             "ExampleNotebooksURL",
             "IamPolicyArn"
           ]
+        },
+        {
+          "Label": {
+            "default": "Networking"
+          },
+          "Parameters": [
+            "ExistingVpcId",
+            "ExistingSubnetIds"
+          ]
         }
       ]
     }
   },
   "Conditions": {
+    "CreateVPC": {
+      "Fn::Equals": [
+        {
+          "Ref": "ExistingVpcId"
+        },
+        ""
+      ]
+    },
     "ExampleNotebooksURLIsNotBlank": {
       "Fn::Not": [
         {
@@ -198,6 +296,16 @@
         }
       ]
     },
+    "AZ3PresentAndCreateVPC": {
+      "Fn::And": [
+        {
+          "Condition": "AZ3Present"
+        },
+        {
+          "Condition": "CreateVPC"
+        }
+      ]
+    },
     "AddIamPolicyArn": {
       "Fn::Not": [
         {
@@ -244,26 +352,34 @@
         },
         "SubnetIds": {
           "Fn::If": [
-            "AZ3NotPresent",
-            [
-              {
-                "Ref": "Subnet1"
-              },
-              {
-                "Ref": "Subnet2"
-              }
-            ],
-            [
-              {
-                "Ref": "Subnet1"
-              },
-              {
-                "Ref": "Subnet2"
-              },
-              {
-                "Ref": "Subnet3"
-              }
-            ]
+            "CreateVPC",
+            {
+              "Fn::If": [
+                "AZ3NotPresent",
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  }
+                ],
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  },
+                  {
+                    "Ref": "Subnet3"
+                  }
+                ]
+              ]
+            },
+            {
+              "Ref": "ExistingSubnetIds"
+            }
           ]
         },
         "Tags": [
@@ -301,7 +417,15 @@
           "Fn::Sub": "${ApplicationId}-client-sg"
         },
         "VpcId": {
-          "Ref": "VPC"
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
         },
         "GroupDescription": "GraphRAG client security group",
         "SecurityGroupEgress": [
@@ -348,7 +472,15 @@
           "Fn::Sub": "${ApplicationId}-neptune-sg"
         },
         "VpcId": {
-          "Ref": "VPC"
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
         },
         "GroupDescription": "GraphRAG Neptune security group",
         "Tags": [
@@ -999,7 +1131,15 @@
           "Fn::Sub": "${ApplicationId}-opensearch-sg"
         },
         "VpcId": {
-          "Ref": "VPC"
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
         },
         "GroupDescription": "Security group for OpenSearch Serverless VPC endpoint",
         "SecurityGroupIngress": [
@@ -1052,30 +1192,46 @@
           "Fn::Sub": "${ApplicationId}-vpce"
         },
         "VpcId": {
-          "Ref": "VPC"
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
         },
         "SubnetIds": {
           "Fn::If": [
-            "AZ3Present",
-            [
-              {
-                "Ref": "Subnet1"
-              },
-              {
-                "Ref": "Subnet2"
-              },
-              {
-                "Ref": "Subnet3"
-              }
-            ],
-            [
-              {
-                "Ref": "Subnet1"
-              },
-              {
-                "Ref": "Subnet2"
-              }
-            ]
+            "CreateVPC",
+            {
+              "Fn::If": [
+                "AZ3Present",
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  },
+                  {
+                    "Ref": "Subnet3"
+                  }
+                ],
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  }
+                ]
+              ]
+            },
+            {
+              "Ref": "ExistingSubnetIds"
+            }
           ]
         },
         "SecurityGroupIds": [
@@ -1280,7 +1436,20 @@
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },
         "SubnetId": {
-          "Ref": "Subnet4"
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "Subnet4"
+            },
+            {
+              "Fn::Select": [
+                0,
+                {
+                  "Ref": "ExistingSubnetIds"
+                }
+              ]
+            }
+          ]
         },
         "SecurityGroupIds": [
           {
@@ -1545,12 +1714,14 @@
     },
     "ElasticIP1": {
       "Type": "AWS::EC2::EIP",
+      "Condition": "CreateVPC",
       "Properties": {
         "Domain": "VPC"
       }
     },
     "VPC": {
       "Type": "AWS::EC2::VPC",
+      "Condition": "CreateVPC",
       "Properties": {
         "CidrBlock": "172.30.0.0/16",
         "EnableDnsSupport": "true",
@@ -1579,6 +1750,7 @@
     },
     "PublicRouteTable": {
       "Type": "AWS::EC2::RouteTable",
+      "Condition": "CreateVPC",
       "Properties": {
         "VpcId": {
           "Ref": "VPC"
@@ -1590,6 +1762,7 @@
     },
     "PrivateRouteTable": {
       "Type": "AWS::EC2::RouteTable",
+      "Condition": "CreateVPC",
       "Properties": {
         "VpcId": {
           "Ref": "VPC"
@@ -1601,6 +1774,7 @@
     },
     "IGWAtt": {
       "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Condition": "CreateVPC",
       "Properties": {
         "InternetGatewayId": {
           "Ref": "IGW"
@@ -1616,6 +1790,7 @@
     },
     "IGW": {
       "Type": "AWS::EC2::InternetGateway",
+      "Condition": "CreateVPC",
       "Properties": {
         "Tags": [
           {
@@ -1647,6 +1822,7 @@
     },
     "NATGW": {
       "Type": "AWS::EC2::NatGateway",
+      "Condition": "CreateVPC",
       "Properties": {
         "AllocationId": {
           "Fn::GetAtt": [
@@ -1661,6 +1837,7 @@
     },
     "PublicRoute": {
       "Type": "AWS::EC2::Route",
+      "Condition": "CreateVPC",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "GatewayId": {
@@ -1676,6 +1853,7 @@
     },
     "PrivateRoute": {
       "Type": "AWS::EC2::Route",
+      "Condition": "CreateVPC",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "NatGatewayId": {
@@ -1691,6 +1869,7 @@
     },
     "Subnet1": {
       "Type": "AWS::EC2::Subnet",
+      "Condition": "CreateVPC",
       "Properties": {
         "CidrBlock": "172.30.1.0/24",
         "VpcId": {
@@ -1708,6 +1887,7 @@
     },
     "Subnet2": {
       "Type": "AWS::EC2::Subnet",
+      "Condition": "CreateVPC",
       "Properties": {
         "CidrBlock": "172.30.2.0/24",
         "VpcId": {
@@ -1725,7 +1905,7 @@
     },
     "Subnet3": {
       "Type": "AWS::EC2::Subnet",
-      "Condition": "AZ3Present",
+      "Condition": "AZ3PresentAndCreateVPC",
       "Properties": {
         "CidrBlock": "172.30.3.0/24",
         "VpcId": {
@@ -1743,6 +1923,7 @@
     },
     "Subnet4": {
       "Type": "AWS::EC2::Subnet",
+      "Condition": "CreateVPC",
       "Properties": {
         "CidrBlock": "172.30.4.0/24",
         "MapPublicIpOnLaunch": "true",
@@ -1761,6 +1942,7 @@
     },
     "SubnetRTAssociation1": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "CreateVPC",
       "DependsOn": [
         "Subnet1",
         "PrivateRouteTable"
@@ -1776,6 +1958,7 @@
     },
     "SubnetRTAssociation2": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "CreateVPC",
       "DependsOn": [
         "Subnet2",
         "PrivateRouteTable"
@@ -1791,7 +1974,7 @@
     },
     "SubnetRTAssociation3": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Condition": "AZ3Present",
+      "Condition": "AZ3PresentAndCreateVPC",
       "DependsOn": [
         "Subnet3",
         "PrivateRouteTable"
@@ -1807,6 +1990,7 @@
     },
     "SubnetRTAssociation4": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "CreateVPC",
       "DependsOn": [
         "Subnet4",
         "PublicRouteTable"
@@ -1884,7 +2068,15 @@
     "VPC": {
       "Description": "VPC",
       "Value": {
-        "Ref": "VPC"
+        "Fn::If": [
+          "CreateVPC",
+          {
+            "Ref": "VPC"
+          },
+          {
+            "Ref": "ExistingVpcId"
+          }
+        ]
       }
     }
   }

--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -87,6 +87,8 @@ if [[ "$#" -gt 0 ]]; then
     echo "  --benchmark-data-s3-uri <S3 URI for benchmark data (synced at runtime instead of uploading)>"
     echo "  --benchmark-qa-limit <max number of QA pairs to evaluate (for prototype runs)>"
     echo "  --benchmark-prototype"
+    echo "  --existing-vpc-id <Existing VPC ID to reuse (skip VPC creation)>"
+    echo "  --existing-subnet-ids <Comma-separated existing subnet IDs (min 2, spanning 2 AZs)>"
     echo "  --prev-stack <Previous stack name or ID>"
 		echo "  --delete-on-pass"
 		echo "  --fail-fast"
@@ -173,6 +175,8 @@ while [[ "$#" -gt 0 ]]; do
         --benchmark-data-s3-uri) BENCHMARK_DATA_S3_URI="$2"; shift ;;
         --benchmark-qa-limit) BENCHMARK_QA_LIMIT="$2"; shift ;;
         --benchmark-prototype) BENCHMARK_IS_PROTOTYPE=true ;;
+        --existing-vpc-id) EXISTING_VPC_ID="$2"; shift ;;
+        --existing-subnet-ids) EXISTING_SUBNET_IDS="$2"; shift ;;
         --prev-stack) PREV_STACK_NAME="$2"; shift ;;
 				--delete-on-pass) DELETE_ON_PASS=True ;;
 				--fail-fast) FAIL_FAST=True ;;
@@ -411,6 +415,8 @@ echo "TESTS                    : $TESTS"
 echo "BENCHMARK_DATA_DIR       : $BENCHMARK_DATA_DIR"
 echo "BENCHMARK_DATA_S3_URI    : $BENCHMARK_DATA_S3_URI"
 echo "BENCHMARK_QA_LIMIT       : $BENCHMARK_QA_LIMIT"
+echo "EXISTING_VPC_ID          : $EXISTING_VPC_ID"
+echo "EXISTING_SUBNET_IDS      : $EXISTING_SUBNET_IDS"
 echo "PREV_STACK_NAME"         : $PREV_STACK_NAME
 echo "----------------------------------------------------"
 echo ""
@@ -473,6 +479,8 @@ if [[ -z "$DRY_RUN" ]]; then
 		ParameterKey=IamPolicyArn,ParameterValue="$ADDITIONAL_IAM_POLICY_ARN" \
 		ParameterKey=SSHCIDR,ParameterValue="$SSHCIDR" \
 		ParameterKey=DbPassword,ParameterValue="$DB_PASSWORD" \
+		ParameterKey=ExistingVpcId,ParameterValue="${EXISTING_VPC_ID:-}" \
+		ParameterKey=ExistingSubnetIds,ParameterValue="${EXISTING_SUBNET_IDS:-}" \
 	  --capabilities CAPABILITY_NAMED_IAM \
 	  --tags \
 	    Key=ApplicationName,Value="graphrag-toolkit test" \

--- a/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
+++ b/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
@@ -78,7 +78,17 @@
 			"Description": "Database password (used by some store providers)",
 			"Type": "String",
 			"NoEcho": true
-		}
+		},
+    "ExistingVpcId": {
+      "Description": "Optional existing VPC ID to reuse (leave empty to create a new VPC)",
+      "Type": "String",
+      "Default": ""
+    },
+    "ExistingSubnetIds": {
+      "Description": "Optional existing subnet IDs to reuse (comma-delimited, min 2 across 2 AZs). Must be provided together with ExistingVpcId",
+      "Type": "CommaDelimitedList",
+      "Default": ""
+    }
   },
   "Mappings": {
     "EnvTypeMap": {
@@ -535,6 +545,17 @@
               },
               {
                 "Ref": "AWS::NoValue"
+              }
+            ]
+          },
+          "ExistingVpcId": {
+            "Ref": "ExistingVpcId"
+          },
+          "ExistingSubnetIds": {
+            "Fn::Join": [
+              ",",
+              {
+                "Ref": "ExistingSubnetIds"
               }
             ]
           }

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_build.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_build.py
@@ -4,7 +4,6 @@ import os
 import unittest
 from contextlib import nullcontext
 from typing import Dict, Any, Optional
-<<<<<<< HEAD
 import logging
 
 from graphrag_toolkit_tests.integration_test_base import IntegrationTestBase
@@ -13,24 +12,14 @@ from graphrag_toolkit_tests.benchmark_utils.s3_utils import sync_benchmark_data_
 
 from graphrag_toolkit.lexical_graph import LexicalGraphIndex
 from graphrag_toolkit.lexical_graph import GraphRAGConfig
-=======
-
-from graphrag_toolkit_tests.integration_test_base import IntegrationTestBase
-from graphrag_toolkit_tests.integration_test_handler import IntegrationTestHandler
-
-from graphrag_toolkit.lexical_graph import LexicalGraphIndex
->>>>>>> main
 from graphrag_toolkit.lexical_graph.storage import GraphStoreFactory
 from graphrag_toolkit.lexical_graph.storage import VectorStoreFactory
 from graphrag_toolkit.lexical_graph.storage.graph import NonRedactedGraphQueryLogFormatting
 from graphrag_toolkit.lexical_graph.indexing.load import FileBasedDocs
 
-<<<<<<< HEAD
 logger = logging.getLogger(__name__)
 
 
-=======
->>>>>>> main
 DATASET_CONFIG = {
     'cuad-prototype': {
         'num_docs': 2,
@@ -45,7 +34,6 @@ DATASET_CONFIG = {
     },
     'concurrentqa': {
         'num_docs': 13501,
-<<<<<<< HEAD
         'extracted_dir': 'extracted',
         'collection_id': '20260513-174224',
     },
@@ -55,17 +43,12 @@ DATASET_CONFIG = {
     },
     'wikihow': {
         'num_docs': 5000,
-=======
->>>>>>> main
     },
 }
 
 BENCHMARK_DATA_DIR = 'source-data'
 
-<<<<<<< HEAD
 
-=======
->>>>>>> main
 def run_benchmark_build(handler: IntegrationTestHandler, 
                         dataset: str, 
                         data_dir: str,
@@ -87,7 +70,6 @@ def run_benchmark_build(handler: IntegrationTestHandler,
             'neptune-graph://<graph-id>').
         vector_store_conn: Optional vector store connection string (e.g. 'aoss://...').
     """
-<<<<<<< HEAD
     sync_benchmark_data_from_s3(dataset, data_dir)
 
     config = DATASET_CONFIG.get(dataset, {})
@@ -103,16 +85,6 @@ def run_benchmark_build(handler: IntegrationTestHandler,
     docs = FileBasedDocs(
         docs_directory=docs_directory,
         collection_id=collection_id
-=======
-    config = DATASET_CONFIG.get(dataset, {})
-
-    extracted_subdir = config.get('extracted_dir', 'extracted')
-    docs_directory = os.path.join(data_dir, dataset, extracted_subdir)
-
-    docs = FileBasedDocs(
-        docs_directory=docs_directory,
-        collection_id=dataset
->>>>>>> main
     )
 
     graph_ctx = GraphStoreFactory.for_graph_store(
@@ -165,7 +137,6 @@ class CuadBenchmarkBuild(IntegrationTestBase):
             dataset_name = 'cuad'
 
         run_benchmark_build(handler, dataset_name, BENCHMARK_DATA_DIR, graph_store_conn, vector_store_conn)
-<<<<<<< HEAD
 
 
 class ConcurrentQaBenchmarkBuild(IntegrationTestBase):
@@ -210,5 +181,3 @@ class PgaBenchmarkBuild(IntegrationTestBase):
         vector_store_conn = os.environ.get('VECTOR_STORE')
 
         run_benchmark_build(handler, 'pga', BENCHMARK_DATA_DIR, graph_store_conn, vector_store_conn)
-=======
->>>>>>> main


### PR DESCRIPTION
## Description

Allows running multiple integration test stacks in parallel without hitting the VPC-per-region limit by reusing an existing VPC.

## Changes

- Added `existing-vpc-id` and `existing-subnet-ids` CLI args to build-tests.sh
- Added `ExistingVpcId` and `ExistingSubnetIds` parameters to both CFN templates
- Security groups are always created per-stack
- CFN Rules enforce that both VPC ID and subnet IDs must be provided together or both left empty
- Existing behavior (create new VPC) is unchanged when parameters are omitted

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
