### PR TITLE
[Benchmarking]: Token calculation in benchmarking results

### DIFF
--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_query.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_query.py
@@ -170,7 +170,7 @@ def run_benchmark_query(handler: IntegrationTestHandler,
                 total_ms = math.floor(raw_total_ms) if raw_total_ms is not None else None
 
                 # Extract per-query token usage
-                input_tokens, output_tokens = extract_token_usage(llm_cache)
+                input_tokens, output_tokens, retrieval_context_tokens = extract_token_usage(llm_cache)
 
                 # Classify question hop complexity
                 hop_classification = classify_hop(question)
@@ -201,6 +201,7 @@ def run_benchmark_query(handler: IntegrationTestHandler,
                     'total_ms': total_ms,
                     'input_tokens': input_tokens,
                     'output_tokens': output_tokens,
+                    'retrieval_context_tokens': retrieval_context_tokens,
                     'hop_classification': hop_classification,
                 })
 
@@ -212,6 +213,7 @@ def run_benchmark_query(handler: IntegrationTestHandler,
                     'total_ms': total_ms,
                     'input_tokens': input_tokens,
                     'output_tokens': output_tokens,
+                    'retrieval_context_tokens': retrieval_context_tokens,
                     'hop_classification': hop_classification,
                     'retrieval_iterations': agentic_retrieval_iterations,
                     'agentic_retrieval_ms': agentic_retrieval_ms_val,

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/metrics_summary.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/metrics_summary.py
@@ -128,7 +128,7 @@ def compute_metrics_summary(
     num_with_prompt_tokens = len(per_query_data) - num_missing_token_metadata
     num_with_context_tokens = len(per_query_data) - num_missing_context_token_metadata
 
-    avg_prompt_tokens_per_query = round(
+    avg_input_tokens_per_query = round(
         total_input_tokens / num_with_prompt_tokens, 2
     ) if num_with_prompt_tokens > 0 else None
 
@@ -162,7 +162,7 @@ def compute_metrics_summary(
             'total_input_tokens': total_input_tokens,
             'total_output_tokens': total_output_tokens,
             'total_retrieval_context_tokens': total_retrieval_context_tokens,
-            'avg_prompt_tokens_per_query': avg_prompt_tokens_per_query,
+            'avg_input_tokens_per_query': avg_input_tokens_per_query,
             'avg_retrieval_context_tokens_per_query': avg_retrieval_context_tokens_per_query,
         },
         'estimated_cost_usd': estimated_cost_usd,

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/metrics_summary.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/metrics_summary.py
@@ -104,17 +104,37 @@ def compute_metrics_summary(
     # Compute total tokens (excluding null entries)
     total_input_tokens = 0
     total_output_tokens = 0
+    total_retrieval_context_tokens = 0
     num_missing_token_metadata = 0
+    num_missing_context_token_metadata = 0
 
     for entry in per_query_data:
         input_tokens = entry.get('input_tokens')
         output_tokens = entry.get('output_tokens')
+        retrieval_context_tokens = entry.get('retrieval_context_tokens')
 
         if input_tokens is None or output_tokens is None:
             num_missing_token_metadata += 1
         else:
             total_input_tokens += input_tokens
             total_output_tokens += output_tokens
+
+        if retrieval_context_tokens is None:
+            num_missing_context_token_metadata += 1
+        else:
+            total_retrieval_context_tokens += retrieval_context_tokens
+
+    # Compute per-query averages for token reporting
+    num_with_prompt_tokens = len(per_query_data) - num_missing_token_metadata
+    num_with_context_tokens = len(per_query_data) - num_missing_context_token_metadata
+
+    avg_prompt_tokens_per_query = round(
+        total_input_tokens / num_with_prompt_tokens, 2
+    ) if num_with_prompt_tokens > 0 else None
+
+    avg_retrieval_context_tokens_per_query = round(
+        total_retrieval_context_tokens / num_with_context_tokens, 2
+    ) if num_with_context_tokens > 0 else None
 
     # Compute estimated cost using per-model pricing lookup
     estimated_cost_usd: Optional[float] = None
@@ -136,10 +156,14 @@ def compute_metrics_summary(
         'num_queries': len(per_query_data),
         'num_empty_responses': num_empty,
         'num_missing_token_metadata': num_missing_token_metadata,
+        'num_missing_context_token_metadata': num_missing_context_token_metadata,
         'latency': latency,
         'tokens': {
             'total_input_tokens': total_input_tokens,
             'total_output_tokens': total_output_tokens,
+            'total_retrieval_context_tokens': total_retrieval_context_tokens,
+            'avg_prompt_tokens_per_query': avg_prompt_tokens_per_query,
+            'avg_retrieval_context_tokens_per_query': avg_retrieval_context_tokens_per_query,
         },
         'estimated_cost_usd': estimated_cost_usd,
     }

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/test_metrics_summary.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/test_metrics_summary.py
@@ -82,13 +82,14 @@ class TestAggregateLatencyStatistics:
 
 # Strategy to generate a per-query entry with either valid token counts or None
 def per_query_entry_strategy():
-    """Generate a per-query dict where input_tokens and output_tokens may be None."""
+    """Generate a per-query dict where input_tokens, output_tokens, and retrieval_context_tokens may be None."""
     return st.fixed_dictionaries({
         'retrieval_ms': st.just(100),
         'response_ms': st.just(200),
         'total_ms': st.just(300),
         'input_tokens': st.one_of(st.none(), st.integers(min_value=0, max_value=1_000_000)),
         'output_tokens': st.one_of(st.none(), st.integers(min_value=0, max_value=1_000_000)),
+        'retrieval_context_tokens': st.one_of(st.none(), st.integers(min_value=0, max_value=1_000_000)),
     })
 
 
@@ -152,6 +153,59 @@ class TestNullTokenExclusionProperty:
             f"Expected num_missing_token_metadata={expected_missing_count}, "
             f"got {result['num_missing_token_metadata']}"
         )
+
+
+class TestRetrievalContextTokenAggregation:
+    """
+    Retrieval context token aggregation
+
+    For any list of per-query results, the aggregate retrieval context tokens
+    SHALL include only non-null entries, and avg_retrieval_context_tokens_per_query
+    SHALL equal the arithmetic mean of non-null context token values.
+    """
+
+    @settings(max_examples=100)
+    @given(
+        per_query_data=st.lists(
+            per_query_entry_strategy(),
+            min_size=1,
+            max_size=50,
+        )
+    )
+    def test_retrieval_context_token_aggregation(self, per_query_data):
+        """
+        Verify total_retrieval_context_tokens sums only non-null entries and
+        avg_retrieval_context_tokens_per_query is computed correctly.
+        """
+        result = compute_metrics_summary(
+            per_query_data=per_query_data,
+            retriever_id='traversal',
+            dataset='test_dataset',
+            model_id='us.anthropic.claude-haiku-4-5-20251001-v1:0',
+            num_empty=0,
+        )
+
+        # Compute expected values manually
+        expected_context_sum = 0
+        expected_missing_context_count = 0
+
+        for entry in per_query_data:
+            context_tokens = entry.get('retrieval_context_tokens')
+            if context_tokens is None:
+                expected_missing_context_count += 1
+            else:
+                expected_context_sum += context_tokens
+
+        num_with_context = len(per_query_data) - expected_missing_context_count
+
+        assert result['tokens']['total_retrieval_context_tokens'] == expected_context_sum
+        assert result['num_missing_context_token_metadata'] == expected_missing_context_count
+
+        if num_with_context > 0:
+            expected_avg = round(expected_context_sum / num_with_context, 2)
+            assert result['tokens']['avg_retrieval_context_tokens_per_query'] == expected_avg
+        else:
+            assert result['tokens']['avg_retrieval_context_tokens_per_query'] is None
 
 
 class TestAggregateCostComputationProperty:

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/test_token_tracker.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/test_token_tracker.py
@@ -37,23 +37,23 @@ def _make_bedrock_llm_mock():
 class TestExtractTokenUsageWithNonTrackingCache:
     """Tests for extract_token_usage when given a regular LLMCache."""
 
-    def test_returns_none_none_for_regular_llm_cache(self):
-        """extract_token_usage returns (None, None) for non-TokenTrackingLLMCache."""
+    def test_returns_none_tuple_for_regular_llm_cache(self):
+        """extract_token_usage returns (None, None, None) for non-TokenTrackingLLMCache."""
         mock_llm = MockLLM()
         cache = LLMCache(llm=mock_llm, enable_cache=False)
         result = extract_token_usage(cache)
-        assert result == (None, None)
+        assert result == (None, None, None)
 
 
 class TestExtractTokenUsageWithNonBedrockLLM:
     """Tests for extract_token_usage when LLM is not BedrockConverse."""
 
-    def test_returns_none_none_for_non_bedrock_llm(self):
-        """extract_token_usage returns (None, None) when LLM is not BedrockConverse."""
+    def test_returns_none_tuple_for_non_bedrock_llm(self):
+        """extract_token_usage returns (None, None, None) when LLM is not BedrockConverse."""
         mock_llm = MockLLM()
         cache = TokenTrackingLLMCache(llm=mock_llm, enable_cache=False)
         result = extract_token_usage(cache)
-        assert result == (None, None)
+        assert result == (None, None, None)
 
 
 class TestTokenTrackingExtractTokensFromResponse:
@@ -168,7 +168,7 @@ class TestTokenTrackingLLMCachePredict:
         assert result == "answer text"
         assert cache._last_input_tokens == 200
         assert cache._last_output_tokens == 50
-        assert extract_token_usage(cache) == (200, 50)
+        assert extract_token_usage(cache) == (200, 50, None)
 
     def test_predict_logs_warning_when_tokens_unavailable(self, caplog):
         """Verify WARNING is logged when token metadata unavailable from live call."""
@@ -233,20 +233,22 @@ class TestTokenTrackingLLMCachePredict:
         prompt = PromptTemplate("{query}")
         result = cache.predict(prompt, query="test")
 
-        # Should still return (None, None) for token usage
-        assert extract_token_usage(cache) == (None, None)
+        # Should still return (None, None, None) for token usage
+        assert extract_token_usage(cache) == (None, None, None)
 
-    def test_cache_hit_returns_none_none(self):
-        """Verify (None, None) when response is served from file cache."""
+    def test_cache_hit_returns_none_with_context_tokens(self):
+        """Verify (None, None, context_tokens) when response is served from file cache."""
         mock_llm = _make_bedrock_llm_mock()
 
         cache = TokenTrackingLLMCache(llm=mock_llm, enable_cache=True)
 
         # Simulate a cache hit by setting the flag directly
         cache._last_was_cache_hit = True
+        # Retrieval context tokens may still be available even on cache hits
+        cache._last_retrieval_context_tokens = 500
 
         result = extract_token_usage(cache)
-        assert result == (None, None)
+        assert result == (None, None, 500)
 
     @patch('os.path.exists', return_value=True)
     def test_file_cache_hit_sets_flag(self, mock_exists):
@@ -267,7 +269,9 @@ class TestTokenTrackingLLMCachePredict:
                 pass  # May fail on file read, but flag should be set
 
         assert cache._last_was_cache_hit is True
-        assert extract_token_usage(cache) == (None, None)
+        # On cache hit: prompt tokens None, output tokens None,
+        # but retrieval_context_tokens is still None since no search_results kwarg
+        assert extract_token_usage(cache) == (None, None, None)
 
     def test_predict_resets_state_between_calls(self):
         """Verify token state is reset between predict calls."""
@@ -299,16 +303,132 @@ class TestTokenTrackingLLMCachePredict:
         # First call
         mock_llm.chat = Mock(return_value=response_with_tokens)
         cache.predict(prompt, query="first")
-        assert extract_token_usage(cache) == (100, 20)
+        assert extract_token_usage(cache) == (100, 20, None)
 
         # Second call - tokens should be reset
         mock_llm.chat = Mock(return_value=response_without_tokens)
         cache.predict(prompt, query="second")
-        assert extract_token_usage(cache) == (None, None)
+        assert extract_token_usage(cache) == (None, None, None)
 
 
 from hypothesis import given, settings
-from hypothesis.strategies import integers
+from hypothesis.strategies import integers, text
+
+from graphrag_toolkit_tests.benchmark_utils.token_tracker import estimate_token_count
+
+
+class TestEstimateTokenCount:
+    """Tests for the estimate_token_count utility function."""
+
+    def test_empty_string_returns_zero(self):
+        assert estimate_token_count('') == 0
+
+    def test_none_returns_zero(self):
+        assert estimate_token_count(None) == 0
+
+    def test_short_text(self):
+        # "hello" is 5 chars -> 5 // 4 = 1
+        assert estimate_token_count("hello") == 1
+
+    def test_moderate_text(self):
+        # 100 chars -> 100 // 4 = 25
+        text_100 = "a" * 100
+        assert estimate_token_count(text_100) == 25
+
+    def test_result_is_non_negative_integer(self):
+        assert estimate_token_count("x") >= 0
+        assert isinstance(estimate_token_count("x"), int)
+
+
+class TestRetrievalContextTokenTracking:
+    """Tests for the retrieval context token tracking (dual-field)."""
+
+    def test_captures_search_results_tokens(self):
+        """Verify retrieval_context_tokens is measured from search_results kwarg."""
+        mock_llm = _make_bedrock_llm_mock()
+
+        mock_chat_response = ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="answer"),
+            raw={'usage': {'inputTokens': 5000, 'outputTokens': 100}},
+        )
+        mock_llm.chat = Mock(return_value=mock_chat_response)
+
+        cache = TokenTrackingLLMCache(llm=mock_llm, enable_cache=False)
+        prompt = PromptTemplate("{search_results}\n{query}")
+
+        # search_results of 400 chars -> 400 // 4 = 100 estimated tokens
+        search_results_text = "x" * 400
+        cache.predict(prompt, search_results=search_results_text, query="test question")
+
+        input_tokens, output_tokens, context_tokens = extract_token_usage(cache)
+        assert input_tokens == 5000
+        assert output_tokens == 100
+        assert context_tokens == 100  # 400 chars // 4
+
+    def test_no_search_results_yields_none_context_tokens(self):
+        """Verify retrieval_context_tokens is None when search_results not in prompt args."""
+        mock_llm = _make_bedrock_llm_mock()
+
+        mock_chat_response = ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="answer"),
+            raw={'usage': {'inputTokens': 200, 'outputTokens': 30}},
+        )
+        mock_llm.chat = Mock(return_value=mock_chat_response)
+
+        cache = TokenTrackingLLMCache(llm=mock_llm, enable_cache=False)
+        prompt = PromptTemplate("{query}")
+
+        cache.predict(prompt, query="test question")
+
+        input_tokens, output_tokens, context_tokens = extract_token_usage(cache)
+        assert input_tokens == 200
+        assert output_tokens == 30
+        assert context_tokens is None  # No search_results kwarg
+
+    def test_empty_search_results_yields_none_context_tokens(self):
+        """Verify retrieval_context_tokens is None when search_results is empty string."""
+        mock_llm = _make_bedrock_llm_mock()
+
+        mock_chat_response = ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="answer"),
+            raw={'usage': {'inputTokens': 200, 'outputTokens': 30}},
+        )
+        mock_llm.chat = Mock(return_value=mock_chat_response)
+
+        cache = TokenTrackingLLMCache(llm=mock_llm, enable_cache=False)
+        prompt = PromptTemplate("{search_results}\n{query}")
+
+        cache.predict(prompt, search_results="", query="test question")
+
+        input_tokens, output_tokens, context_tokens = extract_token_usage(cache)
+        assert context_tokens is None  # Empty string -> 0 -> treated as falsy
+
+    def test_context_tokens_always_less_than_or_equal_to_prompt_tokens(self):
+        """Verify retrieval_context_tokens <= prompt_tokens_total conceptually.
+
+        In practice, the char/4 estimate may exceed actual tokenizer count,
+        but for reasonable inputs the context should be smaller than the full prompt.
+        """
+        mock_llm = _make_bedrock_llm_mock()
+
+        # Full prompt is 10000 tokens (includes system prompt + search_results + user prompt)
+        mock_chat_response = ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="answer"),
+            raw={'usage': {'inputTokens': 10000, 'outputTokens': 50}},
+        )
+        mock_llm.chat = Mock(return_value=mock_chat_response)
+
+        cache = TokenTrackingLLMCache(llm=mock_llm, enable_cache=False)
+        prompt = PromptTemplate("{search_results}\n{query}")
+
+        # 2000 chars of context -> ~500 tokens estimate
+        search_results_text = "statement about a topic. " * 80  # ~2000 chars
+        cache.predict(prompt, search_results=search_results_text, query="test")
+
+        input_tokens, output_tokens, context_tokens = extract_token_usage(cache)
+        assert input_tokens == 10000
+        assert context_tokens is not None
+        assert context_tokens < input_tokens
 
 
 class TestTokenCountPreservationProperty:
