### PR TITLE
feat(retrieval): add TopicBeamSearch retriever (TopicGraphRAG)

### DIFF
--- a/docs-site/src/content/docs/lexical-graph/traversal-based-search.mdx
+++ b/docs-site/src/content/docs/lexical-graph/traversal-based-search.mdx
@@ -89,13 +89,35 @@ An entity network context consists of a filtered and ranked network of entities 
 
 ### Retrievers
 
-Traversal-based search provides three different retrievers:
+Traversal-based search provides four different retrievers:
 
   - The `ChunkBasedSearch` retriever uses a vector similarity search to find information that is similar to the original query. The retriever first finds relevant chunks using vector similarity search. From these chunks, the retriever traverses topics, statements, and facts. Chunk-based search tends to return a narrowly-scoped set of results based on the statement and fact neighbourhoods of chunks that match the original query.
 	- The `EntityBasedSearch` retriever uses as its starting points the entities in an entity network context. From these entities, the retriever traverses facts, statements and topics. Entity-based search tends to return a broadly-scoped set of results, based on the neighbourhoods of individual entities and the facts that connect entities.
 	- The `EntityNetworkSearch` retriever uses textual transcriptions of an entity network context to drive vector searches for information that is dissimilar to the original query but nonetheless structurally relevant for creating an accurate and full response. These vector searches return chunks that are similar to 'something different from the question being asked'. From these chunks, the retriever traverses topics, statements, and facts to explore the structurally relevant space of dissimilar content.
-	
-By default, the traversal-based search is configured to use a combination of `ChunkBasedSearch` and `EntityNetworkSearch`. Together, these two retrievers provide access to content that is similar to the question being asked, plus content that is similar to 'something different from the question being asked'.
+	- The `TopicBeamSearch` retriever starts from the most relevant topics (found by a vector similarity search over the topic index) and then performs a beam search across the topic graph to gather additional related topics, before expanding the winning topics into their statements. Because it is topic-first, it tends to assemble a focused, topic-coherent set of statements and works well on multi-hop, legal, and temporal questions.
+
+By default, the traversal-based search is configured to use a combination of `ChunkBasedSearch` and `EntityNetworkSearch`. Together, these two retrievers provide access to content that is similar to the question being asked, plus content that is similar to 'something different from the question being asked'. `TopicBeamSearch` is used as a standalone, topic-first alternative.
+
+#### TopicBeamSearch options
+
+`TopicBeamSearch` accepts a notable option:
+
+  - `topic_reranker` (default `'none'`): optionally reranks the gathered topics by relevance to the query before their statements are collected, keeping the top `max_topics`. It mirrors the statement `reranker` option and accepts `'tfidf'` or `'bedrock'` (Cohere). Topic reranking is an opt-in, per-corpus tuning lever: it can help when answers are concentrated in a few topics, but is not enabled by default.
+
+The beam's neighbour-edge strategy and other tuning are configured through `ProcessorArgs`
+(mirroring the `chunk_beam_*` parameters), so they can be passed to
+`for_traversal_based_search(...)`:
+
+  - `use_same_chunk_neighbors` (default `True`) and `use_adjacent_chunk_neighbors`
+    (default `True`): expand the beam to topics co-occurring in the same chunk and in the
+    adjacent (next) chunk. Adjacent-chunk expansion is on by default because it improved
+    accuracy across datasets with no regressions in our benchmarks.
+  - `use_entity_neighbors` (default `False`): expand to topics linked through shared
+    entities. This has a large fan-out and tends to add noise, so it is off by default;
+    when enabled, `max_entity_neighbors` (default `100`) caps the neighbours per topic,
+    ranked by entity-connection strength.
+  - `topic_beam_width` (default `100`), `topic_beam_max_depth` (default `6`),
+    `topic_top_k` (default `50`): beam breadth, walk depth, and number of seed topics.
 
 ### Search results
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/bedrock_context_format.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/bedrock_context_format.py
@@ -88,7 +88,16 @@ class BedrockContextFormat(BaseNodePostprocessor):
         if not nodes:
             return [NodeWithScore(node=TextNode(text='No relevant context'))]
 
-        # Group nodes by source
+        # Traversal-based retrievers (e.g. TopicBeamSearch, TopicBasedSearch) return one
+        # node per SearchResult, carrying the full source->topics->statements tree in
+        # metadata['result']. Format those as nested source/topic/statement XML so the
+        # topic grouping is preserved, with statements kept in document order within
+        # each topic.
+        result_nodes = [n for n in nodes if n.node.metadata.get('result')]
+        if result_nodes:
+            return self._format_search_result_nodes(result_nodes)
+
+        # Legacy per-statement nodes: group by source, emit per-statement XML.
         sources: Dict[str, List[NodeWithScore]] = {}
         for node in nodes:
             source_id = node.node.metadata['source']['sourceId']
@@ -124,3 +133,51 @@ class BedrockContextFormat(BaseNodePostprocessor):
             formatted_sources.append("\n".join(source_output))
         
         return [NodeWithScore(node=TextNode(text=formatted_source)) for formatted_source in formatted_sources]
