### PR TITLE
[FIX]: (Integration-Tests) VPC/Subnet ID environment variables for CloudFormation stack creation

### DIFF
--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -480,7 +480,7 @@ if [[ -z "$DRY_RUN" ]]; then
 		ParameterKey=SSHCIDR,ParameterValue="$SSHCIDR" \
 		ParameterKey=DbPassword,ParameterValue="$DB_PASSWORD" \
 		ParameterKey=ExistingVpcId,ParameterValue="${EXISTING_VPC_ID:-}" \
-		ParameterKey=ExistingSubnetIds,ParameterValue="${EXISTING_SUBNET_IDS:-}" \
+		"ParameterKey=ExistingSubnetIds,ParameterValue=${EXISTING_SUBNET_IDS//,/\\,}" \
 	  --capabilities CAPABILITY_NAMED_IAM \
 	  --tags \
 	    Key=ApplicationName,Value="graphrag-toolkit test" \

--- a/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
+++ b/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
@@ -98,7 +98,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "True",
         "IncludeAllowPublicAccess": "True",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "True"
       },
       "neptune-db-postgresql": {
         "TemplateName": "graphrag-toolkit-neptune-db-aurora-postgres.json",
@@ -106,7 +107,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "True",
         "IncludeAllowPublicAccess": "False",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "False"
       },
       "neptune-db-s3vectors": {
         "TemplateName": "graphrag-toolkit-neptune-db-s3-vectors.json",
@@ -114,7 +116,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "True",
         "IncludeAllowPublicAccess": "False",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "False"
       },
       "neptune-graph": {
         "TemplateName": "graphrag-toolkit-neptune-analytics.json",
@@ -122,7 +125,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "False",
         "IncludeAllowPublicAccess": "False",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "False"
       },
       "neptune-graph-aoss": {
         "TemplateName": "graphrag-toolkit-neptune-analytics-opensearch-serverless.json",
@@ -130,7 +134,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "False",
         "IncludeAllowPublicAccess": "True",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "False"
       },
       "neptune-graph-postgresql": {
         "TemplateName": "graphrag-toolkit-neptune-analytics-aurora-postgres.json",
@@ -138,7 +143,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "False",
         "IncludeAllowPublicAccess": "False",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "False"
       },
       "neptune-graph-s3vectors": {
         "TemplateName": "graphrag-toolkit-neptune-analytics-s3-vectors.json",
@@ -146,7 +152,8 @@
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "False",
         "IncludeAllowPublicAccess": "False",
-        "IncludeDbPassword": "False"
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "False"
       },
       "neo4j-aoss": {
         "TemplateName": "graphrag-toolkit-neo4j-opensearch-serverless.json",
@@ -154,7 +161,8 @@
         "IncludeSSHCIDR": "True",
         "IncludeNeptuneInstanceType": "False",
         "IncludeAllowPublicAccess": "True",
-        "IncludeDbPassword": "True"
+        "IncludeDbPassword": "True",
+        "IncludeExistingVpc": "False"
       }
     }
   },
@@ -260,6 +268,20 @@
               "Ref": "EnvType"
             },
             "IncludeDbPassword"
+          ]
+        },
+        "True"
+      ]
+    },
+    "DoIncludeExistingVpc": {
+      "Fn::Equals": [
+        {
+          "Fn::FindInMap": [
+            "EnvTypeMap",
+            {
+              "Ref": "EnvType"
+            },
+            "IncludeExistingVpc"
           ]
         },
         "True"
@@ -549,13 +571,29 @@
             ]
           },
           "ExistingVpcId": {
-            "Ref": "ExistingVpcId"
+            "Fn::If": [
+              "DoIncludeExistingVpc",
+              {
+                "Ref": "ExistingVpcId"
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           },
           "ExistingSubnetIds": {
-            "Fn::Join": [
-              ",",
+            "Fn::If": [
+              "DoIncludeExistingVpc",
               {
-                "Ref": "ExistingSubnetIds"
+                "Fn::Join": [
+                  ",",
+                  {
+                    "Ref": "ExistingSubnetIds"
+                  }
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
               }
             ]
           }

--- a/integration-tests/env.template
+++ b/integration-tests/env.template
@@ -21,3 +21,6 @@ export BENCHMARK_DATA_DIR=<OPTIONAL: Local directory containing benchmark data t
 export BENCHMARK_DATA_S3_URI=<OPTIONAL: S3 URI for benchmark data synced at runtime, e.g. s3://graphrag-toolkit-benchmarking/, default: Empty>
 export BENCHMARK_QA_LIMIT=<OPTIONAL: Max number of QA pairs to evaluate for prototype runs, default: Empty (all pairs)>
 export BENCHMARK_IS_PROTOTYPE=<OPTIONAL: Use prototype datasets (e.g. cuad-prototype instead of cuad), true or false, default: Empty (false)>
+
+export EXISTING_VPC_ID=<OPTIONAL: Existing VPC ID to reuse instead of creating a new VPC, default: Empty>
+export EXISTING_SUBNET_IDS=<OPTIONAL: Comma-delimited existing subnet IDs to reuse (min 2 across 2 AZs, must be provided with EXISTING_VPC_ID), default: Empty>


### PR DESCRIPTION
## Description

Fix VPC/Subnet ID environment variables for CloudFormation stack creation for the integration tests. 

## Changes

  - Fix comma-delimited subnet IDs being passed incorrectly to CloudFormation by escaping commas in the ExistingSubnetIds parameter value (AWS CLI requires \, for list-type parameters)
  - Add `IncludeExistingVpc` mapping to all environment types in the CFN template, enabling conditional passthrough of VPC/Subnet parameters only for supported env types (neptune-db-aoss)
  - Wrap `ExistingVpcId` and `ExistingSubnetIds` in `Fn::If` conditions so they resolve to AWS::NoValue when the env type doesn't support VPC reuse, preventing validation errors on nested stacks
  - Add `EXISTING_VPC_ID` and `EXISTING_SUBNET_IDS` to the env.template for discoverability

## Problem

Integration tests do not run properly against an existing VPC/Subnet.  

Related issue (if any): N/A

## Testing

Run integration tests (short) with existing VPC/Subnet

- [ ] Unit tests added/updated
- [X] Integration tests added (as appropriate)
- [X] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
