### PR TITLE
[FIX] Escape Cypher labels in lexical-graph graph stores

### DIFF
--- a/lexical-graph-contrib/falkordb/tests/conftest.py
+++ b/lexical-graph-contrib/falkordb/tests/conftest.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def pytest_configure(config):
+    """Register the ``integration`` marker so it is known in every run context,
+    whether the contrib package is tested standalone or alongside others."""
+    config.addinivalue_line(
+        'markers',
+        'integration: needs a live FalkorDB; skipped automatically when unreachable',
+    )

--- a/lexical-graph-contrib/falkordb/tests/test_label_injection_live.py
+++ b/lexical-graph-contrib/falkordb/tests/test_label_injection_live.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live Cypher label-injection test against a real FalkorDB graph.
+
+Exercises the exact query shape that ``EntityGraphBuilder`` emits for a domain
+entity, driving a malicious classification through the real ``label_from`` and
+``escape_cypher_label`` helpers, and confirms against a running FalkorDB that:
+
+  * the escaped (patched) query leaves a seeded canary node untouched, and
+  * the un-escaped (pre-patch) query DOES delete the canary - a red-state proof
+    that this test actually detects the regression rather than passing vacuously.
+
+The malicious classification is ``__...__`` wrapped so that ``label_from`` passes
+it through unescaped; un-escaped it closes the SET label and runs a DETACH DELETE
+on the canary, with a trailing ``//`` that comments out the rest of the line.
+
+Marked ``integration`` and skips automatically when no FalkorDB is reachable, so
+it is CI-safe.
+
+Run a FalkorDB locally first, e.g. (Docker Hub blocked? use an internal mirror):
+
+    finch run -d --name falkordb -p 6379:6379 docker.io/falkordb/falkordb:latest
+    FALKORDB_URL=falkordb://localhost:6379 \
+      pytest lexical-graph-contrib/falkordb/tests/test_label_injection_live.py -v
+"""
+
+import os
+import uuid
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.storage import GraphStoreFactory
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import (
+    label_from,
+    escape_cypher_label,
+)
+from graphrag_toolkit_contrib.lexical_graph.storage.graph.falkordb import (
+    FalkorDBGraphStoreFactory,
+)
+
+pytestmark = pytest.mark.integration
+
+FALKORDB_URL = os.environ.get('FALKORDB_URL', 'falkordb://localhost:6379')
+
+CANARY_LABEL = '__InjCanary__'
+CANARY_ID = 'inj-canary'
+
+MALICIOUS_CLASSIFICATION = (
+    f'__Evil` WITH e MATCH (c:`{CANARY_LABEL}`) DETACH DELETE c //__'
+)
+
+
+@pytest.fixture(scope='module')
+def graph_store():
+    GraphStoreFactory.register(FalkorDBGraphStoreFactory)
+    try:
+        store = GraphStoreFactory.for_graph_store(FALKORDB_URL)
+        store.execute_query_with_retry('RETURN 1 AS ok', {})
+    except Exception as e:  # noqa: BLE001 - any connection failure -> skip
+        pytest.skip(f'FalkorDB not reachable at {FALKORDB_URL}: {e}')
+    return store
+
+
+def _canary_count(store):
+    rows = store.execute_query_with_retry(
+        f'MATCH (c:`{CANARY_LABEL}`) RETURN count(c) AS n', {}
+    )
+    return rows[0]['n'] if rows else 0
+
+
+def _seed_canary(store):
+    store.execute_query_with_retry(
+        f'MERGE (c:`{CANARY_LABEL}` {{id: $id}})', {'id': CANARY_ID}
+    )
+
+
+def _cleanup(store):
+    store.execute_query_with_retry(
+        'MATCH (n) WHERE n.id = $id OR n.entityId = $eid DETACH DELETE n',
+        {'id': CANARY_ID, 'eid': _entity_id()},
+    )
+
+
+def _entity_id():
+    return f'ent-{uuid.uuid5(uuid.NAMESPACE_DNS, MALICIOUS_CLASSIFICATION).hex}'
+
+
+def _patched_query(store, e_id, classification):
+    """Mirror of the patched EntityGraphBuilder construction."""
+    e_label = label_from(classification)
+    safe = escape_cypher_label(e_label)
+    return (
+        f"MERGE (e:`__Entity__`{{{store.node_id('entityId')}: $entityId}}) "
+        f"SET e :`{safe}` // awsqid"
+    ), {'entityId': e_id}
+
+
+def _vulnerable_query(store, e_id, classification):
+    """Mirror of the PRE-patch construction (inlined id, un-escaped label)."""
+    e_label = label_from(classification)
+    return (
+        f"MERGE (e:`__Entity__`{{{store.node_id('entityId')}: '{e_id}'}}) "
+        f"SET e :`{e_label}` // awsqid"
+    ), {}
+
+
+def test_patched_query_does_not_inject(graph_store):
+    """The escaped/parameterised query runs without the injected DETACH DELETE,
+    so the seeded canary survives."""
+    store = graph_store
+    _cleanup(store)
+    _seed_canary(store)
+    assert _canary_count(store) == 1
+
+    query, params = _patched_query(store, _entity_id(), MALICIOUS_CLASSIFICATION)
+    store.execute_query_with_retry(query, params)
+
+    assert _canary_count(store) == 1
+    _cleanup(store)
+
+
+def test_vulnerable_query_proves_canary_is_deletable(graph_store):
+    """Red-state: the pre-patch query injects and deletes the canary, proving
+    the canary mechanism is real and the patched test above is meaningful."""
+    store = graph_store
+    _cleanup(store)
+    _seed_canary(store)
+    assert _canary_count(store) == 1
+
+    query, params = _vulnerable_query(store, _entity_id(), MALICIOUS_CLASSIFICATION)
+    store.execute_query_with_retry(query, params)
+
+    assert _canary_count(store) == 0
+    _cleanup(store)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from graphrag_toolkit.lexical_graph.indexing.model import Fact, Entity
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
-from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import search_string_from, label_from, new_query_var
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import search_string_from, label_from, new_query_var, escape_cypher_label
 from graphrag_toolkit.lexical_graph.indexing.build.graph_builder import GraphBuilder
 from graphrag_toolkit.lexical_graph.indexing.constants import DEFAULT_CLASSIFICATION, LOCAL_ENTITY_CLASSIFICATION
 from graphrag_toolkit.lexical_graph.indexing.utils.fact_utils import string_complement_to_entity
@@ -110,16 +110,26 @@ class EntityGraphBuilder(GraphBuilder):
             if include_domain_labels:
 
                 def insert_domain_entity(entity:Entity):
+                    """
+                    Add the entity's domain label (its classification) to the
+                    `__Entity__` node.
 