+
+    @staticmethod
+    def _doc_order_key(statement: dict):
+        """Document-order proxy for a statement: chunk sequence, then statement id."""
+        return (str(statement.get('chunkId') or ''), str(statement.get('statementId') or ''))
+
+    @staticmethod
+    def _format_statement_text(statement: dict) -> str:
+        text = statement.get('statement', '') or ''
+        details = statement.get('details')
+        if details:
+            details = details.strip().replace('\n', ', ')
+            return f"{text} (details: {details})"
+        return text
+
+    def _format_search_result_nodes(self, nodes: List[NodeWithScore]) -> List[NodeWithScore]:
+        """Format traversal SearchResult nodes as nested source/topic/statement XML.
+
+        One node = one source. Topic grouping is preserved; statements within a topic
+        are ordered by document position (chunkId, statementId) so the generator reads
+        them in their original narrative order.
+        """
+        formatted_sources = []
+        for source_count, node in enumerate(nodes, 1):
+            result = node.node.metadata.get('result') or {}
+            source = result.get('source', {}) or {}
+            out = [f"<source_{source_count}>"]
+
+            metadata = source.get('metadata', {}) or {}
+            if metadata:
+                out.append(f"<source_{source_count}_metadata>")
+                for key, value in sorted(metadata.items()):
+                    out.append(f"\t<{key}>{value}</{key}>")
+                out.append(f"</source_{source_count}_metadata>")
+
+            for topic_count, topic in enumerate(result.get('topics', []), 1):
+                topic_name = (topic.get('topic') or '').replace('"', "'")
+                out.append(f'<topic_{source_count}.{topic_count} name="{topic_name}">')
+                statements = sorted(topic.get('statements', []), key=self._doc_order_key)
+                for st_count, statement in enumerate(statements, 1):
+                    tag = f"statement_{source_count}.{topic_count}.{st_count}"
+                    out.append(f"<{tag}>{self._format_statement_text(statement)}</{tag}>")
+                out.append(f"</topic_{source_count}.{topic_count}>")
+
+            out.append(f"</source_{source_count}>")
+            formatted_sources.append("\n".join(out))
+
+        return [NodeWithScore(node=TextNode(text=fs)) for fs in formatted_sources]

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/__init__.py
@@ -15,6 +15,7 @@ from .prune_results import PruneResults
 from .prune_statements import PruneStatements
 from .remove_versioning_metadata import RemoveVersioningMetadata
 from .rerank_statements import RerankStatements
+from .rerank_topics import RerankTopics
 from .rescore_results import RescoreResults
 from .simplify_single_topic_results import SimplifySingleTopicResults
 from .sort_results import SortResults

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/processor_args.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/processor_args.py
@@ -88,6 +88,28 @@ class ProcessorArgs():
         self.chunk_cosine_top_k = kwargs.get('chunk_cosine_top_k', 50)
         self.chunk_beam_width = kwargs.get('chunk_beam_width', 10)
         self.chunk_beam_max_depth = kwargs.get('chunk_beam_max_depth', 3)
