### PR TITLE
[FEATURE] Emit periodic INFO extraction progress in non-TTY environments

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/llm_proposition_extractor.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/llm_proposition_extractor.py
@@ -10,13 +10,13 @@ from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
 from graphrag_toolkit.lexical_graph.indexing.model import Propositions
 from graphrag_toolkit.lexical_graph.indexing.constants import PROPOSITIONS_KEY
 from graphrag_toolkit.lexical_graph.indexing.prompts import EXTRACT_PROPOSITIONS_PROMPT
+from graphrag_toolkit.lexical_graph.indexing.extract.progress import run_jobs_with_progress
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.extractors.interface import BaseExtractor
 from llama_index.core.prompts import PromptTemplate
-from llama_index.core.async_utils import run_jobs
 from llama_index.core.schema import NodeRelationship
 
 
@@ -130,11 +130,13 @@ class LLMPropositionExtractor(BaseExtractor):
         jobs = [
             self._extract_propositions_for_node(node) for node in nodes
         ]
-        return await run_jobs(
-            jobs, 
-            show_progress=self.show_progress, 
-            workers=self.num_workers, 
-            desc=f'Extracting propositions [nodes: {len(jobs)}, num_workers: {self.num_workers}]'
+        return await run_jobs_with_progress(
+            jobs,
+            show_progress=self.show_progress,
+            workers=self.num_workers,
+            desc=f'Extracting propositions [nodes: {len(jobs)}, num_workers: {self.num_workers}]',
+            total=len(jobs),
+            logger=logger
         )
         
     async def _extract_propositions_for_node(self, node):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/progress.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/progress.py
@@ -1,0 +1,149 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Progress reporting for asynchronous extraction jobs.
+
+LlamaIndex's ``run_jobs(show_progress=True, ...)`` renders a ``tqdm`` progress
+bar to stderr using carriage returns (``\\r``). In interactive terminals this is
+a nice live bar, but in non-TTY environments (ECS Fargate -> CloudWatch, Docker,
+CI) line-based log collectors drop or collapse the carriage-return updates, so
+extraction has near-zero progress visibility (issue #129).
+
+``run_jobs_with_progress`` is a drop-in wrapper around ``run_jobs`` that:
+
+* In an interactive TTY, delegates to ``run_jobs`` unchanged, preserving the
+  live ``tqdm`` bar.
+* In a non-TTY environment, suppresses the ``tqdm`` bar (``show_progress=False``)
+  and instead emits periodic newline-delimited ``INFO`` log records as jobs
+  complete, on a percent/time cadence. These survive line-based log collection.
+
+No new dependencies are introduced; only the standard library and the existing
+``run_jobs`` import are used.
+"""
+
+import logging
+import sys
+import time
+from typing import Any, Coroutine, List, Optional, TypeVar
+
+from llama_index.core.async_utils import run_jobs
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Defaults chosen to be quiet enough for large runs but responsive enough to
+# show liveness: log at most every ~10% of progress and no more often than
+# every 5 seconds. The final 100% line is always emitted.
+DEFAULT_LOG_EVERY_PCT = 10.0
+DEFAULT_MIN_INTERVAL_SECONDS = 5.0
+
+
+def _stderr_is_tty() -> bool:
+    """Return whether stderr is an interactive terminal.
+
+    Defensive against environments where ``sys.stderr`` is replaced with an
+    object lacking ``isatty`` (treated as non-TTY).
+    """
+    isatty = getattr(sys.stderr, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except Exception:  # pragma: no cover - extremely defensive
+        return False
+
+
+async def run_jobs_with_progress(
+    jobs: List[Coroutine[Any, Any, T]],
+    *,
+    show_progress: bool = False,
+    workers: int = 4,
+    desc: Optional[str] = None,
+    total: Optional[int] = None,
+    logger: logging.Logger = logger,
+    log_every_pct: float = DEFAULT_LOG_EVERY_PCT,
+    min_interval_seconds: float = DEFAULT_MIN_INTERVAL_SECONDS,
+) -> List[T]:
+    """Run ``jobs`` concurrently with progress visibility in any environment.
+
+    In an interactive TTY this delegates to :func:`run_jobs` with the supplied
+    ``show_progress`` (preserving the live ``tqdm`` bar). In a non-TTY
+    environment the ``tqdm`` bar is suppressed and periodic newline-delimited
+    ``INFO`` progress records are emitted instead.
+
+    Args:
+        jobs: Coroutines to run, mirroring :func:`run_jobs`.
+        show_progress: Whether the caller requested a progress bar. Honoured
+            verbatim in a TTY; forced to ``False`` for ``run_jobs`` in a
+            non-TTY (periodic INFO logging replaces the bar).
+        workers: Maximum concurrent jobs, passed through to :func:`run_jobs`.
+        desc: Human-readable description, used as the log-line prefix and passed
+            through to :func:`run_jobs` for the ``tqdm`` bar.
+        total: Total number of jobs (defaults to ``len(jobs)``); used to compute
+            percentages.
+        logger: Logger used for periodic INFO progress records.
+        log_every_pct: Emit a progress record whenever completion advances at
+            least this many percentage points since the last record. ``0`` logs
+            on every completed job.
+        min_interval_seconds: Suppress progress records emitted within this many
+            seconds of the previous one (the final 100% line is always emitted).
+
+    Returns:
+        Results in the same order as ``jobs`` (matching :func:`run_jobs`).
+    """
+    if total is None:
+        total = len(jobs)
+
+    # Interactive terminal: keep the prior behaviour (live tqdm bar) untouched.
+    if _stderr_is_tty():
+        return await run_jobs(
+            jobs,
+            show_progress=show_progress,
+            workers=workers,
+            desc=desc,
+        )
+
+    # Non-TTY: suppress the carriage-return tqdm bar and emit newline-delimited
+    # INFO progress on a percent/time cadence instead. We still delegate the
+    # actual concurrency to run_jobs (with show_progress=False) so its worker
+    # semantics and result ordering are preserved; each job is wrapped to record
+    # its completion and emit progress.
+    prefix = desc if desc else "Progress"
+
+    if total <= 0:
+        # Nothing to do; still delegate so the empty-input contract matches.
+        return await run_jobs(jobs, show_progress=False, workers=workers, desc=desc)
+
+    completed = 0
+    last_logged_pct = -1.0
+    last_log_time = 0.0
+
+    def _emit(force: bool = False) -> None:
+        nonlocal last_logged_pct, last_log_time
+        pct = (completed / total) * 100.0
+        now = time.monotonic()
+        if not force:
+            if (pct - last_logged_pct) < log_every_pct:
+                return
+            if (now - last_log_time) < min_interval_seconds:
+                return
+        logger.info("%s: %d/%d (%.0f%%)", prefix, completed, total, pct)
+        last_logged_pct = pct
+        last_log_time = now
+
+    async def _tracked(job: Coroutine[Any, Any, T]) -> T:
+        nonlocal completed
+        result = await job
+        completed += 1
+        # Always emit the final completion line; otherwise honour the cadence.
+        _emit(force=(completed == total))
+        return result
+
+    wrapped_jobs = [_tracked(job) for job in jobs]
+    return await run_jobs(
+        wrapped_jobs,
+        show_progress=False,
+        workers=workers,
+        desc=desc,
+    )

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/proposition_extractor.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/proposition_extractor.py
@@ -9,10 +9,11 @@ from typing import List, Optional, Sequence, Dict, Any
 from graphrag_toolkit.lexical_graph.indexing.model import Propositions
 from graphrag_toolkit.lexical_graph.indexing.constants import PROPOSITIONS_KEY
 
+from graphrag_toolkit.lexical_graph.indexing.extract.progress import run_jobs_with_progress
+
 from llama_index.core.schema import BaseNode
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.extractors.interface import BaseExtractor
-from llama_index.core.async_utils import run_jobs
 
 DEFAULT_PROPOSITION_MODEL = 'chentong00/propositionizer-wiki-flan-t5-large'
 
@@ -160,11 +161,13 @@ class PropositionExtractor(BaseExtractor):
         jobs = [
             self._extract_propositions_for_node(node) for node in nodes
         ]
-        return await run_jobs(
-            jobs, 
-            show_progress=self.show_progress, 
-            workers=self.num_workers, 
-            desc=f'Extracting propositions [nodes: {len(nodes)}, num_workers: {self.num_workers}]'
+        return await run_jobs_with_progress(
+            jobs,
+            show_progress=self.show_progress,
+            workers=self.num_workers,
+            desc=f'Extracting propositions [nodes: {len(nodes)}, num_workers: {self.num_workers}]',
+            total=len(nodes),
+            logger=logger
         )
         
     async def _extract_propositions_for_node(self, node):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/topic_extractor.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/topic_extractor.py
@@ -12,13 +12,13 @@ from graphrag_toolkit.lexical_graph.indexing.extract.preferred_values import Pre
 from graphrag_toolkit.lexical_graph.indexing.model import TopicCollection
 from graphrag_toolkit.lexical_graph.indexing.constants import TOPICS_KEY
 from graphrag_toolkit.lexical_graph.indexing.prompts import EXTRACT_TOPICS_PROMPT
+from graphrag_toolkit.lexical_graph.indexing.extract.progress import run_jobs_with_progress
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.extractors.interface import BaseExtractor
 from llama_index.core.prompts import PromptTemplate
-from llama_index.core.async_utils import run_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -122,11 +122,13 @@ class TopicExtractor(BaseExtractor):
         jobs = [
             self._extract_for_node(node) for node in nodes
         ]
-        return await run_jobs(
-            jobs, 
-            show_progress=self.show_progress, 
-            workers=self.num_workers, 
-            desc=f'Extracting topics [nodes: {len(jobs)}, num_workers: {self.num_workers}]'
+        return await run_jobs_with_progress(
+            jobs,
+            show_progress=self.show_progress,
+            workers=self.num_workers,
+            desc=f'Extracting topics [nodes: {len(jobs)}, num_workers: {self.num_workers}]',
+            total=len(jobs),
+            logger=logger
         )
         
     def _get_metadata_or_default(self, metadata, key, default):

--- a/lexical-graph/tests/unit/indexing/extract/test_progress.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_progress.py
@@ -1,0 +1,191 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the non-TTY extraction progress helper (issue #129).
+
+These tests pin the behaviour of ``run_jobs_with_progress``:
+
+* In a non-TTY environment (e.g. ECS Fargate -> CloudWatch, Docker, CI) the
+  helper must emit periodic newline-delimited INFO progress records and must
+  call the underlying ``run_jobs`` with ``show_progress=False`` (the tqdm
+  carriage-return bar is useless to line-based log collectors).
+* In an interactive TTY the helper must preserve the prior behaviour: it
+  delegates to ``run_jobs`` with the caller-supplied ``show_progress`` and does
+  not emit the periodic INFO progress spam.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.indexing.extract import progress as progress_module
+from graphrag_toolkit.lexical_graph.indexing.extract.progress import (
+    run_jobs_with_progress,
+)
+
+
+async def _make_jobs(n):
+    """Build ``n`` trivial coroutines that each return their index."""
+
+    async def _job(i):
+        return i
+
+    return [_job(i) for i in range(n)]
+
+
+class TestRunJobsWithProgressNonTty:
+    """Non-TTY behaviour: periodic INFO logging replaces the tqdm bar."""
+
+    @pytest.mark.asyncio
+    async def test_forces_show_progress_false_when_not_a_tty(self, monkeypatch):
+        """When stderr is not a TTY, run_jobs is called with show_progress=False."""
+        monkeypatch.setattr(progress_module.sys.stderr, "isatty", lambda: False)
+
+        captured = {}
+
+        async def fake_run_jobs(jobs, show_progress=False, workers=4, desc=None):
+            captured["show_progress"] = show_progress
+            captured["workers"] = workers
+            captured["desc"] = desc
+            return [await j for j in jobs]
+
+        monkeypatch.setattr(progress_module, "run_jobs", fake_run_jobs)
+
+        jobs = await _make_jobs(5)
+        results = await run_jobs_with_progress(
+            jobs,
+            show_progress=True,
+            workers=2,
+            desc="Extracting topics",
+            total=5,
+        )
+
+        assert sorted(results) == [0, 1, 2, 3, 4]
+        # The live tqdm bar must be suppressed in non-TTY environments.
+        assert captured["show_progress"] is False
+        # Other parameters are passed through unchanged.
+        assert captured["workers"] == 2
+        assert captured["desc"] == "Extracting topics"
+
+    @pytest.mark.asyncio
+    async def test_emits_periodic_info_progress_when_not_a_tty(
+        self, monkeypatch, caplog
+    ):
+        """When stderr is not a TTY, periodic INFO progress records are emitted."""
+        monkeypatch.setattr(progress_module.sys.stderr, "isatty", lambda: False)
+
+        jobs = await _make_jobs(10)
+
+        with caplog.at_level(logging.INFO, logger=progress_module.logger.name):
+            await run_jobs_with_progress(
+                jobs,
+                show_progress=True,
+                workers=4,
+                desc="Extracting propositions",
+                total=10,
+                # Log on every job so the test is deterministic.
+                min_interval_seconds=0,
+                log_every_pct=0,
+            )
+
+        info_records = [
+            r for r in caplog.records if r.levelno == logging.INFO
+        ]
+        assert info_records, "expected at least one INFO progress record"
+        # Progress messages should be human/log-collector friendly: include the
+        # desc, a completed/total count, and a percentage.
+        joined = "\n".join(r.getMessage() for r in info_records)
+        assert "Extracting propositions" in joined
+        assert "10/10" in joined
+        assert "100%" in joined
+        # A final 100% line must always be emitted so collectors see completion.
+        assert any("100%" in r.getMessage() for r in info_records)
+
+    @pytest.mark.asyncio
+    async def test_returns_results_in_input_order_when_not_a_tty(self, monkeypatch):
+        """Results preserve input order regardless of completion order."""
+        monkeypatch.setattr(progress_module.sys.stderr, "isatty", lambda: False)
+
+        async def _job(i, delay):
+            await asyncio.sleep(delay)
+            return i
+
+        # Job 0 finishes last, job 2 finishes first.
+        jobs = [_job(0, 0.03), _job(1, 0.02), _job(2, 0.0)]
+
+        results = await run_jobs_with_progress(
+            jobs,
+            show_progress=False,
+            workers=4,
+            desc="Extracting propositions",
+            total=3,
+            min_interval_seconds=0,
+            log_every_pct=0,
+        )
+
+        assert results == [0, 1, 2]
+
+
+class TestRunJobsWithProgressTty:
+    """TTY behaviour: prior tqdm behaviour is preserved."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_show_progress_unchanged_when_tty(
+        self, monkeypatch, caplog
+    ):
+        """In a TTY, run_jobs gets the caller's show_progress and no INFO spam."""
+        monkeypatch.setattr(progress_module.sys.stderr, "isatty", lambda: True)
+
+        captured = {}
+
+        async def fake_run_jobs(jobs, show_progress=False, workers=4, desc=None):
+            captured["show_progress"] = show_progress
+            return [await j for j in jobs]
+
+        monkeypatch.setattr(progress_module, "run_jobs", fake_run_jobs)
+
+        jobs = await _make_jobs(4)
+
+        with caplog.at_level(logging.INFO, logger=progress_module.logger.name):
+            results = await run_jobs_with_progress(
+                jobs,
+                show_progress=True,
+                workers=4,
+                desc="Extracting topics",
+                total=4,
+            )
+
+        assert sorted(results) == [0, 1, 2, 3]
+        # TTY path must preserve the live tqdm bar (caller's show_progress).
+        assert captured["show_progress"] is True
+        # No periodic INFO progress spam in interactive TTYs.
+        progress_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "%" in r.getMessage()
+        ]
+        assert progress_records == []
+
+    @pytest.mark.asyncio
+    async def test_respects_show_progress_false_in_tty(self, monkeypatch):
+        """If the caller disables progress in a TTY, run_jobs sees show_progress=False."""
+        monkeypatch.setattr(progress_module.sys.stderr, "isatty", lambda: True)
+
+        captured = {}
+
+        async def fake_run_jobs(jobs, show_progress=False, workers=4, desc=None):
+            captured["show_progress"] = show_progress
+            return [await j for j in jobs]
+
+        monkeypatch.setattr(progress_module, "run_jobs", fake_run_jobs)
+
+        jobs = await _make_jobs(2)
+        await run_jobs_with_progress(
+            jobs,
+            show_progress=False,
+            workers=4,
+            desc="Extracting topics",
+            total=2,
+        )
+
+        assert captured["show_progress"] is False