+                    The classification reaches a backtick-quoted Cypher label, and
+                    `label_from` passes `__...__` values through unescaped, so the
+                    label is escaped with `escape_cypher_label` and the entity id is
+                    bound as a parameter rather than inlined into a string literal.
+                    Newlines are stripped from the trailing `//` comment so a crafted
+                    label cannot terminate it and append further Cypher.
+                    """
                     if entity.classification and entity.classification == LOCAL_ENTITY_CLASSIFICATION:
                         return
 
                     e_var = new_query_var()
                     e_id = entity.entityId
-                    e_label = label_from(entity.classification or DEFAULT_CLASSIFICATION)
-                    e_comment = f'// awsqid:{e_id}-{e_label}'
-                    query_e = f"MERGE ({e_var}:`__Entity__`{{{graph_client.node_id('entityId')}: '{e_id}'}}) SET {e_var} :`{e_label}` {e_comment}"    
-                    graph_client.execute_query_with_retry(query_e, {}, max_attempts=5, max_wait=7)
+                    e_label = escape_cypher_label(label_from(entity.classification or DEFAULT_CLASSIFICATION))
+                    e_comment = f'// awsqid:{e_id}-{e_label}'.replace('\r', ' ').replace('\n', ' ')
+                    query_e = f"MERGE ({e_var}:`__Entity__`{{{graph_client.node_id('entityId')}: $entityId}}) SET {e_var} :`{e_label}` {e_comment}"
+                    graph_client.execute_query_with_retry(query_e, {'entityId': e_id}, max_attempts=5, max_wait=7)
 
                 insert_domain_entity(fact.subject)
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
@@ -52,9 +52,34 @@ def label_from(value:str):
     """
     if value.startswith('__') and value.endswith('__'):
         return value
