### PR TITLE
[FIX] Pass Claude batch system prompt via top-level system field

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/batch_inference_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/batch_inference_utils.py
@@ -83,14 +83,14 @@ def get_request_body(llm:BedrockConverse, messages:List[ChatMessage], inference_
         return request_body
     elif 'anthropic.claude' in model_id:
         anthropic_messages, system_prompt = messages_to_anthropic_messages(messages)
-        if system_prompt:
-            anthropic_messages = [{'role': 'system"', 'content': system_prompt}, *anthropic_messages]
         request_body = {
-            'anthropic_version': inference_parameters.get('anthropic_version', 'bedrock-2023-05-31'), 
+            'anthropic_version': inference_parameters.get('anthropic_version', 'bedrock-2023-05-31'),
             'messages': anthropic_messages,
             'max_tokens': inference_parameters['max_tokens'],
             'temperature': inference_parameters['temperature']
         }
+        if system_prompt:
+            request_body['system'] = system_prompt
         return request_body
     elif 'meta.llama' in model_id:
         converse_messages, system_prompt = messages_to_converse_messages(messages)

--- a/lexical-graph/tests/unit/indexing/utils/test_batch_inference_utils.py
+++ b/lexical-graph/tests/unit/indexing/utils/test_batch_inference_utils.py
@@ -200,6 +200,47 @@ class TestGetRequestBody:
             assert request_body['max_tokens'] == 2000
             assert request_body['temperature'] == 0.8
     
+    def test_get_request_body_claude_with_system_prompt(self):
+        """Verify get_request_body puts the system prompt in the top-level 'system' field for Claude models."""
+        mock_llm = Mock(spec=BedrockConverse)
+        mock_llm.model = 'anthropic.claude-3-sonnet-20240229-v1:0'
+
+        messages = [
+            ChatMessage(role=MessageRole.SYSTEM, content="System prompt"),
+            ChatMessage(role=MessageRole.USER, content="User message")
+        ]
+        inference_params = {'max_tokens': 2000, 'temperature': 0.8}
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils.messages_to_anthropic_messages') as mock_convert:
+            mock_convert.return_value = ([{'role': 'user', 'content': 'User message'}], 'System prompt')
+
+            request_body = get_request_body(mock_llm, messages, inference_params)
+
+            # System prompt belongs in the top-level 'system' field per the Anthropic
+            # Bedrock invoke schema, not injected as a chat message.
+            assert request_body['system'] == 'System prompt'
+            assert request_body['messages'] == [{'role': 'user', 'content': 'User message'}]
+            assert all(m.get('role') != 'system' for m in request_body['messages'])
+            assert request_body['anthropic_version'] == 'bedrock-2023-05-31'
+
+    def test_get_request_body_claude_without_system_prompt(self):
+        """Verify get_request_body omits the 'system' field for Claude models when there is no system prompt."""
+        mock_llm = Mock(spec=BedrockConverse)
+        mock_llm.model = 'anthropic.claude-3-sonnet-20240229-v1:0'
+
+        messages = [
+            ChatMessage(role=MessageRole.USER, content="User message")
+        ]
+        inference_params = {'max_tokens': 2000, 'temperature': 0.8}
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils.messages_to_anthropic_messages') as mock_convert:
+            mock_convert.return_value = ([{'role': 'user', 'content': 'User message'}], None)
+
+            request_body = get_request_body(mock_llm, messages, inference_params)
+
+            assert 'system' not in request_body
+            assert request_body['messages'] == [{'role': 'user', 'content': 'User message'}]
+
     def test_get_request_body_llama_model(self):
         """Verify get_request_body creates correct structure for Llama models."""
         mock_llm = Mock(spec=BedrockConverse)


### PR DESCRIPTION
Thanks for the toolkit and for maintaining the Bedrock batch path. Fixes #330.

### Problem

In `get_request_body` (`lexical-graph/.../indexing/utils/batch_inference_utils.py`), the Claude branch injects the system prompt as a chat message with a malformed role literal `'system"'`. The Anthropic-on-Bedrock invoke schema (`anthropic_version: "bedrock-2023-05-31"`) expects the system prompt in the **top-level `system` field**, and `messages` only accepts `user`/`assistant` roles — so the prompt is dropped/misplaced for Claude batch jobs.

### Cause

The Claude branch is missing the pattern the sibling **Nova** branch already follows (`request_body['system'] = [{'text': system_prompt}]`). The existing Claude test mocked `system_prompt=None`, so this branch was never exercised.

### Changes

- Remove the malformed message injection (`{'role': 'system"', ...}`).
- Set the system prompt on the top-level `system` field when present (string form — `messages_to_anthropic_messages` returns the system prompt as a string).

```python
elif 'anthropic.claude' in model_id:
    anthropic_messages, system_prompt = messages_to_anthropic_messages(messages)
    request_body = {
        'anthropic_version': inference_parameters.get('anthropic_version', 'bedrock-2023-05-31'),
        'messages': anthropic_messages,
        'max_tokens': inference_parameters['max_tokens'],
        'temperature': inference_parameters['temperature']
    }
    if system_prompt:
        request_body['system'] = system_prompt
    return request_body
```

### Before / After

| Item | Before | After |
|------|--------|-------|
| System prompt location (Claude) | ❌ injected as `messages` entry | ✅ top-level `system` field (matches Bedrock invoke schema) |
| Role literal | ❌ `'system"'` (typo, invalid role) | ✅ removed |
| `system` present when prompt set | ❌ never set | ✅ `request_body['system'] == system_prompt` |
| Nova / Llama branches | ✅ unchanged | ✅ unchanged |
| `messages` content / order | (system prepended) | ✅ only `user`/`assistant`, unchanged otherwise |
| `anthropic_version` default | `bedrock-2023-05-31` | ✅ unchanged |
| No-system-prompt case | `system` absent | ✅ `system` still absent (no regression) |

### Tests

Added two regression tests to `TestGetRequestBody` exercising the previously-untested non-None system-prompt path.

**With the fix (all pass):**

```
tests/unit/indexing/utils/test_batch_inference_utils.py ... 23 passed, 1 warning in 0.02s
```

**Proof the new test catches the bug** — revert the source fix only (keep the new tests), the system-prompt test fails:

```
>           assert request_body['system'] == 'System prompt'
E           KeyError: 'system'
...
FAILED tests/.../test_get_request_body_claude_with_system_prompt
==================== 1 failed, 1 passed, 1 warning in 0.13s ====================
```

Restoring the fix returns it to 23 passed.

### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate) — N/A for this utility fix
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (covered by regression tests above)

### Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files (no new files; existing headers intact)
- [ ] Documentation updated (if applicable) — N/A
- [x] No breaking changes (public API/args/result order unchanged; Nova/Llama branches untouched)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the reasoning, and the test results before submission.*