@@ -353,3 +473,24 @@ class TestTokenCountPreservationProperty:
         assert cache._last_output_tokens == output_tokens, (
             f"Output tokens not preserved: expected {output_tokens}, got {cache._last_output_tokens}"
         )
+
+
+class TestEstimateTokenCountProperty:
+    """
+    Property: estimate_token_count always returns a non-negative integer.
+    """
+
+    @settings(max_examples=100)
+    @given(input_text=text(min_size=0, max_size=500_000))
+    def test_estimate_always_non_negative_int(self, input_text):
+        """For any string input, estimate_token_count returns >= 0 integer."""
+        result = estimate_token_count(input_text)
+        assert isinstance(result, int)
+        assert result >= 0
+
+    @settings(max_examples=100)
+    @given(input_text=text(min_size=1, max_size=500_000))
+    def test_estimate_bounded_by_char_count(self, input_text):
+        """For any non-empty string, estimate <= len(text) (since chars_per_token >= 1)."""
+        result = estimate_token_count(input_text)
+        assert result <= len(input_text)

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/test_token_tracker.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/test_token_tracker.py
@@ -323,9 +323,6 @@ class TestEstimateTokenCount:
     def test_empty_string_returns_zero(self):
         assert estimate_token_count('') == 0
 
-    def test_none_returns_zero(self):
-        assert estimate_token_count(None) == 0
-
     def test_short_text(self):
         # "hello" is 5 chars -> 5 // 4 = 1
         assert estimate_token_count("hello") == 1

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/token_tracker.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/token_tracker.py
@@ -25,8 +25,8 @@ from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT = 60.0
-MAX_ATTEMPTS = 10
+_TIMEOUT = 60.0
+_MAX_ATTEMPTS = 10
 # Approximate chars-per-token ratio, calibrated for Claude-family models on English text.
 # Other model families or non-English content may have a different ratio.
 # For structured text (JSON, code, lists) this can be off by 30-50%; acceptable for