-    
+
     value = SEARCH_STRING_PATTERN.sub(' ', value)
     return string.capwords(value).replace(' ', '')
+
+def escape_cypher_label(label:str) -> str:
+    """
+    Escape backticks before a label is interpolated into a backtick-quoted Cypher
+    identifier (`:`{label}``).
+
+    Doubling is Cypher's escape rule for an embedded backtick; without it a label
+    containing a backtick can close the identifier early and inject arbitrary
+    Cypher. Note that `label_from` does not guarantee a safe label - it passes
+    `__...__` reserved-style values through unchanged - so any label-position
+    interpolation must route through this function regardless of provenance.
+
+    Args:
+        label (str): The label to escape.
+
+    Returns:
+        str: The label with every backtick doubled.
+
+    Raises:
+        TypeError: If `label` is not a string, so an unsafe query is never built
+            silently from a non-string value.
+    """
+    if not isinstance(label, str):
+        raise TypeError(f'Cypher label must be a string, got {type(label).__name__}')
+    return label.replace('`', '``')
 
 def relationship_name_from(value:str):
     """

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/neptune_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/neptune_vector_indexes.py
@@ -9,7 +9,7 @@ from graphrag_toolkit.lexical_graph.metadata import FilterConfig
 from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
 from graphrag_toolkit.lexical_graph.storage import GraphStoreFactory
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore, MultiTenantGraphStore
-from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import node_result, filter_config_to_opencypher_filters
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import node_result, filter_config_to_opencypher_filters, escape_cypher_label
 from graphrag_toolkit.lexical_graph.storage.graph.neptune_graph_stores import NeptuneAnalyticsClient
 from graphrag_toolkit.lexical_graph.storage.vector import VectorIndex, VectorIndexFactoryMethod, to_embedded_query
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
@@ -181,7 +181,7 @@ class NeptuneIndex(VectorIndex):
         
         for node in nodes:
         
-            statement = f"MATCH (n:`{self.label}`) WHERE {self.neptune_client.node_id('n.{self.id_name}')} = $nodeId"
+            statement = f"MATCH (n:`{escape_cypher_label(self.label)}`) WHERE {self.neptune_client.node_id('n.{self.id_name}')} = $nodeId"
             
             embedding = id_to_embed_map[node.node_id]
             
@@ -262,7 +262,7 @@ class NeptuneIndex(VectorIndex):
         for i in set(ids):
 
             cypher = f'''
-            MATCH (n:`{self.label}`)  WHERE {self.neptune_client.node_id('n.{self.id_name}')} = $elementId
+            MATCH (n:`{escape_cypher_label(self.label)}`)  WHERE {self.neptune_client.node_id('n.{self.id_name}')} = $elementId
             CALL neptune.algo.vectors.get(
                 n
             )

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/repair_opensearch_vector_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/repair_opensearch_vector_store.py
@@ -10,6 +10,7 @@ from graphrag_toolkit.lexical_graph import TenantId, TenantIdType, to_tenant_id,
 from graphrag_toolkit.lexical_graph.storage import GraphStoreFactory
 from graphrag_toolkit.lexical_graph.storage import VectorStoreFactory
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore, MultiTenantGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import escape_cypher_label
 from graphrag_toolkit.lexical_graph.storage.vector import VectorStore, MultiTenantVectorStore, ReadOnlyVectorStore
 from graphrag_toolkit.lexical_graph.storage.vector.opensearch_vector_indexes import OpenSearchIndex
 from graphrag_toolkit.lexical_graph.storage.constants import ALL_EMBEDDING_INDEXES
@@ -51,7 +52,7 @@ def get_node_ids(tenant_id:TenantId, index_name:str, graph_store:GraphStore):
     id_name = f'n.{index_name}Id'
     id_selector = graph_store.node_id(id_name)
     
-    cypher = f'MATCH (n:`{label_name}`) RETURN {id_selector} AS node_id'
+    cypher = f'MATCH (n:`{escape_cypher_label(label_name)}`) RETURN {id_selector} AS node_id'
 
     multi_tenant_graph_store = MultiTenantGraphStore.wrap(
         graph_store,

--- a/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_label_injection.py
+++ b/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_label_injection.py
@@ -1,0 +1,87 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drives the real EntityGraphBuilder with a malicious entity classification and
+captures the Cypher it emits, asserting the domain-entity query is escaped and
+parameterised (no label breakout, no inlined id literal).
+
+The classification is ``__...__`` wrapped so label_from passes it through
+unescaped; un-escaped it would close the SET label and append a DETACH DELETE."""
+
+from llama_index.core.schema import TextNode
+
+from graphrag_toolkit.lexical_graph.indexing.build.entity_graph_builder import (
+    EntityGraphBuilder,
+)
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import (
+    label_from,
+    escape_cypher_label,
+)
+
+MALICIOUS_CLASSIFICATION = '__Evil` WITH e MATCH (c:`__Canary__`) DETACH DELETE c //__'
+ENTITY_ID = 'ent-deadbeef'
+
+
+class _CapturingClient:
+    def __init__(self):
+        self.queries = []
+
+    def node_id(self, name):
+        return name
+
+    def execute_query_with_retry(self, query, params, **kwargs):
+        self.queries.append((query, params))
+        return []
+
+
+def _fact_node():
+    return TextNode(
+        text='x',
+        metadata={
+            'fact': {
+                'factId': 'fact-1',
+                'subject': {
+                    'entityId': ENTITY_ID,
+                    'value': 'Acme',
+                    'classification': MALICIOUS_CLASSIFICATION,
+                },
+                'predicate': {'value': 'operates'},
+                'object': None,
+            }
+        },
+    )
+
+
+def _domain_query(client):
+    """Return the captured domain-entity statement (the one carrying awsqid)."""
+    domain = [q for q, _ in client.queries if 'awsqid' in q]
+    assert domain, 'expected a domain-entity query to be emitted'
+    return domain[0]
+
+
+def test_domain_entity_query_is_escaped_and_parameterised():
+    """The real builder emits the escaped label (not the raw label-wrap) and binds
+    entityId as a parameter instead of inlining it as a string literal."""
+    client = _CapturingClient()
+    EntityGraphBuilder().build(
+        _fact_node(),
+        client,
+        include_domain_labels=True,
+        include_local_entities=False,
+    )
+
+    query = _domain_query(client)
+
+    safe = escape_cypher_label(label_from(MALICIOUS_CLASSIFICATION))
+    raw = label_from(MALICIOUS_CLASSIFICATION)
+    assert f':`{safe}`' in query
+    assert f':`{raw}`' not in query
+    assert '$entityId' in query
+    assert f"'{ENTITY_ID}'" not in query
+
+
+def test_label_from_passthrough_is_the_precondition():
+    """Why escaping is required: label_from does not sanitise a __...__ value, so
+    the dangerous backtick survives into the label and must be escaped downstream."""
+    assert label_from(MALICIOUS_CLASSIFICATION) == MALICIOUS_CLASSIFICATION
+    assert '`' in label_from(MALICIOUS_CLASSIFICATION)

