### PR TITLE
fix(retrieval): guard source-diverse retrieval against indexes missing source

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
@@ -63,7 +63,7 @@ class KeywordVSSProvider(KeywordProviderBase):
         index_name = self.index_name
         id_name = f'{index_name}Id'
 
-        vss_results = get_diverse_vss_elements(index_name, query_bundle, self.vector_store, 5, 3, self.filter_config)
+        vss_results = get_diverse_vss_elements(index_name, query_bundle, self.vector_store, 5, 3, self.filter_config, graph_store=self.graph_store)
         
         node_ids = [result[index_name][id_name] for result in vss_results]
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_based_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_based_search.py
@@ -127,7 +127,8 @@ class ChunkBasedSearch(TraversalBasedBaseRetriever):
             self.vector_store, 
             self.args.vss_diversity_factor, 
             self.args.vss_top_k, 
-            self.filter_config
+            self.filter_config,
+            graph_store=self.graph_store
         )
         
         return [chunk['chunk']['chunkId'] for chunk in chunks]

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/entity_network_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/entity_network_search.py
@@ -95,7 +95,8 @@ class EntityNetworkSearch(TraversalBasedBaseRetriever):
             self.vector_store, 
             self.args.vss_diversity_factor, 
             self.args.vss_top_k, 
-            self.filter_config
+            self.filter_config,
+            graph_store=self.graph_store
         )
 
         node_ids = [result[index_name][id_name] for result in top_k_results]

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/topic_based_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/topic_based_search.py
@@ -138,7 +138,8 @@ class TopicBasedSearch(TraversalBasedBaseRetriever):
             self.vector_store, 
             self.args.vss_diversity_factor, 
             self.args.vss_top_k, 
-            self.filter_config
+            self.filter_config,
+            graph_store=self.graph_store
         )
         
         return [topic['topic']['topicId'] for topic in topics]

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/utils/vector_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/utils/vector_utils.py
@@ -3,6 +3,8 @@
 
 import logging
 import queue
+import threading
+from collections import OrderedDict
 from typing import Optional
 
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig
@@ -13,7 +15,98 @@ from llama_index.core.schema import QueryBundle
 
 logger = logging.getLogger(__name__)
 
