### PR TITLE
[Benchmarking]: Update evaluation methodology to use Sonnet 4.6

### DIFF
--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_evaluate.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_evaluate.py
@@ -1,13 +1,33 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+"""
+Benchmark evaluation for GraphRAG benchmark results.
+
+This module provides:
+- run_benchmark_evaluate(): Evaluation function used by pipeline test classes
+- Test classes: CuadBenchmarkEvaluate, ConcurrentQaBenchmarkEvaluate,
+  WikihowBenchmarkEvaluate, PgaBenchmarkEvaluate
+
+Environment Variables:
+    BENCHMARK_JUDGE_LLM: Model ID for evaluation judge (default: us.anthropic.claude-sonnet-4-6)
+"""
 import json
+import logging
 import os
 import unittest
 from typing import Dict, Any, Optional, List
 
 from graphrag_toolkit_tests.integration_test_base import IntegrationTestBase
 from graphrag_toolkit_tests.integration_test_handler import IntegrationTestHandler
-from graphrag_toolkit_tests.benchmark_utils.run_evaluation import CorrectnessEvaluator, IDKEvaluator
+from graphrag_toolkit_tests.benchmark_utils.run_evaluation import evaluate_responses
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline evaluation helpers
+# ---------------------------------------------------------------------------
 
 
 def run_benchmark_evaluate(handler: IntegrationTestHandler, params: Dict[str, Any],
@@ -63,56 +83,13 @@ def run_benchmark_evaluate(handler: IntegrationTestHandler, params: Dict[str, An
         for line in fin:
             data.append(json.loads(line))
 
-    model_id = os.environ.get('TEST_RESPONSE_LLM')
-    assert model_id, 'TEST_RESPONSE_LLM environment variable must be set'
+    # Default uses cross-region inference profile; requires it enabled in the account.
+    # Override via BENCHMARK_JUDGE_LLM env var for accounts without cross-region access.
+    judge_model_id = os.environ.get('BENCHMARK_JUDGE_LLM', 'us.anthropic.claude-sonnet-4-6')
 
-    scores = {}
+    scores = evaluate_responses(data, results_dir, judge_model_id, metrics)
 
-    for metric in metrics:
-        if metric == 'correctness_on_answerable':
-            correctness_path = os.path.join(results_dir, 'correctness_evals.json')
-            idk_path = os.path.join(results_dir, 'idk_evals.json')
-            with open(correctness_path) as f:
-                correctness_data = json.load(f)
-            with open(idk_path) as f:
-                idk_data = json.load(f)
-            total, count = 0, 0
-            for c_eval, i_eval in zip(correctness_data, idk_data):
-                if i_eval['label'] == 'answerable':
-                    total += 1
-                    if c_eval['llmCorrectnessGrade'] == 'correct':
-                        count += 1
-            score = count / total if total > 0 else 0.0
-        else:
-            if metric == 'correctness':
-                evaluator = CorrectnessEvaluator(model_id=model_id)
-            elif metric == 'idk':
-                evaluator = IDKEvaluator(model_id=model_id)
-
-            evals = []
-            for example in data:
-                question = example['raw_example']['question']
-                answer = example['raw_example']['answer']
-                response = example['response']
-                evals.append(evaluator.evaluate(question, answer, response))
-
-            evals_path = os.path.join(results_dir, f'{metric}_evals.json')
-            with open(evals_path, 'w') as f:
-                json.dump(evals, f, indent=2)
-
-            count, total = 0, len(evals)
-            for e in evals:
-                if metric == 'correctness' and e.get('llmCorrectnessGrade') == 'correct':
-                    count += 1
-                elif metric == 'idk' and e.get('label') == 'unanswerable':
-                    count += 1
-            score = count / total if total > 0 else 0.0
-
-        scores[metric] = score
-        score_path = os.path.join(results_dir, f'{metric}.json')
-        with open(score_path, 'w') as f:
-            json.dump({metric: score}, f, indent=2)
-
+    for metric, score in scores.items():
         handler.add_output(metric, score)
 
     params['benchmark_scores'] = scores

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/run_evaluation.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/run_evaluation.py
@@ -1,17 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Single source of truth for all benchmark evaluation logic.
+
+This module provides:
+- call_bedrock_invoke_model: Bedrock invocation with retry and parse-failure handling
+- CorrectnessEvaluator: LLM-as-judge correctness grading
+- IDKEvaluator: Detects "I don't know" / unanswerable responses
+- evaluate_responses: Shared evaluation loop used by all callers
+- BKB_CORRECTNESS_GRADING / IDK_DETECTION prompt templates
+
+Environment Variables:
+    BENCHMARK_JUDGE_LLM: Model ID for evaluation judge (default: us.anthropic.claude-sonnet-4-6).
+        Uses cross-region inference profile; requires it enabled in the account.
+    AWS_REGION: AWS region for Bedrock calls (default: us-west-2)
+    REGION_NAME: Fallback for AWS_REGION
+"""
 from boto3 import Session
 from botocore.config import Config
 import logging
 import json
-import argparse
-from tqdm import tqdm
 import os
 import time
+from typing import Dict, List, Optional
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def call_bedrock_invoke_model(prompt, bedrock, model_id, is_json_output=True):
-    while True:
+_REGION = os.environ.get('AWS_REGION', os.environ.get('REGION_NAME', 'us-west-2'))
+
+
+def call_bedrock_invoke_model(prompt, bedrock, model_id, is_json_output=True, max_retries=10):
+    """Invoke a Bedrock model with retry logic and parse-failure handling.
+
+    Args:
+        prompt: The prompt string to send to the model.
+        bedrock: A boto3 bedrock-runtime client.
+        model_id: The Bedrock model ID to invoke.
+        is_json_output: If True, parse the response as JSON and return a dict.
+        max_retries: Maximum number of retry attempts on transient failures.
+
+    Returns:
+        If is_json_output=True: a dict with 'grade', 'justification', and 'llm_response' keys.
+        If is_json_output=False: the raw response text string.
+
+    Raises:
+        The last exception encountered if all retries are exhausted.
+    """
+    last_exception = None
+    for _attempt in range(max_retries):
         try:
             accept = 'application/json'
             contentType = 'application/json'
@@ -50,19 +87,26 @@ def call_bedrock_invoke_model(prompt, bedrock, model_id, is_json_output=True):
                     parsed_json = json.loads(parsed_completion)
                     parsed_json['llm_response'] = response_text
                     return parsed_json
-                except:
-                    logger.error(response_text)
-                    return {
-                        'grade': "incorrect",
-                        'justification': "LLM failed grading",
-                        'llm_response': response_text
-                    }
+                except (ValueError, KeyError, json.JSONDecodeError, TypeError):
+                    logger.error(f"PARSING_FAILURE: Could not parse judge response: {response_text[:200]}")
+                    last_exception = ValueError(f"Parse failure: {response_text[:200]}")
+                    time.sleep(3)
+                    continue
             else:
                 return response_text
         except Exception as e:
+            last_exception = e
             logger.error(str(e))
             time.sleep(3)
-        
+
+    # All retries exhausted
+    if last_exception and isinstance(last_exception, ValueError):
+        return {
+            "grade": "incorrect",
+            "justification": "PARSING_FAILURE: All retries returned unparseable responses",
+            "llm_response": ""
+        }
+    raise last_exception
 
 
 BKB_CORRECTNESS_GRADING = """
@@ -97,27 +141,29 @@ IDK_DETECTION = """You are a teacher grading a quiz. Based on students' response
 Response: {response}
 Please output "Unanswerable" if the students identify that they can not answer the question. Otherwise, output "Answerable".
 """
-import os
-os.environ["AWS_REGION_NAME"] = "us-west-2"
-    
+
 
 class GenerationEvaluator:
+    """Base evaluator class that holds a shared Bedrock client."""
+
     bedrock = Session().client(
         service_name='bedrock-runtime',
-        region_name="us-west-2",
+        region_name=_REGION,
         config=Config(
             max_pool_connections=50,
             retries={"max_attempts": 10, "mode": "standard"},
             connect_timeout=500,
             read_timeout=500,
-            region_name="us-west-2"  
+            region_name=_REGION
         ))
-    
 
     def __init__(self, model_id):
         self.model_id = model_id
 
+
 class CorrectnessEvaluator(GenerationEvaluator):
+    """Evaluates whether a response is factually correct against a ground-truth answer."""
+
     def __init__(self, model_id):
         super().__init__(model_id)
     
@@ -125,7 +171,7 @@ class CorrectnessEvaluator(GenerationEvaluator):
         grading = {}
         grading.update(self._llm_evaluate(question, answer, response))
         return grading
-        
+
     def _llm_evaluate(self, question, answer, response):
         prompt = BKB_CORRECTNESS_GRADING.format(
             query=question,
@@ -137,14 +183,14 @@ class CorrectnessEvaluator(GenerationEvaluator):
             completion['grade'] = "incorrect"
             completion['justification'] = "No answer was provided"
 
-        if not completion or not completion['grade'] or not completion['justification']:
+        if not completion or not completion.get('grade') or not completion.get('justification'):
             logger.error("Failed to grade")
             logger.error(str(completion))
             return {
                 'question': question,
                 'llmCorrectnessGrade': "incorrect",
-                'llmCorrectnessGradeJustification': "LLM failed grading",
-                'llm_response': completion.get('llm_response', str(completion))  # Store the raw response
+                'llmCorrectnessGradeJustification': "PARSING_FAILURE: Judge returned invalid or empty grade structure",
+                'llm_response': completion.get('llm_response', str(completion)) if completion else ''
             }
 
         try:
@@ -152,28 +198,30 @@ class CorrectnessEvaluator(GenerationEvaluator):
                 'question': question,
                 'llmCorrectnessGrade': completion['grade'].lower(),
                 'llmCorrectnessGradeJustification': completion['justification'].replace("\"", "\\\""),
-                'llm_response': completion.get('llm_response', str(completion))  # Store the raw response
+                'llm_response': completion.get('llm_response', str(completion))
             }
             return grading
-        except Exception as e:
+        except (AttributeError, KeyError, TypeError) as e:
             logger.info(str(e))
             return {
                 'question': question,
                 'llmCorrectnessGrade': "incorrect",
-                'llmCorrectnessGradeJustification': "LLM failed grading",
-                'llm_response': completion.get('llm_response', str(completion))  # Store the raw response
+                'llmCorrectnessGradeJustification': f"PARSING_FAILURE: {str(e)}",
+                'llm_response': completion.get('llm_response', str(completion)) if completion else ''
             }
-            
+
 
 class IDKEvaluator(GenerationEvaluator):
+    """Detects whether a response indicates the model couldn't answer the question."""
+
     def __init__(self, model_id):
         super().__init__(model_id)
-    
+
     def evaluate(self, question, answer, response):
         grading = {}
         grading.update(self._llm_evaluate(question, answer, response))
         return grading
-    
+
     def _llm_evaluate(self, question, answer, response):
         prompt = IDK_DETECTION.format(
             question=question,
@@ -189,92 +237,91 @@ class IDKEvaluator(GenerationEvaluator):
             return {
                 "label": "answerable"
             }
-        
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--input-file-path", type=str)
-    parser.add_argument("--metrics-output-path", type=str)
-    parser.add_argument("--eval-artifacts", type=str)
-    parser.add_argument("--metric", type=str, default="correctness", choices=["correctness", "idk", "correctness_on_answerable"])
-    args = parser.parse_args()
 
-    if args.metric == "correctness_on_answerable":
-        eval_correctness_artifact, eval_idk_artifact = args.eval_artifacts.split(",")
-        with open(eval_correctness_artifact) as fin:
-            eval_correctness_data = json.load(fin)
-        with open(eval_idk_artifact) as fin:
-            eval_idk_data = json.load(fin)
-        assert len(eval_correctness_data) == len(eval_idk_data)
-        total, count = 0, 0
-        for correctness_eval, idk_eval in zip(eval_correctness_data, eval_idk_data):
-            if idk_eval["label"] == "answerable":
-                total += 1
-                if correctness_eval["llmCorrectnessGrade"] == "correct":
+def evaluate_responses(data: List[dict], output_dir: str, judge_model_id: str,
+                       metrics: Optional[List[str]] = None) -> Dict[str, float]:
+    """Evaluate a list of response records and write results to output_dir.
+
+    This is the shared evaluation loop used by benchmark_evaluate.py.
+
+    Args:
+        data: List of response dicts, each with 'raw_example' (question/answer) and 'response'.
+        output_dir: Directory to write metric_evals.json and metric.json files.
+        judge_model_id: Bedrock model ID for the evaluation judge.
+        metrics: List of metrics to compute. Defaults to ['correctness', 'idk'].
+
+    Returns:
+        Dict of {metric_name: score} for each computed metric.
+    """
+    if metrics is None:
+        metrics = ['correctness', 'idk']
+
+    # Ensure dependencies are computed before correctness_on_answerable
+    if "correctness_on_answerable" in metrics:
+        for dep in ["correctness", "idk"]:
+            if dep not in metrics:
+                metrics.insert(metrics.index("correctness_on_answerable"), dep)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    scores = {}
+
+    for metric in metrics:
+        if metric == 'correctness_on_answerable':
+            # Requires correctness and idk to have been run first
+            correctness_path = os.path.join(output_dir, 'correctness_evals.json')
+            idk_path = os.path.join(output_dir, 'idk_evals.json')
+            if not os.path.exists(correctness_path) or not os.path.exists(idk_path):
+                logger.warning("Cannot compute correctness_on_answerable without correctness and idk evals")
+                continue
+            with open(correctness_path) as f:
+                correctness_data = json.load(f)
+            with open(idk_path) as f:
+                idk_data = json.load(f)
+            total, count = 0, 0
+            for c_eval, i_eval in zip(correctness_data, idk_data):
+                if i_eval['label'] == 'answerable':
+                    total += 1
+                    if c_eval['llmCorrectnessGrade'] == 'correct':
+                        count += 1
+            score = count / total if total > 0 else 0.0
+        else:
+            if metric == 'correctness':
+                evaluator = CorrectnessEvaluator(model_id=judge_model_id)
+            elif metric == 'idk':
+                evaluator = IDKEvaluator(model_id=judge_model_id)
+            else:
+                logger.warning(f"Unknown metric: {metric} — skipping")
+                continue
+
+            evals = []
+            for example in data:
+                question = example['raw_example']['question']
+                answer = example['raw_example']['answer']
+                response = example['response']
+                evals.append(evaluator.evaluate(question, answer, response))
+
+            # Write per-item evaluation results
+            evals_path = os.path.join(output_dir, f'{metric}_evals.json')
+            with open(evals_path, 'w') as f:
+                json.dump(evals, f, indent=2)
+
+            count, total = 0, len(evals)
+            for e in evals:
+                if metric == 'correctness' and e.get('llmCorrectnessGrade') == 'correct':
                     count += 1
-        logger.info("{}: {}".format(args.metric, count / total))
-    else:
-        if args.metric == "correctness":
-            evaluator = CorrectnessEvaluator(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
-        elif args.metric == "idk":
-            evaluator = IDKEvaluator(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
-        
-
-        data = []
-        with open(args.input_file_path) as fin:
-            for line in fin:
-                data.append(json.loads(line))
-        evaluation_outputs = []
-        for example in tqdm(data):
-            answer = example["raw_example"]["answer"]
-            response = example["response"]
-            question = example["raw_example"]["question"]
-            evaluation_outputs.append(evaluator.evaluate(question, answer, response))
-        count, total = 0, 0
-        for evaluation in evaluation_outputs:
-            total += 1
-            if args.metric == "correctness":
-                if evaluation["llmCorrectnessGrade"] == "correct":
+                elif metric == 'idk' and e.get('label') == 'unanswerable':
                     count += 1
-            if args.metric == "idk":
-                if evaluation["label"] == "unanswerable":
-                    count += 1
-        
-        logger.info("{}: {}".format(args.metric, count / total))
-        os.makedirs(os.path.dirname(args.metrics_output_path), exist_ok=True)
-        with open(args.metrics_output_path, "w") as fout:
-            json.dump(evaluation_outputs, fout, indent=4)
-        with open(os.path.join(os.path.dirname(args.metrics_output_path), "{}.json".format(args.metric)), "w") as fout:
-            json.dump({
-                args.metric: count / total
-            }, fout, indent=4)
+            score = count / total if total > 0 else 0.0
 
-import multiprocessing as mp
-import yaml
+        scores[metric] = score
 
-class SafeCounter():
-    # constructor
-    def __init__(self):
-        # initialize counter
-        self._counter = mp.Value('i', 0)
-        # initialize lock
-        self._lock = mp.Lock()
- 
-    # increment the counter
-    def increment(self):
-        # get the lock
-        with self._lock:
-            self._counter.value += 1
- 
-    # get the counter value
-    def value(self):
-    	with self._lock:
-        	return self._counter.value
-         
-def read_yaml(file_path):
-    if file_path:
-        with open(file_path, 'r') as file:
-            data = yaml.safe_load(file)
-        return data
-    else:
-        return {}
+        # Write aggregate score file
+        score_path = os.path.join(output_dir, f'{metric}.json')
+        with open(score_path, 'w') as f:
+            json.dump({metric: score}, f, indent=2)
+
+        logger.info(f"  {metric}: {score:.4f}")
+
+    return scores

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/run_evaluation.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/run_evaluation.py
@@ -257,7 +257,7 @@ def evaluate_responses(data: List[dict], output_dir: str, judge_model_id: str,
     if metrics is None:
         metrics = ['correctness', 'idk']
 
-    # Ensure dependencies are computed before correctness_on_answerable
+    # if "correctness_on_answerable" in metrics, make sure it's last in the last
     if "correctness_on_answerable" in metrics:
         for dep in ["correctness", "idk"]:
             if dep not in metrics:


### PR DESCRIPTION
## Description

Switch benchmark evaluation judge LLM from Haiku 4.5 to Sonnet 4.6

## Changes

- Introduced BENCHMARK_JUDGE_LLM environment variable (default: us.anthropic.claude-sonnet-4-6) to decouple evaluation judge from extraction/response LLM
- Consolidated evaluation logic into single source of truth
- Added evaluate_responses() shared function to eliminate code duplication
- Added retry limit (max 10 attempts) to call_bedrock_invoke_model — previously had infinite loop
- Made Bedrock region configurable via AWS_REGION/REGION_NAME env vars (was hardcoded us-west-2)

## Problem

The benchmarking evaluation 1st phase used Haiku 4.5 as the judge, which produced less reliable correctness scores

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