--- a/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
+++ b/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
@@ -14,6 +14,7 @@ from llama_index.core.vector_stores.types import (
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig
 from graphrag_toolkit.lexical_graph.storage.graph.graph_store import NodeId
 from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import (
+    escape_cypher_label,
     filter_config_to_opencypher_filters,
     formatter_for_type,
     label_from,
@@ -72,6 +73,39 @@ class TestLabelFrom:
 
     def test_single_word(self):
         assert label_from('chunk') == 'Chunk'
+
+
+class TestEscapeCypherLabel:
+    """escape_cypher_label doubles every backtick so a label cannot break out of
+    its backtick-quoted identifier, and rejects non-string input."""
+
+    def test_plain_label_unchanged(self):
+        assert escape_cypher_label('Person') == 'Person'
+
+    def test_doubles_single_backtick(self):
+        assert escape_cypher_label('a`b') == 'a``b'
+
+    def test_doubles_every_backtick(self):
+        assert escape_cypher_label('`x`y`') == '``x``y``'
+
+    def test_breakout_payload_is_neutralised(self):
+        """A label crafted to close the identifier and append a DETACH DELETE
+        leaves no lone (un-doubled) backtick, so the injection stays inert."""
+        escaped = escape_cypher_label('Evil`) MATCH (c:`Canary`) DETACH DELETE c //')
+        assert '`' not in escaped.replace('``', '')
+        assert escaped == 'Evil``) MATCH (c:``Canary``) DETACH DELETE c //'
+
+    def test_closes_label_from_dunder_passthrough(self):
+        """label_from passes __...__ values through unescaped, so escaping must
+        still neutralise a backtick smuggled inside one."""
+        raw = label_from('__a`b__')
+        assert raw == '__a`b__'
+        assert escape_cypher_label(raw) == '__a``b__'
+
+    @pytest.mark.parametrize('bad', [None, 123, b'Person', ['Person']])
+    def test_non_string_raises_type_error(self, bad):
+        with pytest.raises(TypeError):
+            escape_cypher_label(bad)
 
 
 class TestRelationshipNameFrom:


### PR DESCRIPTION
## Description

The lexical-graph graph stores interpolate node/relationship label names directly into backtick-quoted Cypher identifiers (`` :`{label}` ``). A label containing a backtick can close the identifier early and inject arbitrary Cypher. This applies the same backtick-escaping mitigation already landed for byokg-rag in #305, but in the lexical-graph package, behind a single shared helper applied at every label-position sink.

The main data-driven surface is `EntityGraphBuilder`: an entity's domain label comes from `label_from(classification)`, and `label_from` deliberately passes `__...__`-style reserved values through **unchanged**, so a crafted classification reaches the backtick-quoted label unescaped.

## Changes

- New `escape_cypher_label()` in `storage/graph/graph_utils.py` — doubles backticks (Cypher's escape rule) and raises `TypeError` on non-string input.
- `indexing/build/entity_graph_builder.py` — escape the domain-entity label, bind `entityId` as a query parameter instead of inlining it into a string literal, and strip newlines from the trailing `//` comment so a crafted label cannot terminate it and append Cypher.
- `storage/vector/neptune_vector_indexes.py` — escape `self.label` in the add/get-embedding queries (previously raw).
- `storage/vector/repair_opensearch_vector_store.py` — escape the derived `label_name`.

**Out of scope (intentional):** the `top_k` / `get_embeddings` vertex-filter values interpolate a tenant-derived label into a *string literal* (not a label identifier) and already strip backticks. That's a different sink, config-derived, so it's left unchanged here.

## Problem

Label names reach Cypher identifier positions that cannot be parameterised, so a value containing a backtick can break out and inject Cypher. `label_from` does not sanitise reserved `__...__` values, so escaping at the sink is required regardless of provenance.

## Testing

- Unit coverage for `escape_cypher_label`, including the `label_from` `__...__` passthrough and non-string `TypeError`.
- A test that drives the **real** `EntityGraphBuilder` with a malicious classification and asserts the emitted domain-entity query is escaped and parameterised (raw label-wrap absent, `$entityId` bound).
- A live FalkorDB canary injection test (`@pytest.mark.integration`, skips automatically when no graph is reachable) with a red-state proof that the pre-patch query deletes a seeded canary while the patched query does not.
- Full lexical-graph unit suite: every touched module passes. (The live FalkorDB test was authored and skip-guarded but not executed in my environment — Docker Hub is unreachable there; it runs wherever a FalkorDB image/registry is available.)

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (live FalkorDB run pending an environment with registry access)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)