-def get_diverse_vss_elements(index_name:str, query_bundle: QueryBundle, vector_store:VectorStore, diversity_factor:int, vss_top_k:int, filter_config:Optional[FilterConfig]):
+# Bounded LRU cache: topicId -> sourceId. A topic's source never changes, so entries are
+# safe to cache indefinitely; the size cap keeps memory flat in long-running processes
+# (this cache is process-global, not per-query).
+_TOPIC_SOURCE_CACHE_MAXSIZE = 50000
+_topic_source_cache = OrderedDict()
+_topic_source_cache_lock = threading.Lock()
+
+
+def _cache_get(topic_id):
+    with _topic_source_cache_lock:
+        if topic_id in _topic_source_cache:
+            _topic_source_cache.move_to_end(topic_id)
+            return _topic_source_cache[topic_id]
+    return None
+
+
+def _cache_put(topic_id, source_id):
+    with _topic_source_cache_lock:
+        _topic_source_cache[topic_id] = source_id
+        _topic_source_cache.move_to_end(topic_id)
+        while len(_topic_source_cache) > _TOPIC_SOURCE_CACHE_MAXSIZE:
+            _topic_source_cache.popitem(last=False)
+
+
+def _resolve_source_ids(graph_store, index_name, elements):
+    """Backfill the 'source' key for elements that lack it.
+
+    Correctly-built elements already carry source (the node builder sets it at index time):
+    we first lift it from the element's own metadata, which involves no I/O and applies to any
+    index type. The graph fallback (Topic -> Chunk -> Source) is topic-specific, so it is only
+    attempted for the topic index; other indexes (e.g. chunk, statement) rely on the metadata
+    source and are left untouched if it is absent. A topic's source is immutable, so graph
+    resolutions are memoised in a bounded LRU cache - resolved at most once, without unbounded
+    memory growth in long-running processes.
+    """
+    # 1) Prefer source already present in each element's metadata (no graph call).
+    #    The node builder sets this at index time, so this works for any index type.
+    for element in elements:
+        if 'source' in element:
+            continue
+        meta_source = (element.get('metadata') or {}).get('source')
+        if meta_source and meta_source.get('sourceId'):
+            element['source'] = {'sourceId': meta_source['sourceId']}
+
+    # 2) The graph fallback below walks Topic -> Chunk -> Source, so it is only valid for
+    #    the topic index. For other indexes (chunk, statement) the metadata source above is
+    #    authoritative; if it is absent we skip gracefully rather than run a Topic query that
+    #    could never match their ids.
+    if index_name != 'topic':
+        return
+
+    id_key = f'{index_name}Id'
+    ids_to_resolve = []
+
+    for element in elements:
+        if 'source' in element:
+            continue
+        node_id = element.get(index_name, {}).get(id_key)
+        if not node_id:
+            continue
+        cached = _cache_get(node_id)
+        if cached is not None:
+            element['source'] = {'sourceId': cached}
+        else:
+            ids_to_resolve.append(node_id)
+
+    # 3) Resolve any still-missing ids from the graph in a single query.
+    if ids_to_resolve:
+        cypher = f"""
+        MATCH (t:`__Topic__`)-[:`__MENTIONED_IN__`]->(c:`__Chunk__`)-[:`__EXTRACTED_FROM__`]->(s:`__Source__`)
+        WHERE {graph_store.node_id('t.topicId')} IN $topicIds
+        RETURN DISTINCT {graph_store.node_id('t.topicId')} AS topicId,
+               {graph_store.node_id('s.sourceId')} AS sourceId
+        """
+        try:
+            results = graph_store.execute_query(cypher, {'topicIds': ids_to_resolve})
+            for r in results:
+                _cache_put(r['topicId'], r['sourceId'])
+        except Exception as e:
+            logger.warning(f'Failed to resolve topic sources: {e}', exc_info=True)
+
+        for element in elements:
+            if 'source' in element:
+                continue
+            node_id = element.get(index_name, {}).get(id_key)
+            if node_id:
+                cached = _cache_get(node_id)
+                if cached is not None:
+                    element['source'] = {'sourceId': cached}
+
+
+def get_diverse_vss_elements(index_name:str, query_bundle: QueryBundle, vector_store:VectorStore, diversity_factor:int, vss_top_k:int, filter_config:Optional[FilterConfig], graph_store=None):
     """
     Retrieve diverse elements from a vector search system (VSS) by applying a diversity
     factor to limit redundancy among results.
@@ -45,7 +138,18 @@ def get_diverse_vss_elements(index_name:str, query_bundle: QueryBundle, vector_s
     source_map = {}
         
     for element in elements:
-        source_id = element['source']['sourceId']
+        source = element.get('source')
+        if source is None and graph_store is not None:
+            # Resolve sources via graph lookup + cache
+            _resolve_source_ids(graph_store, index_name, elements)
+            break
+    
+    for element in elements:
+        source = element.get('source')
+        if source is None:
+            # No graph_store available or resolution failed — skip diversity
+            return elements[:vss_top_k]
+        source_id = source['sourceId']
         if source_id not in source_map:
             source_map[source_id] = queue.Queue()
         source_map[source_id].put(element)

--- a/lexical-graph/tests/unit/retrieval/utils/test_vector_utils.py
+++ b/lexical-graph/tests/unit/retrieval/utils/test_vector_utils.py
@@ -9,6 +9,8 @@ from llama_index.core.schema import QueryBundle
 
 from graphrag_toolkit.lexical_graph.retrieval.utils.vector_utils import (
     get_diverse_vss_elements,
+    _resolve_source_ids,
+    _topic_source_cache,
 )
 
 
@@ -78,3 +80,127 @@ class TestGetDiverseVssElements:
             diversity_factor=2, vss_top_k=3, filter_config=None,
         )
         assert len(result) == 3
+
+
+def _fake_graph_store(mapping):
+    """Graph store whose query returns {topicId, sourceId} for requested ids."""
+    gs = MagicMock()
+    gs.node_id.side_effect = lambda x: x
+    gs.execute_query.side_effect = lambda cypher, params: [
+        {'topicId': t, 'sourceId': mapping[t]} for t in params['topicIds'] if t in mapping
+    ]
+    return gs
+
+
+class TestSourceResolution:
+    """Topic-index results lack a 'source' key; these cover the graph-based fallback."""
+
+    def test_missing_source_without_graph_store_does_not_crash(self):
+        # Regression: previously raised when an element had no 'source'.
+        elements = [{'topic': {'topicId': 't1'}}]
+        vs, _ = _vector_store(elements)
+        result = get_diverse_vss_elements(
+            'topic', QueryBundle('q'), vs,
+            diversity_factor=2, vss_top_k=5, filter_config=None,
+        )
+        assert result == elements[:5]  # graceful: returns un-diversified slice
+
+    def test_missing_source_resolved_via_graph_store(self):
+        _topic_source_cache.clear()
+        elements = [{'topic': {'topicId': 'tA'}}, {'topic': {'topicId': 'tB'}}]
+        _resolve_source_ids(_fake_graph_store({'tA': 'sX', 'tB': 'sY'}), 'topic', elements)
+        assert elements[0]['source'] == {'sourceId': 'sX'}
+        assert elements[1]['source'] == {'sourceId': 'sY'}
+
+    def test_existing_source_not_overwritten(self):
+        _topic_source_cache.clear()
+        elements = [{'topic': {'topicId': 'tC'}, 'source': {'sourceId': 'orig'}}]
+        _resolve_source_ids(_fake_graph_store({'tC': 'other'}), 'topic', elements)
+        assert elements[0]['source'] == {'sourceId': 'orig'}
+
+    def test_resolution_is_cached(self):
+        _topic_source_cache.clear()
+        gs = _fake_graph_store({'tD': 'sD'})
+        _resolve_source_ids(gs, 'topic', [{'topic': {'topicId': 'tD'}}])
+        # Second call for the same id should hit the cache, not re-query the graph.
+        _resolve_source_ids(gs, 'topic', [{'topic': {'topicId': 'tD'}}])
+        assert gs.execute_query.call_count == 1
+        assert _topic_source_cache['tD'] == 'sD'
+
+    def test_metadata_source_used_without_graph_call(self):
+        # If the element already carries source in its metadata, it is lifted directly and
+        # the graph is NOT queried (the normal, correctly-built-index path).
+        _topic_source_cache.clear()
+        gs = _fake_graph_store({'tE': 'unused'})
+        elements = [{'topic': {'topicId': 'tE'},
+                     'metadata': {'source': {'sourceId': 'sFromMeta'}}}]
+        _resolve_source_ids(gs, 'topic', elements)
+        assert elements[0]['source'] == {'sourceId': 'sFromMeta'}
+        gs.execute_query.assert_not_called()
+
+    def test_cache_is_bounded(self):
+        # The LRU cache caps its size and evicts the oldest entries.
+        import graphrag_toolkit.lexical_graph.retrieval.utils.vector_utils as vu
+        vu._topic_source_cache.clear()
+        original = vu._TOPIC_SOURCE_CACHE_MAXSIZE
+        vu._TOPIC_SOURCE_CACHE_MAXSIZE = 3
+        try:
+            for i in range(5):
+                vu._cache_put(f't{i}', f's{i}')
+            assert len(vu._topic_source_cache) == 3      # capped
+            assert 't0' not in vu._topic_source_cache    # oldest evicted
+            assert 't4' in vu._topic_source_cache        # newest retained
+        finally:
+            vu._TOPIC_SOURCE_CACHE_MAXSIZE = original
+            vu._topic_source_cache.clear()
+
+    def test_partial_resolution_fills_what_it_can(self):
+        # Intermediate state: 4 topic elements where source comes from different places and
+        # one is unresolvable. Resolution must fill each via the best-available path without
+        # bailing on the whole batch.
+        _topic_source_cache.clear()
+        gs = _fake_graph_store({'tGraph': 'sGraph'})  # only tGraph resolvable from the graph
+        elements = [
+            {'topic': {'topicId': 't0'}, 'source': {'sourceId': 'sExisting'}},
+            {'topic': {'topicId': 't1'}, 'metadata': {'source': {'sourceId': 'sMeta'}}},
+            {'topic': {'topicId': 'tGraph'}},
+            {'topic': {'topicId': 'tUnknown'}},  # not in graph mapping -> unresolvable
+        ]
+        _resolve_source_ids(gs, 'topic', elements)
+        assert elements[0]['source'] == {'sourceId': 'sExisting'}  # untouched
+        assert elements[1]['source'] == {'sourceId': 'sMeta'}       # lifted from metadata
+        assert elements[2]['source'] == {'sourceId': 'sGraph'}      # resolved from graph
+        assert 'source' not in elements[3]                          # left unresolved, no crash
+
+    def test_non_topic_index_skips_topic_graph_query(self):
+        # For a non-topic index (e.g. chunk), the Topic -> Chunk -> Source fallback must NOT
+        # run (its ids could never match a __Topic__ node). Metadata source is still lifted;
+        # elements without it are left unresolved gracefully.
+        _topic_source_cache.clear()
+        gs = _fake_graph_store({'c1': 'sShouldNotBeUsed'})
+        elements = [
+            {'chunk': {'chunkId': 'c1'}, 'metadata': {'source': {'sourceId': 'sMeta'}}},
+            {'chunk': {'chunkId': 'c2'}},  # no metadata source -> stays unresolved
+        ]
+        _resolve_source_ids(gs, 'chunk', elements)
+        assert elements[0]['source'] == {'sourceId': 'sMeta'}  # metadata lift works for any index
+        assert 'source' not in elements[1]                     # not bogusly resolved
+        gs.execute_query.assert_not_called()                   # no Topic query for a chunk index
+
+    def test_resolution_priority_existing_then_metadata_then_graph(self):
+        # All three resolution paths fire in one call; validate precedence and that only the
+        # genuinely-unresolved id reaches the graph.
+        _topic_source_cache.clear()
+        gs = _fake_graph_store({'tA': 'sGraphA'})
+        elements = [
+            {'topic': {'topicId': 'tExisting'}, 'source': {'sourceId': 'sExisting'},
+             'metadata': {'source': {'sourceId': 'sMetaIgnored'}}},
+            {'topic': {'topicId': 'tMeta'}, 'metadata': {'source': {'sourceId': 'sMeta'}}},
+            {'topic': {'topicId': 'tA'}},
+        ]
+        _resolve_source_ids(gs, 'topic', elements)
+        assert elements[0]['source'] == {'sourceId': 'sExisting'}  # existing wins over metadata
+        assert elements[1]['source'] == {'sourceId': 'sMeta'}      # metadata wins over graph
+        assert elements[2]['source'] == {'sourceId': 'sGraphA'}    # graph used only as last resort
+        params = gs.execute_query.call_args[0][1]
+        assert params['topicIds'] == ['tA']  # only the otherwise-unresolved id hit the graph


### PR DESCRIPTION
**Problem.** `get_diverse_vss_elements` groups results by `source['sourceId']` for diversity. Correctly-built indexes carry `source`, but topic indexes missing source metadata (inconsistent/legacy builds) cause source-diverse retrieval to fail when the topic index is active.

**Solution.** For elements lacking `source`, lift it from the element's own `metadata['source']` first (no I/O — the normal path). Only when source is absent everywhere, resolve it from the graph (`Topic→Chunk→Source`), memoised in a bounded LRU cache (a topic's source is immutable). Fall back to the un-diversified slice if it can't be determined. `graph_store` is threaded through the four call sites.

This is a defensive guard, not a happy-path change: correctly-built indexes never hit the graph lookup (verified with a freshly built pga topic index returns `source` and diversifies without this fix).

**Testing.** Missing-source regression; metadata-first resolution (asserts no graph call); graph fallback; existing-source preserved; caching; cache bounding/eviction.