### PR DESCRIPTION
## Description

In non-TTY environments (ECS Fargate → CloudWatch, Docker, CI), extraction had
near-zero progress visibility. LlamaIndex `run_jobs(show_progress=True)` renders
a tqdm bar to stderr using carriage returns (`\r`); line-based log collectors drop
or collapse those updates, so operators see no progress.

## Changes

- Add a `run_jobs_with_progress` helper (new `indexing/extract/progress.py`) that
  wraps `run_jobs`:
  - **Interactive TTY:** delegates to `run_jobs` unchanged, preserving the live
    tqdm bar (caller-supplied `show_progress` honoured verbatim).
  - **Non-TTY** (`sys.stderr.isatty()` is `False`): forces `show_progress=False`
    to suppress the carriage-return bar, and instead emits periodic
    newline-delimited INFO records (`<desc>: <completed>/<total> (<pct>%)`) on a
    percent/time cadence, with a guaranteed final 100% line. These survive
    line-based log collection.
- Wire the helper into the three identical `run_jobs(...)` call sites:
  `proposition_extractor`, `llm_proposition_extractor`, `topic_extractor`.
- No new dependencies (stdlib + existing `run_jobs` only). TTY behaviour is
  unchanged; the repo logging config already defaults to INFO.

## Problem

Related issue (if any): #129

## Testing

- [x] Unit tests added/updated (`tests/unit/indexing/extract/test_progress.py`)
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.