### PR TITLE
[FIX] Use placeholder account ID and bucket name in examples

### DIFF
--- a/docs-site/src/content/docs/lexical-graph/nova-2-model-support.mdx
+++ b/docs-site/src/content/docs/lexical-graph/nova-2-model-support.mdx
@@ -256,7 +256,7 @@ metadata:
   name: argo-workflows-server
   namespace: argo-workflows
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::188967239867:role/ArgoWorkflowAccessRole
+    eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/ArgoWorkflowAccessRole
 ```
 
 The `GraphRAGConfig.session` automatically uses IRSA credentials when running in EKS.

--- a/docs-site/src/content/docs/lexical-graph/nova-2-model-support.mdx
+++ b/docs-site/src/content/docs/lexical-graph/nova-2-model-support.mdx
@@ -256,7 +256,7 @@ metadata:
   name: argo-workflows-server
   namespace: argo-workflows
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/ArgoWorkflowAccessRole
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ArgoWorkflowAccessRole
 ```
 
 The `GraphRAGConfig.session` automatically uses IRSA credentials when running in EKS.

--- a/examples/lexical-graph/cloudformation-templates/update-stack.sh
+++ b/examples/lexical-graph/cloudformation-templates/update-stack.sh
@@ -7,7 +7,7 @@
 # Configuration variables
 STACK_NAME="AWS-GraphRAG-01"  # Replace with your stack name
 TEMPLATE_FILE="graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json"  # Path to your updated template file
-S3_BUCKET_ARN="arn:aws:s3:::ccms-rag-extract-188967239867"  # Replace with your S3 bucket ARN
+S3_BUCKET_ARN="arn:aws:s3:::my-rag-extract-bucket"  # Replace with your S3 bucket ARN
 REGION="us-east-1"  # Replace with your AWS region
 PARAMETERS_FILE="parameters.json"  # Temporary parameters file
 AWS_PROFILE="master"  # Will be set if --profile is provided


### PR DESCRIPTION
## Description
Replace a real AWS account ID and an account-bearing S3 bucket name with placeholders in the documentation and an example script.

## Changes
- `docs-site/src/content/docs/lexical-graph/nova-2-model-support.mdx` — EKS service-account example: account ID in the IAM role ARN → `111111111111`
- `examples/lexical-graph/cloudformation-templates/update-stack.sh` — `S3_BUCKET_ARN` example → `arn:aws:s3:::my-rag-extract-bucket` (drops the embedded account ID)

## Problem
Both examples carried a real 12-digit AWS account ID, which exposes an internal account identifier. Examples should use placeholder values that readers replace with their own.

## Testing
- Docs and example-only change; no functional code affected
- Confirmed no occurrences of the account ID remain in the tree

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