@@ -34,11 +34,21 @@ MAX_ATTEMPTS = 10
 _CHARS_PER_TOKEN = 4
 
 
-def estimate_token_count(text: str) -> int:
-    """Estimate token count using ~4 chars/token heuristic for Claude models."""
+def estimate_token_count(text: str, chars_per_token: int = _CHARS_PER_TOKEN) -> int:
+    """Estimate token count using ~4 chars/token heuristic for Claude models.
+
+    Args:
+        text: The text to estimate token count for.
+        chars_per_token: Override the chars-per-token ratio. Defaults to _CHARS_PER_TOKEN (4),
+            which is calibrated for Claude-family models on English text. Adjust for other
+            model families, non-English content, or structured text (JSON, code).
+
+    Returns:
+        Estimated token count as a non-negative integer.
+    """
     if not text:
         return 0
-    return max(0, len(text) // _CHARS_PER_TOKEN)
+    return max(0, len(text) // chars_per_token)
 
 
 class TokenTrackingLLMCache(LLMCache):
@@ -89,9 +99,9 @@ class TokenTrackingLLMCache(LLMCache):
 
         if not hasattr(self.llm, '_client') or self.llm._client is None:
             config = Config(
-                retries={'max_attempts': MAX_ATTEMPTS, 'mode': 'standard'},
-                connect_timeout=TIMEOUT,
-                read_timeout=TIMEOUT,
+                retries={'max_attempts': _MAX_ATTEMPTS, 'mode': 'standard'},
+                connect_timeout=_TIMEOUT,
+                read_timeout=_TIMEOUT,
             )
             session = GraphRAGConfig.session
             self.llm._client = session.client('bedrock-runtime', config=config)
@@ -135,12 +145,26 @@ class TokenTrackingLLMCache(LLMCache):
 
 
 def extract_token_usage(llm_cache: LLMCache) -> Tuple[Optional[int], Optional[int], Optional[int]]:
-    """
-    Returns (prompt_tokens_total, output_tokens, retrieval_context_tokens).
+    """Extract token usage from a TokenTrackingLLMCache after a predict call.
 
-    Returns (None, None, None) if llm_cache is not a TokenTrackingLLMCache,
-    LLM is not BedrockConverse, or usage metadata is unavailable.
-    On cache hits, prompt/output tokens are None but context tokens may be available.
+    Args:
+        llm_cache: The LLM cache instance to extract token usage from.
+
+    Returns:
+        A 3-tuple of (input_tokens, output_tokens, retrieval_context_tokens) where:
+          - input_tokens: Full prompt token count from Bedrock usage metadata
+            (system prompt + retrieval context + query). None on cache hits or if
+            unavailable.
+          - output_tokens: Generated output token count from Bedrock usage metadata.
+            None on cache hits or if unavailable.
+          - retrieval_context_tokens: Estimated token count of just the retrieval
+            context (search_results), computed via char/token heuristic before prompt
+            assembly. None if search_results was absent or empty.
+
+        Returns (None, None, None) if llm_cache is not a TokenTrackingLLMCache,
+        the LLM is not BedrockConverse, or usage metadata is unavailable.
+        On cache hits, input/output tokens are None but retrieval_context_tokens
+        may still be populated.
     """
     if not isinstance(llm_cache, TokenTrackingLLMCache):
         return (None, None, None)

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/token_tracker.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/benchmark_utils/token_tracker.py
@@ -4,8 +4,11 @@
 """
 Token tracking utilities for capturing Bedrock converse API token usage.
 
-Provides a wrapper around LLMCache that intercepts predict calls to capture
-input/output token counts from Bedrock converse responses.
+Tracks two measurements:
+- prompt_tokens_total: Full LLM prompt tokens from Bedrock usage metadata
+  (system prompt + retrieval context + query).
+- retrieval_context_tokens: Estimated token count of just the retrieval context
+  (search_results param), measured via char/4 approximation before prompt assembly.
 """
 
 import os
@@ -24,21 +27,29 @@ logger = logging.getLogger(__name__)
 
 TIMEOUT = 60.0
 MAX_ATTEMPTS = 10
+# Approximate chars-per-token ratio, calibrated for Claude-family models on English text.
+# Other model families or non-English content may have a different ratio.
+# For structured text (JSON, code, lists) this can be off by 30-50%; acceptable for
+# directional metrics but worth refining if tighter estimates are needed.
+_CHARS_PER_TOKEN = 4
+
+
+def estimate_token_count(text: str) -> int:
+    """Estimate token count using ~4 chars/token heuristic for Claude models."""
+    if not text:
+        return 0
+    return max(0, len(text) // _CHARS_PER_TOKEN)
 
 
 class TokenTrackingLLMCache(LLMCache):
     """
-    Wraps LLMCache to capture Bedrock converse response token usage
-    (usage.inputTokens / usage.outputTokens) after each predict call.
-
-    Token usage is available when:
-    - The underlying LLM is a BedrockConverse instance
-    - The response is NOT served from the file cache
-    - The Bedrock response contains usage metadata
+    Wraps LLMCache to capture Bedrock token usage after each predict call.
+    Also measures retrieval context tokens separately from full prompt tokens.
     """
 
     _last_input_tokens: Optional[int] = None
     _last_output_tokens: Optional[int] = None
+    _last_retrieval_context_tokens: Optional[int] = None
     _last_was_cache_hit: bool = False
 
     def predict(
@@ -46,24 +57,22 @@ class TokenTrackingLLMCache(LLMCache):
         prompt: BasePromptTemplate,
         **prompt_args: Any,
     ) -> str:
-        """
-        Predict with token usage tracking.
-
-        For BedrockConverse LLMs, calls chat() directly to access the full
-        ChatResponse (which contains token usage in .raw['usage']).
-        Falls back to parent predict() for non-Bedrock LLMs or cache hits.
-        """
         self._last_input_tokens = None
         self._last_output_tokens = None
+        self._last_retrieval_context_tokens = None
         self._last_was_cache_hit = False
+
+        search_results = prompt_args.get('search_results', '')
+        # Intentionally treats both missing and empty search_results as "no context":
+        # retrieval_context_tokens stays None to distinguish "not measured" from "zero tokens".
+        if search_results:
+            self._last_retrieval_context_tokens = estimate_token_count(search_results)
 
         if not isinstance(self.llm, BedrockConverse):
             return super().predict(prompt, **prompt_args)
 
-        # Format the prompt
         formatted_prompt = prompt.format(**prompt_args)
 
-        # Check file cache
         if self.enable_cache:
             prompt_args_copy = prompt_args.copy()
             for key in prompt_args.get('exclude_cache_keys', []):
@@ -78,7 +87,6 @@ class TokenTrackingLLMCache(LLMCache):
                 with open(cache_file, 'r', encoding='utf-8') as f:
                     return f.read()
 
-        # Ensure the Bedrock client is initialized
         if not hasattr(self.llm, '_client') or self.llm._client is None:
             config = Config(
                 retries={'max_attempts': MAX_ATTEMPTS, 'mode': 'standard'},
@@ -88,26 +96,19 @@ class TokenTrackingLLMCache(LLMCache):
             session = GraphRAGConfig.session
             self.llm._client = session.client('bedrock-runtime', config=config)
 
-        # Call chat() directly to get the full ChatResponse with token metadata
         messages = [ChatMessage(role=MessageRole.USER, content=formatted_prompt)]
         chat_response = self.llm.chat(messages)
 
-        # Extract the text response
         response_text = chat_response.message.content if chat_response.message else ''
-
-        # Extract token usage from the raw Bedrock response
         self._extract_tokens_from_response(chat_response)
 
-        # Write to cache if enabled
         if self.enable_cache:
             os.makedirs(os.path.dirname(os.path.realpath(cache_file)), exist_ok=True)
             with open(cache_file, 'w') as f:
                 f.write(response_text)
 
         if self._last_input_tokens is None:
-            logger.warning(
-                "Token metadata unavailable from live Bedrock invocation"
-            )
+            logger.warning("Token metadata unavailable from live Bedrock invocation")
 
         return response_text
 
@@ -133,23 +134,25 @@ class TokenTrackingLLMCache(LLMCache):
             pass
 
 
-def extract_token_usage(llm_cache: LLMCache) -> Tuple[Optional[int], Optional[int]]:
+def extract_token_usage(llm_cache: LLMCache) -> Tuple[Optional[int], Optional[int], Optional[int]]:
     """
-    Extracts input_tokens and output_tokens from the last Bedrock invocation.
+    Returns (prompt_tokens_total, output_tokens, retrieval_context_tokens).
 
-    Returns (None, None) if:
-    - Response was served from file cache
-    - LLM is not BedrockConverse
-    - Usage metadata is unavailable
-    - llm_cache is not a TokenTrackingLLMCache instance
+    Returns (None, None, None) if llm_cache is not a TokenTrackingLLMCache,
+    LLM is not BedrockConverse, or usage metadata is unavailable.
+    On cache hits, prompt/output tokens are None but context tokens may be available.
     """
     if not isinstance(llm_cache, TokenTrackingLLMCache):
-        return (None, None)
+        return (None, None, None)
 
     if llm_cache._last_was_cache_hit:
-        return (None, None)
+        return (None, None, llm_cache._last_retrieval_context_tokens)
 
     if not isinstance(llm_cache.llm, BedrockConverse):
-        return (None, None)
+        return (None, None, None)
 
-    return (llm_cache._last_input_tokens, llm_cache._last_output_tokens)
+    return (
+        llm_cache._last_input_tokens,
+        llm_cache._last_output_tokens,
+        llm_cache._last_retrieval_context_tokens,
+    )


### PR DESCRIPTION
## Description

Add dual-field token tracking to separate retrieval context tokens from full prompt tokens in benchmark pipeline

## Changes

<!-- List the key changes made -->

- Added retrieval_context_tokens field to TokenTrackingLLMCache that measures just the search_results parameter (retrieval context) using a char/4 approximation, separate from Bedrock's full prompt inputTokens
- Updated benchmark_query.py to capture and persist retrieval_context_tokens in the per-query JSONL output
- Extended metrics_summary.py to aggregate retrieval context tokens separately, reporting total_retrieval_context_tokens, avg_retrieval_context_tokens_per_query, and num_missing_context_token_metadata
- Added estimate_token_count() utility function

## Problem

Investigating token calculation discrepancy

## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
