### PR TITLE
Fix/exclude topics from chunk embedding

### DIFF
--- a/docs-site/src/content/docs/lexical-graph/graph-model.mdx
+++ b/docs-site/src/content/docs/lexical-graph/graph-model.mdx
@@ -13,6 +13,7 @@ title: Graph Model
     - [Facts](#facts)
     - [Statements](#statements)
     - [Topics](#topics)
+  - [Embedding metadata](#embedding-metadata)
 
 ### Overview
 
@@ -123,3 +124,28 @@ Topics are scoped to individual source documents so as to provide connectivity a
 Topics increase *connectivity between relevant chunks within a single source*, and provide a simple document-level summary mechanism.
 
 Topics can, optionally, be embedded, and so can act as higher-level entry points in the graph based on a vector search. A topic embedding represents the topic name and all the statements belonging to that topic.
+
+### Embedding metadata
+
+Embeddable nodes (chunks, topics, and statements) embed their **content** plus a small,
+deliberate subset of their metadata. Structural and lineage metadata is *excluded* from
+the embedding so it does not dilute the vector, while remaining available on the node for
+filtering, graph queries, and LLM context. Each node builder controls this via its
+`excluded_embed_metadata_keys`.
+
+What each node type embeds:
+
+  - **Chunk** — the chunk text only. Source/document metadata (e.g. file name, author,
+    URL, and the internal versioning timestamps) lives under the `source` key and is
+    excluded, as are the internal index key and any configured external properties (under
+    the `chunk` key). The chunk's topic labels are also excluded, so the chunk vector
+    reflects the passage content rather than its topic names.
+  - **Topic** — the topic name plus all statements belonging to that topic.
+  - **Statement** — the statement text (and its supporting details, when present).
+
+In other words, document-level metadata such as `file_name` or `size` is **not** baked
+into chunk embeddings by default — it is carried as graph/source metadata (see
+[External properties](/lexical-graph/external-properties/) for making such metadata
+queryable). If you want a piece of metadata to influence the embedding itself, include it
+in the node's content rather than relying on metadata, since metadata under `source`,
+`chunk`, `statement`, and the internal index keys is excluded from the vector.

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/chunk_node_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/chunk_node_builder.py
@@ -119,7 +119,7 @@ class ChunkNodeBuilder(NodeBuilder):
             }
 
             chunk_node.metadata = metadata
-            chunk_node.excluded_embed_metadata_keys = [INDEX_KEY, 'chunk', 'source']
+            chunk_node.excluded_embed_metadata_keys = [INDEX_KEY, 'chunk', 'source', 'topics']
             chunk_node.excluded_llm_metadata_keys = [INDEX_KEY, 'chunk', 'source']
 
             chunk_nodes.append(chunk_node)

--- a/lexical-graph/tests/unit/indexing/build/test_chunk_node_builder.py
+++ b/lexical-graph/tests/unit/indexing/build/test_chunk_node_builder.py
@@ -86,6 +86,24 @@ class TestChunkNodeCreation:
         assert 'AI' in results[0].metadata['topics']
         assert 'Graphs' in results[0].metadata['topics']
 
+    def test_topics_excluded_from_embedding_but_kept_for_llm(self):
+        """Topics must not pollute the chunk embedding, but stay available to the LLM
+        and in metadata. Chunk embeddings should be the chunk content only."""
+        from llama_index.core.schema import MetadataMode
+        builder = _make_builder()
+        node = _make_node(text='Quarterly cash flow rose sharply.', topics=['Liquidity', 'Cash Flow'])
+        chunk = builder.build_nodes([node])[0]
+
+        # topics excluded from the embedding text, NOT from the LLM text
+        assert 'topics' in chunk.excluded_embed_metadata_keys
+        assert 'topics' not in chunk.excluded_llm_metadata_keys
+        # the embedded text contains the content but not the topic names / "topics:" label
+        embed_text = chunk.get_content(metadata_mode=MetadataMode.EMBED)
+        assert 'Quarterly cash flow rose sharply.' in embed_text
+        assert 'topics:' not in embed_text and 'Liquidity' not in embed_text
+        # topics still present in metadata for downstream use
+        assert chunk.metadata['topics'] == ['Liquidity', 'Cash Flow']
+
     def test_build_nodes_sets_index_key(self):
         """Verify build_nodes sets the INDEX_KEY to 'chunk'."""
         builder = _make_builder()


### PR DESCRIPTION

### Problem
The chunk node builder included the `topics` metadata in the chunk's **embedding** text,
rendered with the default `{key}: {value}` template — so every chunk vector was prefixed
with a literal `topics: ['...', '...']` string (key label + Python-list repr). That's
formatting noise in the embedding.

### Fix
Add `topics` to the chunk's `excluded_embed_metadata_keys` so chunk embeddings reflect the
chunk **content** only. Topics remain in metadata and available to the LLM
(`excluded_llm_metadata_keys` is unchanged).

### Docs
Adds an "Embedding metadata" section to `graph-model.mdx` documenting what each embeddable
node (chunk / topic / statement) includes vs excludes — closing a previously undocumented gap.

### Tests
Unit test asserting `topics` is excluded from the chunk embedding text.

