### PR TITLE
[CHORE] Add git-secrets secret-scanning workflow for pull requests

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,28 @@
+# Runs git-secrets on every pull request to block committed AWS credentials.
+# Server-side counterpart to the local pre-commit hook in .pre-commit-config.yaml.
+
+name: Secret Scan
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  git-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install git-secrets
+        run: |
+          git clone https://github.com/awslabs/git-secrets /tmp/git-secrets
+          git -C /tmp/git-secrets checkout 7d6b970cbd3c216353cb22b383b70c150140662e
+          sudo make -C /tmp/git-secrets install
+
+      - name: Register AWS secret patterns
+        run: git secrets --register-aws
+
+      - name: Scan tracked files for secrets
+        run: git ls-files -z | xargs -0 git secrets --scan


### PR DESCRIPTION
## Description
Add a `secret-scan` workflow that runs git-secrets on every pull request, scanning tracked files for committed AWS credentials. Server-side counterpart to the existing local git-secrets pre-commit hook.

## Changes
- Added `.github/workflows/secret-scan.yml` with a `git-secrets` job on `ubuntu-latest`, triggered on `pull_request`
- Installs git-secrets pinned to the same commit (`7d6b970`) as the `.pre-commit-config.yaml` hook, so local and CI scans match
- Runs `git secrets --register-aws`, then scans tracked files; allowlisted values come from the existing `.gitallowed`
- `contents: read` permissions only

## Problem
The repo has a local git-secrets pre-commit hook, but pre-commit hooks are opt-in and can be skipped with `--no-verify`, so a credential can still reach the remote. There was no server-side enforcement on pull requests. This adds that as defense-in-depth.

## Testing
- No functional code change — CI workflow addition only
- Ran the same steps locally against the current tree: a clean checkout passes, a planted `AKIA`-prefixed key fails the scan, and the placeholder account ID in `.gitallowed` is ignored
- git-secrets runs on pull requests and blocks matches

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