+        # TopicBeamSearch tuning (mirrors the chunk_beam_* parameters above).
+        self.topic_beam_width = kwargs.get('topic_beam_width', 100)
+        self.topic_beam_max_depth = kwargs.get('topic_beam_max_depth', 6)
+        self.topic_top_k = kwargs.get('topic_top_k', 50)
+        # Beam neighbour-edge strategies. adjacent-chunk co-occurrence is enabled by
+        # default: benchmarks showed it improves accuracy across datasets with no
+        # regressions, whereas entity-overlap (off by default) tends to add noise.
+        self.use_entity_neighbors = kwargs.get('use_entity_neighbors', False)
+        self.use_same_chunk_neighbors = kwargs.get('use_same_chunk_neighbors', True)
+        self.use_adjacent_chunk_neighbors = kwargs.get('use_adjacent_chunk_neighbors', True)
+        # Cap on entity-overlap neighbours per topic (ranked by connection strength) to
+        # bound the fan-out when use_entity_neighbors is enabled.
+        self.max_entity_neighbors = kwargs.get('max_entity_neighbors', 100)
+        # Defensive cap on chunk-based neighbour strategies (same-chunk + adjacent-chunk),
+        # mirroring max_entity_neighbors. Bounds the neighbour set per topic in case a chunk
+        # is referenced by an unusually large number of topics.
+        self.max_chunk_neighbors = kwargs.get('max_chunk_neighbors', 100)
+        # Topic-level reranking (mirrors `reranker`): 'none' | 'tfidf' | 'bedrock'.
+        # When set, RerankTopics scores each topic (name + statements) against the query
+        # and keeps the top `max_topics` before statement selection.
+        self.topic_reranker = kwargs.get('topic_reranker', 'none')
+        self.max_topics = kwargs.get('max_topics', 40)
         self.no_cache = kwargs.get('no_cache', None)
         
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/rerank_topics.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/rerank_topics.py
@@ -1,0 +1,123 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+RerankTopics processor.
+
+Follows the same convention as RerankStatements: the reranking strategy is selected by a
+string arg (``ProcessorArgs.topic_reranker`` -> 'tfidf' | 'bedrock' | 'none') and
+dispatched here, rather than via ad-hoc flags. Where RerankStatements reranks statements
+*within* a topic, this processor reranks whole topics by scoring each topic's
+``name + all its statements`` against the query, keeps the top ``max_topics``, and drops the
+rest before the token-budget truncation runs.
+
+It also propagates each surviving topic's relevance score down to any statement that does not
+already carry a score. This lets the statement reranker be turned off (``reranker='none'``)
+so that statement selection is driven purely by topic relevance -- the ablation that answers
+"if a topic ranks high by the reranker, is statement-level tfidf still needed?".
+"""
+import logging
+import time
+from typing import List, Dict
+
+import boto3
+
+from graphrag_toolkit.lexical_graph import GraphRAGConfig
+from graphrag_toolkit.lexical_graph.retrieval.processors.processor_base import ProcessorBase
+from graphrag_toolkit.lexical_graph.retrieval.processors.processor_args import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.model import Topic
+from graphrag_toolkit.lexical_graph.utils.reranker_utils import score_values_with_tfidf
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+
+from llama_index.core.schema import QueryBundle
+
+logger = logging.getLogger(__name__)
+
+
+class RerankTopics(ProcessorBase):
+    """Reranks and prunes whole topics by query relevance, using the strategy named in
+    ``ProcessorArgs.topic_reranker``. No-op when topic_reranker is unset/'none'."""
+
+    def __init__(self, args: ProcessorArgs, filter_config: FilterConfig):
+        super().__init__(args, filter_config)
+
+    def _topic_text(self, topic: Topic) -> str:
+        stmts = ' '.join([s.statement_str or '' for s in topic.statements])
+        return (f'{topic.topic}\n{stmts}')[:4000]  # cap per-doc length for the reranker
+
+    def _score_with_tfidf(self, texts: List[str], query: QueryBundle) -> List[float]:
+        scored = score_values_with_tfidf(texts, [query.query_str], len(texts))
+        return [scored.get(t, 0.0) for t in texts]
+
+    def _score_with_bedrock(self, texts: List[str], query: QueryBundle) -> List[float]:
+        region = boto3.Session().region_name or getattr(GraphRAGConfig, 'aws_region', None) or 'us-east-1'
+        client = boto3.client('bedrock-agent-runtime', region_name=region)
+        model_arn = f'arn:aws:bedrock:{region}::foundation-model/{GraphRAGConfig.bedrock_reranking_model}'
+        sources = [{'type': 'INLINE', 'inlineDocumentSource': {'type': 'TEXT', 'textDocument': {'text': t}}}
+                   for t in texts]
+        resp = client.rerank(
+            queries=[{'type': 'TEXT', 'textQuery': {'text': query.query_str}}],
+            sources=sources,
+            rerankingConfiguration={
+                'type': 'BEDROCK_RERANKING_MODEL',
+                'bedrockRerankingConfiguration': {
+                    'numberOfResults': len(texts),
+                    'modelConfiguration': {'modelArn': model_arn},
+                },
+            },
+        )
+        scores = [0.0] * len(texts)
+        for r in resp['results']:
+            scores[r['index']] = r['relevanceScore']
+        return scores
+
+    def _process_results(self, search_results, query: QueryBundle):
+        mode = (self.args.topic_reranker or 'none').lower()
+        if mode == 'none':
+            return search_results
+
+        # Flatten (result_index, topic) pairs and build one document per topic.
+        pairs = []
+        texts = []
+        for ri, sr in enumerate(search_results.results):
+            for topic in sr.topics:
+                pairs.append((ri, topic))
+                texts.append(self._topic_text(topic))
+        if not texts:
+            return search_results
+
+        start = time.time()
+        if mode == 'tfidf':
+            scores = self._score_with_tfidf(texts, query)
+        elif mode == 'bedrock':
+            scores = self._score_with_bedrock(texts, query)
+        else:
+            logger.warning(f'Unknown topic_reranker "{mode}", skipping topic rerank')
+            return search_results
+        logger.debug(f'Topic rerank ({mode}) of {len(texts)} topics: {(time.time()-start)*1000:.0f}ms')
+
+        # Rank topics globally; keep the top max_topics.
+        order = sorted(range(len(pairs)), key=lambda i: scores[i], reverse=True)
+        keep = set(order[: self.args.max_topics])
+
+        kept_topics_by_result: Dict[int, List[Topic]] = {}
+        for i, (ri, topic) in enumerate(pairs):
+            if i not in keep:
+                continue
+            # Propagate topic relevance to statements that have no score yet, so selection can
+            # run on topic relevance alone when the statement reranker is disabled.
+            for stmt in topic.statements:
+                if stmt.score is None or stmt.score == 0.0:
+                    stmt.score = scores[i]
+            kept_topics_by_result.setdefault(ri, []).append(topic)
+
+        # Rebuild results, dropping topics (and now-empty sources) that did not survive.
+        new_results = []
+        for ri, sr in enumerate(search_results.results):
+            kept = kept_topics_by_result.get(ri)
+            if not kept:
+                continue
+            sr.topics = kept
+            new_results.append(sr)
+        search_results = search_results.with_new_results(results=new_results)
+        return search_results

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/__init__.py
@@ -14,6 +14,8 @@ from .composite_traversal_based_retriever import CompositeTraversalBasedRetrieve
 from .query_mode_retriever import QueryModeRetriever
 from .chunk_cosine_search import ChunkCosineSimilaritySearch
 from .semantic_chunk_beam_search import SemanticChunkBeamGraphSearch
+from .beam_search_base import BeamSearch
+from .topic_beam_search import TopicBeamSearch
 
 # Mapping of deprecated class names to their module paths within the deprecated sub-package
 _DEPRECATED_NAMES = {

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/beam_search_base.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/beam_search_base.py
@@ -1,0 +1,167 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from abc import abstractmethod
+from queue import PriorityQueue
+from typing import Dict, List, Set, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class BeamSearch:
+    """Base class for beam search over graph structures.
+    
+    Subclasses must implement get_neighbors() and get_neighbors_batch()
+    to define the graph traversal pattern.
+    """
+
+    def __init__(self, beam_width=100, max_depth=8, scoring_mode='cosine', **kwargs):
+        self.beam_width = beam_width
+        self.max_depth = max_depth
+        self.scoring_mode = scoring_mode
+
+    @abstractmethod
+    def get_neighbors(self, node_id: str) -> List[str]:
+        """Get neighbor IDs for a single node."""
+        ...
+
+    @abstractmethod
+    def get_neighbors_batch(self, node_ids: List[str]) -> Dict[str, List[str]]:
+        """Get neighbor IDs for multiple nodes. Returns {source_id: [neighbor_ids]}."""
+        ...
+
+    @abstractmethod
+    def _get_embeddings(self, ids: List[str]) -> dict:
+        """Get embeddings for the given IDs from the cache."""
+        ...
+
+    @abstractmethod
+    def _get_top_k(self, query_embedding, embeddings, top_k):
+        """Get top-k scored items from embeddings dict."""
+        ...
+
+    def _score_neighbors(self, query_embedding, parent_embedding, neighbor_embeddings, top_k):
+        """Score neighbors using the configured scoring mode.
+        
+        Args:
+            query_embedding: Query vector
+            parent_embedding: Embedding of the parent node
+            neighbor_embeddings: Dict of {id: embedding}
+            top_k: Number of top results to return
+        
+        Returns:
+            List of (score, neighbor_id) tuples, sorted descending
+        """
+        if not neighbor_embeddings:
+            return []
+        
+        ids = list(neighbor_embeddings.keys())
+        embeddings = np.array([neighbor_embeddings[sid] for sid in ids])
+        
+        query_norm = np.linalg.norm(query_embedding)
+        norms = np.linalg.norm(embeddings, axis=1)
+        safe_denom = np.maximum(norms * query_norm, 1e-10)
+        query_scores = np.dot(embeddings, query_embedding) / safe_denom
+        
+        if self.scoring_mode == 'path_weighted' and parent_embedding is not None:
+            parent_norm = np.linalg.norm(parent_embedding)
+            parent_denom = np.maximum(norms * parent_norm, 1e-10)
+            parent_scores = np.dot(embeddings, parent_embedding) / parent_denom
+            scores = query_scores * (1.0 + parent_scores) / 2.0
+        elif self.scoring_mode == 'path_propagated' and parent_embedding is not None:
+            # cosine(query, parent) × cosine(parent, neighbor)
+            parent_norm = np.linalg.norm(parent_embedding)
+            query_parent_sim = np.dot(query_embedding, parent_embedding) / np.maximum(query_norm * parent_norm, 1e-10)
+            parent_denom = np.maximum(norms * parent_norm, 1e-10)
+            parent_neighbor_scores = np.dot(embeddings, parent_embedding) / parent_denom
+            scores = query_parent_sim * parent_neighbor_scores
+        elif self.scoring_mode == 'attention' and parent_embedding is not None:
+            dim = len(parent_embedding)
+            attn_logits = np.dot(embeddings, parent_embedding) / np.sqrt(dim)
+            attn_logits = attn_logits - np.max(attn_logits)
+            attn_weights = np.exp(attn_logits) / np.sum(np.exp(attn_logits))
+            scores = query_scores * (1.0 + attn_weights)
+        else:
+            scores = query_scores
+        
+        top_k = min(top_k, len(scores))
+        top_indices = np.argsort(scores)[::-1][:top_k]
+        return [(scores[idx], ids[idx]) for idx in top_indices]
+
+    def beam_search(
+        self,
+        query_embedding: np.ndarray,
+        start_ids: List[str]
+    ) -> List[Tuple[str, List[str]]]:
+        """Perform beam search starting from seed IDs.
+        
+        Returns list of (node_id, path) tuples.
+        """
+        visited: Set[str] = set()
+        results: List[Tuple[str, List[str]]] = []
+        queue: PriorityQueue = PriorityQueue()
+        batch_size = 10
+
+        start_embeddings = self._get_embeddings(start_ids)
+        start_scores = self._get_top_k(query_embedding, start_embeddings, len(start_ids))
+
+        for similarity, node_id in start_scores:
+            queue.put((-similarity, 0, node_id, [node_id]))
+
+        while not queue.empty() and len(results) < self.beam_width:
+            batch = []
+            while not queue.empty() and len(batch) < batch_size:
+                item = queue.get()
+                neg_score, depth, current_id, path = item
+                if current_id not in visited:
+                    batch.append(item)
+
+            if not batch:
+                break
+
+            expand_ids = []
+            expand_items = []
+            for neg_score, depth, current_id, path in batch:
+                visited.add(current_id)
+                results.append((current_id, path))
+                if len(results) >= self.beam_width:
+                    break
+                if depth < self.max_depth:
+                    expand_ids.append(current_id)
+                    expand_items.append((depth, path))
+
+            if not expand_ids:
+                continue
+
+            neighbors_map = self.get_neighbors_batch(expand_ids)
+            all_neighbor_ids = list({nid for nids in neighbors_map.values() for nid in nids if nid not in visited})
+            
+            if all_neighbor_ids:
+                neighbor_embeddings = self._get_embeddings(all_neighbor_ids)
+
+                if self.scoring_mode == 'cosine':
+                    scored = self._get_top_k(query_embedding, neighbor_embeddings, self.beam_width)
+                    scored_dict = {sid: sim for sim, sid in scored}
+                    for expand_id, (depth, path) in zip(expand_ids, expand_items):
+                        for neighbor_id in neighbors_map.get(expand_id, []):
+                            if neighbor_id not in visited and neighbor_id in scored_dict:
+                                queue.put((-scored_dict[neighbor_id], depth + 1, neighbor_id, path + [neighbor_id]))
+                else:
+                    parent_embeddings = self._get_embeddings(expand_ids)
+                    for expand_id, (depth, path) in zip(expand_ids, expand_items):
+                        parent_emb = parent_embeddings.get(expand_id)
+                        if parent_emb is not None:
+                            parent_emb = np.array(parent_emb)
+                        local_neighbors = {
+                            nid: neighbor_embeddings[nid]
+                            for nid in neighbors_map.get(expand_id, [])
+                            if nid not in visited and nid in neighbor_embeddings
+                        }
+                        scored = self._score_neighbors(query_embedding, parent_emb, local_neighbors, self.beam_width)
+                        for score, neighbor_id in scored:
+                            queue.put((-score, depth + 1, neighbor_id, path + [neighbor_id]))
+
+        return results

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/topic_beam_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/topic_beam_search.py
@@ -1,0 +1,263 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Dict, List, Optional, Type
+
+import numpy as np
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.vector import VectorStore
+from graphrag_toolkit.lexical_graph.storage.vector.vector_index import to_embedded_query
+from graphrag_toolkit.lexical_graph.retrieval.model import SearchResultCollection
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorBase, ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import TraversalBasedBaseRetriever
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.beam_search_base import BeamSearch
+from graphrag_toolkit.lexical_graph.retrieval.utils.statement_utils import get_top_k
+
+from llama_index.core.schema import QueryBundle
+from llama_index.core.vector_stores.types import VectorStoreQueryMode
+
+logger = logging.getLogger(__name__)
+
+
+class TopicBeamSearch(TraversalBasedBaseRetriever, BeamSearch):
+    """Traversal-based retriever that beam-searches over the topic graph.
+
+    Two phases:
+      1. Seed: top-k topics from the topic vector index (``get_start_node_ids``).
+      2. Beam: expand seeds over same-chunk topic neighbours (``do_graph_search``),
+         score with the configured beam scoring mode, then expand the winning
+         topics into their statements via the standard traversal helpers.
+
+    Neighbour strategy is configurable; the default (same-chunk only) reflects the
+    best-performing configuration: topics that co-occur in the same source chunk
+    are more reliably related than topics linked only by shared entities across
+    documents.
+    """
+
+    def __init__(self,
+                 graph_store: GraphStore,
+                 vector_store: VectorStore,
+                 processor_args: Optional[ProcessorArgs] = None,
+                 processors: Optional[List[Type[ProcessorBase]]] = None,
+                 filter_config: FilterConfig = None,
+                 max_depth: int = None,
+                 beam_width: int = None,
+                 top_k: int = None,
+                 use_entity_neighbors: bool = None,
+                 use_same_chunk_neighbors: bool = None,
+                 use_adjacent_chunk_neighbors: bool = None,
+                 max_entity_neighbors: int = None,
+                 max_chunk_neighbors: int = None,
+                 max_statements_per_topic: int = 25,
+                 scoring_mode: str = 'path_weighted',
+                 **kwargs):
+        # Tuning is sourced from ProcessorArgs (the repo convention - mirrors how the
+        # chunk-beam retriever reads chunk_beam_* from args). Explicit constructor
+        # arguments, when provided, override the ProcessorArgs value.
+        args = processor_args if processor_args is not None else ProcessorArgs(**kwargs)
+        beam_width = beam_width if beam_width is not None else args.topic_beam_width
+        max_depth = max_depth if max_depth is not None else args.topic_beam_max_depth
+        BeamSearch.__init__(self, beam_width=beam_width, max_depth=max_depth, scoring_mode=scoring_mode)
+        # When topic reranking is requested (and the caller hasn't supplied an explicit
+        # processor list), insert RerankTopics into the default pipeline right after
+        # statement reranking so it can prune topics by query relevance.
+        if processors is None and (getattr(args, 'topic_reranker', 'none') or 'none').lower() != 'none':
+            from graphrag_toolkit.lexical_graph.retrieval.processors import RerankStatements, RerankTopics
+            from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import DEFAULT_PROCESSORS
+            _procs = list(DEFAULT_PROCESSORS)
+            _idx = _procs.index(RerankStatements) + 1 if RerankStatements in _procs else len(_procs)
+            _procs.insert(_idx, RerankTopics)
+            processors = _procs
+        TraversalBasedBaseRetriever.__init__(
+            self,
+            graph_store=graph_store,
+            vector_store=vector_store,
+            processor_args=args,
+            processors=processors,
+            filter_config=filter_config,
+            **kwargs,
+        )
+        pick = lambda override, default: override if override is not None else default
+        self.top_k = pick(top_k, args.topic_top_k)
+        self.use_entity_neighbors = pick(use_entity_neighbors, args.use_entity_neighbors)
+        self.use_same_chunk_neighbors = pick(use_same_chunk_neighbors, args.use_same_chunk_neighbors)
+        self.use_adjacent_chunk_neighbors = pick(use_adjacent_chunk_neighbors, args.use_adjacent_chunk_neighbors)
+        self.max_entity_neighbors = pick(max_entity_neighbors, args.max_entity_neighbors)
+        self.max_chunk_neighbors = pick(max_chunk_neighbors, args.max_chunk_neighbors)
+        self.max_statements_per_topic = max_statements_per_topic
+        self._topic_cache: Dict[str, np.ndarray] = {}
+        self._query_embedding = None
+
+    def _init(self, query_bundle: QueryBundle):
+        # Topic beam search does not use entity contexts; skip that extraction to
+        # avoid the extra keyword/entity provider round-trips.
+        return
+
+    # --- Phase 1: seed topics ---
+
+    def get_start_node_ids(self, query_bundle: QueryBundle) -> List[str]:
+        # Reset the per-query topic-embedding cache. This retriever instance is typically
+        # instantiated once and reused for every query, so without clearing here the cache
+        # would accumulate embeddings across queries and grow without bound.
+        self._topic_cache.clear()
+        topic_index = self.vector_store.get_index('topic')
+        query_bundle = to_embedded_query(query_bundle, topic_index.embed_model)
+        self._query_embedding = np.array(query_bundle.embedding)
+
+        results = topic_index.client.query(
+            VectorStoreQueryMode.DEFAULT,
+            query_str=query_bundle.query_str,
+            query_embedding=query_bundle.embedding,
+            k=self.top_k,
+            filters=None,
+        )
+        topic_ids = []
+        for node in results.nodes:
+            if node and node.metadata:
+                topic_id = node.metadata.get('topic', {}).get('topicId')
+                if topic_id:
+                    topic_ids.append(topic_id)
+                    if node.embedding:
+                        self._topic_cache[topic_id] = np.array(node.embedding)
+        return topic_ids
+
+    # --- BeamSearch hooks ---
+
+    def _get_embeddings(self, ids: List[str]) -> dict:
+        """Embeddings for topic ids, sourced entirely from the stored topic vectors.
+
+        Seeds are cached from the topic VSS query; neighbour ids discovered during the
+        beam are resolved by fetching their stored embeddings from the topic index by id
+        (one batched lookup). This keeps every vector on the same basis as the seeds
+        (the stored topic embedding = name + statements) and avoids recomputing anything
+        at query time. TopicBeamSearch already requires an embedded topic index in order
+        to seed, so neighbour vectors are expected to be present; any id the index does
+        not return is skipped (and logged) rather than recomputed on the fly.
+        """
+        missing = [tid for tid in ids if tid not in self._topic_cache]
+        if not missing:
+            return {tid: self._topic_cache[tid] for tid in ids if tid in self._topic_cache}
+
+        try:
+            topic_index = self.vector_store.get_index('topic')
+            # Fetch stored vectors by id through the VectorIndex abstraction (backend-agnostic),
+            # rather than reaching into a concrete client. get_embeddings batches internally.
+            for rec in topic_index.get_embeddings(missing):
+                # The id key differs by vector backend: OpenSearch/AOSS returns a top-level
+                # 'id', whereas Neptune Analytics returns the index's return_fields shape
+                # (e.g. {'embedding': ..., 'topic': {'topicId': ...}}) with no top-level 'id'.
+                # Handle both so beam expansion works regardless of vector store.
+                tid = rec.get('id') or (rec.get('topic') or {}).get('topicId')
+                emb = rec.get('embedding')
+                if tid and emb is not None:
+                    self._topic_cache[tid] = np.array(emb)
+        except Exception as ex:
+            logger.warning(f'Failed to fetch stored topic embeddings: {ex}')
+
+        # Skip (do not expand to) any neighbour topics without a stored embedding;
+        # this should not happen for a normally-built, seedable topic index.
+        unresolved = [tid for tid in missing if tid not in self._topic_cache]
+        if unresolved:
+            logger.debug(
+                f'Skipping {len(unresolved)} neighbour topic(s) with no stored embedding '
+                f'in the topic index (e.g. {unresolved[:3]})'
+            )
+        return {tid: self._topic_cache[tid] for tid in ids if tid in self._topic_cache}
+
+    def _get_top_k(self, query_embedding, embeddings, top_k):
+        return get_top_k(query_embedding, embeddings, top_k)
+
+    def get_neighbors(self, topic_id: str) -> List[str]:
+        return self.get_neighbors_batch([topic_id]).get(topic_id, [])
+
+    def get_neighbors_batch(self, topic_ids: List[str]) -> Dict[str, List[str]]:
+        """Neighbour topics via the configured strategies (entity-overlap,
+        same-chunk co-occurrence, adjacent-chunk co-occurrence)."""
+        if not topic_ids:
+            return {}
+
+        parts = []
+        match_clause = f"""
+        MATCH (t:`__Topic__`)
+        WHERE {self.graph_store.node_id('t.topicId')} IN $topicIds
+        """
+
+        if self.use_entity_neighbors:
+            parts.append(f"""
+            OPTIONAL MATCH (t)<-[:`__BELONGS_TO__`]-(s:`__Statement__`)<-[:`__SUPPORTS__`]-(f:`__Fact__`)<-[:`__SUBJECT__`|`__OBJECT__`]-(e:`__Entity__`)
+            WITH t, COLLECT(DISTINCT e) AS entities
+            UNWIND CASE WHEN size(entities) = 0 THEN [null] ELSE entities END AS entity
+            OPTIONAL MATCH (entity)-[:`__SUBJECT__`|`__OBJECT__`]->(f2:`__Fact__`)-[:`__SUPPORTS__`]->(s2:`__Statement__`)-[:`__BELONGS_TO__`]->(nt:`__Topic__`)
+            WHERE entity IS NOT NULL AND nt <> t
+            WITH t, {self.graph_store.node_id('nt.topicId')} AS ntid, count(f2) AS strength
+            ORDER BY strength DESC
+            WITH t, COLLECT(DISTINCT ntid)[..{int(self.max_entity_neighbors)}] AS entity_neighbors
+            """)
+        else:
+            parts.append("WITH t, [] AS entity_neighbors")
+
+        if self.use_same_chunk_neighbors:
+            parts.append(f"""
+            OPTIONAL MATCH (t)-[:`__MENTIONED_IN__`]->(c:`__Chunk__`)<-[:`__MENTIONED_IN__`]-(ct:`__Topic__`)
+            WHERE ct <> t
+            WITH t, entity_neighbors, COLLECT(DISTINCT {self.graph_store.node_id('ct.topicId')})[..{int(self.max_chunk_neighbors)}] AS chunk_neighbors
+            """)
+        else:
+            parts.append("WITH t, entity_neighbors, [] AS chunk_neighbors")
+
+        if self.use_adjacent_chunk_neighbors:
+            parts.append(f"""
+            OPTIONAL MATCH (t)-[:`__MENTIONED_IN__`]->(c:`__Chunk__`)-[:`__NEXT__`]->(adj:`__Chunk__`)<-[:`__MENTIONED_IN__`]-(at:`__Topic__`)
+            WHERE at <> t
+            WITH {self.graph_store.node_id('t.topicId')} AS sourceId,
+                 entity_neighbors, chunk_neighbors,
+                 COLLECT(DISTINCT {self.graph_store.node_id('at.topicId')})[..{int(self.max_chunk_neighbors)}] AS adjacent_neighbors
+            """)
+        else:
+            parts.append(f"""
+            WITH {self.graph_store.node_id('t.topicId')} AS sourceId,
+                 entity_neighbors, chunk_neighbors, [] AS adjacent_neighbors
+            """)
+
+        return_clause = "RETURN sourceId, entity_neighbors + chunk_neighbors + adjacent_neighbors AS neighborIds"
+        cypher = match_clause + "\n".join(parts) + "\n" + return_clause
+        results = self.graph_store.execute_query(cypher, {'topicIds': topic_ids})
+        return {r['sourceId']: list(set(r['neighborIds'])) for r in results}
+
+    # --- Phase 2: beam search + statement expansion ---
+
+    def _expand_topics_to_statement_ids(self, topic_ids: List[str]) -> List[str]:
+        """Statement ids for the winning topics, capped per topic."""
+        if not topic_ids:
+            return []
+        cypher = f"""
+        MATCH (s:`__Statement__`)-[:`__BELONGS_TO__`]->(t:`__Topic__`)
+        WHERE {self.graph_store.node_id('t.topicId')} IN $topicIds
+        RETURN {self.graph_store.node_id('t.topicId')} AS topicId,
+               {self.graph_store.node_id('s.statementId')} AS statementId
+        """
+        rows = self.graph_store.execute_query(cypher, {'topicIds': topic_ids})
+        per_topic: Dict[str, int] = {}
+        statement_ids = []
+        for row in rows:
+            tid = row['topicId']
+            count = per_topic.get(tid, 0)
+            if count < self.max_statements_per_topic:
+                statement_ids.append(row['statementId'])
+                per_topic[tid] = count + 1
+        return statement_ids
+
+    def do_graph_search(self, query_bundle: QueryBundle, start_node_ids: List[str]) -> SearchResultCollection:
+        if not start_node_ids:
+            return self._to_search_results_collection([])
+
+        beam_results = self.beam_search(self._query_embedding, start_node_ids)
+        winning_topic_ids = [topic_id for topic_id, _path in beam_results]
+        logger.debug(f'TopicBeamSearch: {len(start_node_ids)} seeds -> {len(winning_topic_ids)} topics')
+
+        statement_ids = self._expand_topics_to_statement_ids(winning_topic_ids)
+        statement_results = self.get_statements_by_topic_and_source(list(set(statement_ids)))
+        return self._to_search_results_collection(statement_results)

--- a/lexical-graph/tests/unit/retrieval/processors/test_rerank_topics.py
+++ b/lexical-graph/tests/unit/retrieval/processors/test_rerank_topics.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the RerankTopics processor (topic-level reranking)."""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs, RerankTopics
+from graphrag_toolkit.lexical_graph.retrieval.model import (
+    SearchResultCollection, SearchResult, Topic, Statement, Source, Versioning, EntityContexts,
+)
+from llama_index.core.schema import QueryBundle
+
+
+def _collection():
+    versioning = Versioning(valid_from=0, valid_to=9999999999)
+    source = Source(sourceId='doc1', metadata={}, versioning=versioning)
+    # three topics; one clearly matches the query terms, two are unrelated
+    topics = [
+        Topic(topic='Golf tournament prize money and purse', topicId='t1', statements=[
+            Statement(statementId='a', statement='The purse was 1.2 million dollars',
+                      statement_str='The purse was 1.2 million dollars', score=0.0)]),
+        Topic(topic='Weather and climate patterns', topicId='t2', statements=[
+            Statement(statementId='b', statement='It rained heavily that week',
+                      statement_str='It rained heavily that week', score=0.0)]),
+        Topic(topic='Cooking recipes and ingredients', topicId='t3', statements=[
+            Statement(statementId='c', statement='Add two cups of flour',
+                      statement_str='Add two cups of flour', score=0.0)]),
+    ]
+    result = SearchResult(source=source, topics=topics, score=0.9)
+    return SearchResultCollection(results=[result], entity_contexts=EntityContexts(contexts=[], keywords=[]))
+
+
+@pytest.fixture
+def query():
+    return QueryBundle(query_str='What was the tournament purse prize money?')
+
+
+def _topic_ids(collection):
+    return [t.topicId for r in collection.results for t in r.topics]
+
+
+def test_noop_when_topic_reranker_none(query):
+    proc = RerankTopics(ProcessorArgs(topic_reranker='none', max_topics=1), FilterConfig())
+    out = proc._process_results(_collection(), query)
+    assert _topic_ids(out) == ['t1', 't2', 't3']  # unchanged
+
+
+def test_prunes_to_max_topics(query):
+    proc = RerankTopics(ProcessorArgs(topic_reranker='tfidf', max_topics=2), FilterConfig())
+    out = proc._process_results(_collection(), query)
+    ids = _topic_ids(out)
+    assert len(ids) <= 2
+    assert 't1' in ids  # the purse/prize-money topic is most relevant and must survive
+
+
+def test_propagates_topic_score_to_unscored_statements(query):
+    # statements start at score 0.0; after rerank they inherit the topic relevance score
+    proc = RerankTopics(ProcessorArgs(topic_reranker='tfidf', max_topics=3), FilterConfig())
+    out = proc._process_results(_collection(), query)
+    scores = [s.score for r in out.results for t in r.topics for s in t.statements]
+    assert any(sc and sc > 0.0 for sc in scores)

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_topic_beam_search.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_topic_beam_search.py
@@ -1,0 +1,185 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the (non-deprecated) traversal-based TopicBeamSearch retriever."""
+
+from unittest.mock import MagicMock
+
+from llama_index.core.schema import QueryBundle
+
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.topic_beam_search import TopicBeamSearch
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import (
+    TraversalBasedBaseRetriever,
+)
+
+
+def _make(graph_store=None, vector_store=None, **kwargs):
+    return TopicBeamSearch(
+        graph_store=graph_store or MagicMock(),
+        vector_store=vector_store or MagicMock(),
+        **kwargs,
+    )
+
+
+def test_is_traversal_based_retriever():
+    assert issubclass(TopicBeamSearch, TraversalBasedBaseRetriever)
+
+
+def test_defaults_sourced_from_processor_args():
+    r = _make()
+    # neighbour defaults: same-chunk + adjacent-chunk on, entity off (sourced from ProcessorArgs)
+    assert r.use_same_chunk_neighbors is True
+    assert r.use_adjacent_chunk_neighbors is True   # validated win, now default-on
+    assert r.use_entity_neighbors is False
+    assert r.max_entity_neighbors == 100            # entity fan-out cap
+    assert r.scoring_mode == 'path_weighted'
+    assert (r.top_k, r.beam_width, r.max_depth) == (50, 100, 6)
+
+
+def test_processor_args_override_and_constructor_override():
+    from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+    # values flow from ProcessorArgs ...
+    r = _make(processor_args=ProcessorArgs(use_adjacent_chunk_neighbors=False, max_entity_neighbors=25, topic_top_k=8))
+    assert r.use_adjacent_chunk_neighbors is False
+    assert r.max_entity_neighbors == 25
+    assert r.top_k == 8
+    # ... and an explicit constructor argument overrides ProcessorArgs
+    r2 = _make(processor_args=ProcessorArgs(use_entity_neighbors=False), use_entity_neighbors=True)
+    assert r2.use_entity_neighbors is True
+
+
+def test_init_is_noop_skips_entity_context():
+    # _init must not invoke keyword/entity providers (latency-sensitive path).
+    r = _make()
+    r.entity_contexts = MagicMock()
+    r.entity_contexts.keywords = []
+    r._init(QueryBundle(query_str='q'))
+    r.entity_contexts.contexts.extend.assert_not_called()
+
+
+def test_get_start_node_ids_returns_ids_and_caches_embeddings():
+    vs = MagicMock()
+    topic_index = MagicMock()
+    vs.get_index.return_value = topic_index
+    n1 = MagicMock(metadata={'topic': {'topicId': 't1'}}, embedding=[0.1, 0.2])
+    n2 = MagicMock(metadata={'topic': {'topicId': 't2'}}, embedding=[0.3, 0.4])
+    topic_index.client.query.return_value = MagicMock(nodes=[n1, n2])
+
+    r = _make(vector_store=vs)
+    qb = QueryBundle(query_str='q')
+    qb.embedding = [0.5, 0.6]  # pre-set so to_embedded_query is a no-op
+
+    ids = r.get_start_node_ids(qb)
+    assert ids == ['t1', 't2']
+    assert 't1' in r._topic_cache and 't2' in r._topic_cache  # stored seed embeddings cached
+
+
+def test_get_neighbors_batch_builds_map():
+    gs = MagicMock()
+    gs.node_id.side_effect = lambda x: x
+    gs.execute_query.return_value = [{'sourceId': 't1', 'neighborIds': ['t2', 't3', 't2']}]
+    r = _make(graph_store=gs)
+    result = r.get_neighbors_batch(['t1'])
+    assert set(result['t1']) == {'t2', 't3'}  # de-duplicated
+
+
+def test_expand_topics_caps_statements_per_topic():
+    gs = MagicMock()
+    gs.node_id.side_effect = lambda x: x
+    # 5 statements for one topic; cap should limit to max_statements_per_topic
+    gs.execute_query.return_value = [
+        {'topicId': 't1', 'statementId': f's{i}'} for i in range(5)
+    ]
+    r = _make(graph_store=gs, max_statements_per_topic=3)
+    statement_ids = r._expand_topics_to_statement_ids(['t1'])
+    assert statement_ids == ['s0', 's1', 's2']
+
+
+def test_do_graph_search_empty_seeds_returns_empty_collection():
+    r = _make()
+    out = r.do_graph_search(QueryBundle(query_str='q'), [])
+    assert out.results == []
+
+
+def test_neighbour_embeddings_fetched_from_stored_index_not_recomputed():
+    # Neighbour topic embeddings are read from the stored topic index via the VectorIndex
+    # abstraction (get_embeddings); nothing is recomputed on the fly.
+    gs = MagicMock()
+    vs = MagicMock()
+    ti = MagicMock()
+    vs.get_index.return_value = ti
+    ti.get_embeddings.return_value = [
+        {'id': 't1', 'embedding': [0.1, 0.2]},
+        {'id': 't2', 'embedding': [0.3, 0.4]},
+    ]
+    r = _make(graph_store=gs, vector_store=vs)
+    out = r._get_embeddings(['t1', 't2'])
+    assert set(out.keys()) == {'t1', 't2'}
+    ti.get_embeddings.assert_called_once()            # used the abstraction
+    gs.execute_query.assert_not_called()              # no on-the-fly graph lookup
+    ti.embed_model.get_text_embedding_batch.assert_not_called()  # no on-the-fly embedding
+
+
+def test_neighbours_without_stored_embedding_are_skipped():
+    # A neighbour with no stored vector in the index is skipped (not recomputed).
+    gs = MagicMock()
+    vs = MagicMock()
+    ti = MagicMock()
+    vs.get_index.return_value = ti
+    ti.get_embeddings.return_value = [{'id': 't1', 'embedding': [0.1, 0.2]}]
+    r = _make(graph_store=gs, vector_store=vs)
+    out = r._get_embeddings(['t1', 't2'])   # t2 has no stored embedding
+    assert 't1' in out and 't2' not in out
+    gs.execute_query.assert_not_called()
+
+
+def test_get_embeddings_handles_both_backend_id_shapes():
+    # The id key differs by vector backend: OpenSearch/AOSS returns a top-level 'id';
+    # Neptune Analytics returns {'embedding':..., 'topic': {'topicId':...}} with no 'id'.
+    # _get_embeddings must resolve the topic id from either shape.
+    vs = MagicMock()
+    ti = MagicMock()
+    vs.get_index.return_value = ti
+    ti.get_embeddings.return_value = [
+        {'id': 'aoss1', 'embedding': [0.1, 0.2]},                       # AOSS shape
+        {'topic': {'topicId': 'neptune1'}, 'embedding': [0.3, 0.4]},    # Neptune Analytics shape
+    ]
+    r = _make(vector_store=vs)
+    out = r._get_embeddings(['aoss1', 'neptune1'])
+    assert set(out.keys()) == {'aoss1', 'neptune1'}  # both backends resolved
+
+
+def test_get_start_node_ids_clears_cache_each_query():
+    # The retriever instance is reused across queries; the per-query topic-embedding cache
+    # must be reset on each call so it cannot grow without bound.
+    vs = MagicMock()
+    topic_index = MagicMock()
+    vs.get_index.return_value = topic_index
+    n1 = MagicMock(metadata={'topic': {'topicId': 't1'}}, embedding=[0.1, 0.2])
+    topic_index.client.query.return_value = MagicMock(nodes=[n1])
+
+    r = _make(vector_store=vs)
+    r._topic_cache['stale'] = 'leftover-from-previous-query'
+    qb = QueryBundle(query_str='q')
+    qb.embedding = [0.5, 0.6]
+
+    r.get_start_node_ids(qb)
+    assert 'stale' not in r._topic_cache       # previous-query entry evicted
+    assert 't1' in r._topic_cache              # fresh seed cached
+
+
+def test_neighbor_query_caps_chunk_and_adjacent_neighbours():
+    # Entity neighbours were already capped; chunk + adjacent-chunk neighbours must be too.
+    # Use distinct caps so the chunk cap is unambiguously applied to both chunk strategies.
+    gs = MagicMock()
+    gs.node_id.side_effect = lambda x: x
+    gs.execute_query.return_value = []
+    r = _make(graph_store=gs, max_entity_neighbors=100, max_chunk_neighbors=50)
+    r.use_entity_neighbors = True
+    r.use_same_chunk_neighbors = True
+    r.use_adjacent_chunk_neighbors = True
+
+    r.get_neighbors_batch(['t1'])
+    cypher = gs.execute_query.call_args[0][0]
+    assert '[..100]' in cypher            # entity cap (pre-existing)
+    assert cypher.count('[..50]') == 2    # same-chunk + adjacent-chunk caps (the fix)


### PR DESCRIPTION
**Summary.** Adds `TopicBeamSearch` ("TopicGraphRAG"), a topic-seeded beam-search retriever that seeds from the topic index and beams across the graph to assemble source→topic→statement context, formatted as nested `bedrock_xml`. In our benchmarks it outperformed traversal-native retrieval on every evaluated dataset.

**Configuration** (via `ProcessorArgs`, mirroring `chunk_beam_*`; constructor args override):
- `use_same_chunk_neighbors` / `use_adjacent_chunk_neighbors` (both default `True`) — adjacent-chunk expansion is on by default (consistent benchmark gains, no regressions).
- `use_entity_neighbors` (default `False`) with `max_entity_neighbors` (default `100`, ranked by connection strength) to bound fan-out.
- `topic_beam_width` / `topic_beam_max_depth` / `topic_top_k`.
- `topic_reranker` (`tfidf` / `bedrock`, default `none`) — adds a `RerankTopics` processor that prunes topics by query relevance.

**Design.** Neighbour embeddings are read from the stored topic index by id — the same basis as the seeds (name + statements), with no query-time recomputation. Topics lacking a stored embedding are skipped and logged (a seedable topic index always has them).

**Testing.** ProcessorArgs defaults, override precedence, neighbour query construction, stored-embedding resolution (asserts no recomputation), skip-on-missing, and `RerankTopics`.
