### PR TITLE
[CHORE] Bump docs-site transitive dependencies and add dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,17 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
+  - package-ecosystem: "npm"
+    directory: "/docs-site"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -3433,9 +3433,9 @@
       }
     },
     "node_modules/astro/node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -4995,9 +4995,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7535,9 +7535,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",


### PR DESCRIPTION
## Description

Bump vulnerable transitive dependencies in the docs-site and add npm ecosystem monitoring to prevent future coverage gaps.

## Changes

- `js-yaml` 4.1.1 → 4.2.0 (fixes quadratic-complexity DoS via repeated aliases)
- `vite` 6.4.2 → 6.4.3 (fixes `server.fs.deny` bypass on Windows)
- `vite` 7.3.2 → 7.3.5 (same fix, astro-nested copy)
- Add `/docs-site` npm ecosystem entry to `.github/dependabot.yml`

## Problem

Trivy scan flagged outdated transitive dependencies in `docs-site/package-lock.json`. The existing `dependabot.yml` did not monitor the docs-site npm ecosystem, so these were not automatically tracked.

Related issue (if any): N/A (security scan finding)

## Testing

- [ ] Unit tests added/updated — N/A (lockfile + config only)
- [ ] Integration tests added (as appropriate) — N/A
- [x] Existing tests pass (`pytest`) — no Python changes
- [x] Tested manually — verified versions in lockfile match registry integrity hashes

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files — N/A (no new files)
- [ ] Documentation updated (if applicable) — N/A
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.