### PR TITLE
[FEATURE] Add progress construct for extract/build

### DIFF
--- a/examples/lexical-graph/workshop/assets/setup.py
+++ b/examples/lexical-graph/workshop/assets/setup.py
@@ -1,14 +1,42 @@
 import os
 import time
+import logging
 
-from graphrag_toolkit.lexical_graph import LexicalGraphIndex, GraphRAGConfig
+from graphrag_toolkit.lexical_graph import LexicalGraphIndex, GraphRAGConfig, NoOpProgressMonitor
 from graphrag_toolkit.lexical_graph.storage import GraphStoreFactory
 from graphrag_toolkit.lexical_graph.storage import VectorStoreFactory
 from graphrag_toolkit.lexical_graph.indexing.load import FileBasedDocs
 from graphrag_toolkit.lexical_graph.indexing.build import Checkpoint
 
+logger = logging.getLogger(__name__)
+
+
+class PrintingProgressMonitor(NoOpProgressMonitor):
+
+    def __init__(self, label):
+        self.label = label
+        self.graph_docs = 0
+        self.graph_chunks = 0
+        self.vector_docs = 0
+        self.vector_chunks = 0
+
+    def increment_graph_processed_documents(self, count=1):
+        self.graph_docs += count
+        logger.info(f'[{self.label}] Graph  - docs: {self.graph_docs}, chunks: {self.graph_chunks}')
+
+    def increment_graph_processed_chunks(self, count=1):
+        self.graph_chunks += count
+
+    def increment_vector_processed_documents(self, count=1):
+        self.vector_docs += count
+        logger.info(f'[{self.label}] Vector - docs: {self.vector_docs}, chunks: {self.vector_chunks}')
+
+    def increment_vector_processed_chunks(self, count=1):
+        self.vector_chunks += count
+
+
 def setup_datasets():
-    
+
     GraphRAGConfig.build_num_workers = 4
     GraphRAGConfig.build_batch_size = 10
     GraphRAGConfig.build_batch_write_size = 150
@@ -17,46 +45,47 @@ def setup_datasets():
         GraphStoreFactory.for_graph_store(os.environ['GRAPH_STORE']) as graph_store,
         VectorStoreFactory.for_vector_store(os.environ['VECTOR_STORE'], index_names=['chunk']) as vector_store
     ):
-        
-        
+
         docs_1 = FileBasedDocs(
             docs_directory='/home/ec2-user/SageMaker/graphrag-toolkit/source-data',
             collection_id='wiki-aircraft',
             zip_source='/home/ec2-user/SageMaker/graphrag-toolkit/source-data/wiki-aircraft.zip'
         )
-        
+
         checkpoint_1 = Checkpoint('3-build-1')
 
         graph_index_1 = LexicalGraphIndex(
-            graph_store, 
+            graph_store,
             vector_store,
             tenant_id='aircraft'
         )
 
         graph_index_1.build(
-            docs_1, 
-            checkpoint=checkpoint_1, 
-            show_progress=True
+            docs_1,
+            checkpoint=checkpoint_1,
+            show_progress=True,
+            progress_monitor=PrintingProgressMonitor('aircraft')
         )
-        
+
         docs_2 = FileBasedDocs(
             docs_directory='/home/ec2-user/SageMaker/graphrag-toolkit/source-data',
             collection_id='ntsb',
             zip_source='/home/ec2-user/SageMaker/graphrag-toolkit/source-data/ntsb.zip'
         )
-        
+
         checkpoint_2 = Checkpoint('3-build-2')
 
         graph_index_2 = LexicalGraphIndex(
-            graph_store, 
+            graph_store,
             vector_store,
             tenant_id='ntsb'
         )
 
         graph_index_2.build(
-            docs_2, 
-            checkpoint=checkpoint_2, 
-            show_progress=True
+            docs_2,
+            checkpoint=checkpoint_2,
+            show_progress=True,
+            progress_monitor=PrintingProgressMonitor('ntsb')
         )
 
         print('Build complete')

--- a/integration-tests/lexical.long
+++ b/integration-tests/lexical.long
@@ -2,3 +2,4 @@ batch_extract.BatchExtractToS3
 batch_build.BuildFromS3
 query.MultiHopQuery
 query.ChunkBasedSemanticSearchMultiHopQuery
+progress_monitor.ProgressMonitorExtractAndBuild

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/progress_monitor.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/progress_monitor.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import unittest
+from typing import Dict, Any
+
+from graphrag_toolkit_tests.integration_test_base import IntegrationTestBase
+from graphrag_toolkit_tests.integration_test_handler import IntegrationTestHandler
+
+from graphrag_toolkit.lexical_graph import LexicalGraphIndex, GraphRAGConfig, NoOpProgressMonitor
+from graphrag_toolkit.lexical_graph.storage import GraphStoreFactory
+from graphrag_toolkit.lexical_graph.storage import VectorStoreFactory
+from graphrag_toolkit.lexical_graph.storage.graph import NonRedactedGraphQueryLogFormatting
+
+from llama_index.readers.web import SimpleWebPageReader
+
+
+class TrackingProgressMonitor(NoOpProgressMonitor):
+
+    def __init__(self):
+        self.llm_docs = 0
+        self.llm_chunks = 0
+        self.graph_docs = 0
+        self.graph_chunks = 0
+        self.vector_docs = 0
+        self.vector_chunks = 0
+
+    def increment_llm_processed_documents(self, count=1):
+        self.llm_docs += count
+
+    def increment_llm_processed_chunks(self, count=1):
+        self.llm_chunks += count
+
+    def increment_graph_processed_documents(self, count=1):
+        self.graph_docs += count
+
+    def increment_graph_processed_chunks(self, count=1):
+        self.graph_chunks += count
+
+    def increment_vector_processed_documents(self, count=1):
+        self.vector_docs += count
+
+    def increment_vector_processed_chunks(self, count=1):
+        self.vector_chunks += count
+
+
+class ProgressMonitorExtractAndBuild(IntegrationTestBase):
+
+    @property
+    def description(self):
+        return 'ProgressMonitor receives correct document and chunk counts during extract_and_build'
+
+    def _run_test(self, handler: IntegrationTestHandler, params: Dict[str, Any]):
+
+        GraphRAGConfig.extraction_llm = os.environ.get('TEST_EXTRACTION_LLM', 'anthropic.claude-sonnet-4-6')
+
+        monitor = TrackingProgressMonitor()
+
+        doc_urls = [
+            'https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html',
+            'https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-comparison.html'
+        ]
+
+        docs = SimpleWebPageReader(html_to_text=True).load_data(doc_urls)
+
+        with (
+            GraphStoreFactory.for_graph_store(
+                os.environ['GRAPH_STORE'],
+                log_formatting=NonRedactedGraphQueryLogFormatting()
+            ) as graph_store,
+            VectorStoreFactory.for_vector_store(os.environ['VECTOR_STORE']) as vector_store,
+        ):
+            graph_index = LexicalGraphIndex(graph_store, vector_store)
+            graph_index.extract_and_build(docs, show_progress=True, progress_monitor=monitor)
+
+        expected_docs = len(doc_urls)
+
+        class ProgressMonitorAssertions(unittest.TestCase):
+
+            @classmethod
+            def setUpClass(cls):
+                cls.monitor = monitor
+                cls.expected_docs = expected_docs
+
+            def test_llm_processed_documents_matches_input(self):
+                """LLM document count equals number of input documents"""
+                self.assertEqual(self.monitor.llm_docs, self.expected_docs)
+
+            def test_llm_processed_chunks_is_positive(self):
+                """LLM chunk count is positive (documents were chunked)"""
+                self.assertGreater(self.monitor.llm_chunks, 0)
+
+            def test_graph_processed_documents_matches_llm(self):
+                """Graph document count equals LLM document count"""
+                self.assertEqual(self.monitor.graph_docs, self.monitor.llm_docs)
+
+            def test_vector_processed_documents_matches_graph(self):
+                """Vector document count equals graph document count"""
+                self.assertEqual(self.monitor.vector_docs, self.monitor.graph_docs)
+
+            def test_graph_and_vector_chunk_counts_are_consistent(self):
+                """Graph and vector chunk counts match (reported from same source)"""
+                self.assertEqual(self.monitor.graph_chunks, self.monitor.vector_chunks)
+
+            def test_graph_chunks_matches_llm_chunks(self):
+                """Graph chunk count matches LLM chunk count"""
+                self.assertEqual(self.monitor.graph_chunks, self.monitor.llm_chunks)
+
+        handler.run_assertions(ProgressMonitorAssertions)

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/progress_monitor.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/progress_monitor.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
+import logging
 import unittest
 from typing import Dict, Any
 
@@ -13,6 +14,8 @@ from graphrag_toolkit.lexical_graph.storage import VectorStoreFactory
 from graphrag_toolkit.lexical_graph.storage.graph import NonRedactedGraphQueryLogFormatting
 
 from llama_index.readers.web import SimpleWebPageReader
+
+logger = logging.getLogger(__name__)
 
 
 class TrackingProgressMonitor(NoOpProgressMonitor):
@@ -27,18 +30,21 @@ class TrackingProgressMonitor(NoOpProgressMonitor):
 
     def increment_llm_processed_documents(self, count=1):
         self.llm_docs += count
+        logger.info(f'[ProgressMonitor] LLM        - docs: {self.llm_docs}, chunks: {self.llm_chunks}')
 
     def increment_llm_processed_chunks(self, count=1):
         self.llm_chunks += count
 
     def increment_graph_processed_documents(self, count=1):
         self.graph_docs += count
+        logger.info(f'[ProgressMonitor] Graph      - docs: {self.graph_docs}, chunks: {self.graph_chunks}')
 
     def increment_graph_processed_chunks(self, count=1):
         self.graph_chunks += count
 
     def increment_vector_processed_documents(self, count=1):
         self.vector_docs += count
+        logger.info(f'[ProgressMonitor] Vector     - docs: {self.vector_docs}, chunks: {self.vector_chunks}')
 
     def increment_vector_processed_chunks(self, count=1):
         self.vector_chunks += count

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/__init__.py
@@ -47,6 +47,7 @@ from .lexical_graph_index import LexicalGraphIndex
 from .lexical_graph_index import ExtractionConfig, BuildConfig, IndexingConfig
 from .metadata import to_metadata_filter
 from .versioning import add_versioning_info, VersioningConfig, VersioningMode
+from .indexing.progress_monitor import ProgressMonitor, NoOpProgressMonitor
 from . import utils
 from . import indexing
 from . import retrieval

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -19,6 +19,7 @@ from graphrag_toolkit.lexical_graph.indexing.build.checkpoint import Checkpoint,
 from graphrag_toolkit.lexical_graph.indexing.build.node_builders import NodeBuilders
 from graphrag_toolkit.lexical_graph.indexing.build.build_filters import BuildFilters
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
+from graphrag_toolkit.lexical_graph.indexing.progress_monitor import ProgressMonitor
 
 from llama_index.core.utils import iter_batch
 from llama_index.core.ingestion import IngestionPipeline
@@ -60,13 +61,13 @@ class BuildPipeline():
         pipeline_kwargs (dict): Additional keyword arguments passed to the pipeline.
     """
     @staticmethod
-    def create(components: List[TransformComponent], 
-               num_workers:Optional[int]=None, 
-               batch_size:Optional[int]=None, 
-               batch_writes_enabled:Optional[bool]=None, 
-               batch_write_size:Optional[int]=None, 
-               builders:Optional[List[NodeBuilder]]=None, 
-               show_progress=False, 
+    def create(components: List[TransformComponent],
+               num_workers:Optional[int]=None,
+               batch_size:Optional[int]=None,
+               batch_writes_enabled:Optional[bool]=None,
+               batch_write_size:Optional[int]=None,
+               builders:Optional[List[NodeBuilder]]=None,
+               show_progress=False,
                checkpoint:Optional[Checkpoint]=None,
                build_filters:Optional[BuildFilters]=None,
                source_metadata_formatter:Optional[SourceMetadataFormatter]=None,
@@ -74,6 +75,7 @@ class BuildPipeline():
                include_local_entities:Optional[bool]=None,
                include_classification_in_entity_id:Optional[bool]=None,
                tenant_id:Optional[TenantId]=None,
+               progress_monitor:Optional[ProgressMonitor]=None,
                **kwargs:Any
             ):
         """
@@ -131,18 +133,19 @@ class BuildPipeline():
                 include_local_entities=include_local_entities,
                 include_classification_in_entity_id=include_classification_in_entity_id,
                 tenant_id=tenant_id,
+                progress_monitor=progress_monitor,
                 **kwargs
             ).build
         )
     
-    def __init__(self, 
-                 components: List[TransformComponent], 
-                 num_workers:Optional[int]=None, 
-                 batch_size:Optional[int]=None, 
-                 batch_writes_enabled:Optional[bool]=None, 
-                 batch_write_size:Optional[int]=None, 
-                 builders:Optional[List[NodeBuilder]]=None, 
-                 show_progress=False, 
+    def __init__(self,
+                 components: List[TransformComponent],
+                 num_workers:Optional[int]=None,
+                 batch_size:Optional[int]=None,
+                 batch_writes_enabled:Optional[bool]=None,
+                 batch_write_size:Optional[int]=None,
+                 builders:Optional[List[NodeBuilder]]=None,
+                 show_progress=False,
                  checkpoint:Optional[Checkpoint]=None,
                  build_filters:Optional[BuildFilters]=None,
                  source_metadata_formatter:Optional[SourceMetadataFormatter]=None,
@@ -150,6 +153,7 @@ class BuildPipeline():
                  include_local_entities:Optional[bool]=None,
                  include_classification_in_entity_id:Optional[bool]=None,
                  tenant_id:Optional[TenantId]=None,
+                 progress_monitor:Optional[ProgressMonitor]=None,
                  **kwargs:Any
             ):
         """
@@ -234,6 +238,7 @@ class BuildPipeline():
             )
         )
         self.node_filter = NodeFilter() if not checkpoint else checkpoint.add_filter(NodeFilter(), tenant_id)
+        self.progress_monitor = progress_monitor
         self.pipeline_kwargs = kwargs
     
     def _to_node_batches(self, source_doc_batches:Iterable[Iterable[SourceDocument]], build_timestamp:int) -> List[List[BaseNode]]:
@@ -320,5 +325,20 @@ class BuildPipeline():
             )
 
             for node in output_nodes:
-                yield node       
+                yield node
+
+            # TODO: Chunk-level reporting is batched at document boundaries.
+            # All chunks for a document are reported at once when the batch completes,
+            # not as each chunk finishes within a worker process. A future improvement
+            # could use multiprocessing-safe mechanisms for true per-chunk progress.
+            if self.progress_monitor:
+                try:
+                    num_docs = len(source_documents)
+                    num_chunks = sum(len(sd.nodes) for sd in source_documents)
+                    self.progress_monitor.increment_graph_processed_documents(num_docs)
+                    self.progress_monitor.increment_graph_processed_chunks(num_chunks)
+                    self.progress_monitor.increment_vector_processed_documents(num_docs)
+                    self.progress_monitor.increment_vector_processed_chunks(num_chunks)
+                except Exception:
+                    logger.warning("ProgressMonitor raised an exception during build tracking", exc_info=True)
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/progress_monitor.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/progress_monitor.py
@@ -1,0 +1,74 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+
+
+class ProgressMonitor(abc.ABC):
+    """
+    Abstract base class for monitoring progress of extraction and build operations.
+
+    Implementations receive increment calls at document boundaries from the main
+    process/thread. Thread safety is not required — the pipeline guarantees
+    single-threaded invocation. If your implementation performs cross-thread work
+    internally (e.g., pushing to a queue), that is your responsibility.
+
+    Subclass NoOpProgressMonitor if you only need a subset of these methods.
+    """
+
+    @abc.abstractmethod
+    def increment_llm_processed_documents(self, count: int = 1):
+        """Called after a document completes LLM extraction."""
+        pass
+
+    @abc.abstractmethod
+    def increment_llm_processed_chunks(self, count: int = 1):
+        """Called after a document completes LLM extraction, with the number of chunks in that document."""
+        pass
+
+    @abc.abstractmethod
+    def increment_graph_processed_documents(self, count: int = 1):
+        """Called after a document's nodes are written to the graph store."""
+        pass
+
+    @abc.abstractmethod
+    def increment_graph_processed_chunks(self, count: int = 1):
+        """Called after a document's nodes are written to the graph store, with the number of chunks in that document."""
+        pass
+
+    @abc.abstractmethod
+    def increment_vector_processed_documents(self, count: int = 1):
+        """Called after a document's nodes are written to the vector store."""
+        pass
+
+    @abc.abstractmethod
+    def increment_vector_processed_chunks(self, count: int = 1):
+        """Called after a document's nodes are written to the vector store, with the number of chunks in that document."""
+        pass
+
+
+class NoOpProgressMonitor(ProgressMonitor):
+    """
+    A no-op implementation of ProgressMonitor.
+
+    All methods do nothing. Subclass this and override only the methods you
+    care about to avoid implementing all six abstract methods.
+    """
+
+    def increment_llm_processed_documents(self, count: int = 1):
+        pass
+
+    def increment_llm_processed_chunks(self, count: int = 1):
+        pass
+
+    def increment_graph_processed_documents(self, count: int = 1):
+        pass
+
+    def increment_graph_processed_chunks(self, count: int = 1):
+        pass
+
+    def increment_vector_processed_documents(self, count: int = 1):
+        pass
+
+    def increment_vector_processed_chunks(self, count: int = 1):
+        pass

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
@@ -35,6 +35,7 @@ from graphrag_toolkit.lexical_graph.indexing.build.null_builder import NullBuild
 from graphrag_toolkit.lexical_graph.indexing.build.delete_sources import DeleteSources
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
+from graphrag_toolkit.lexical_graph.indexing.progress_monitor import ProgressMonitor
 
 from llama_index.core.node_parser import SentenceSplitter, NodeParser
 from llama_index.core.schema import BaseNode
@@ -428,6 +429,7 @@ class LexicalGraphIndex():
             handler: Optional[NodeHandler] = None,
             checkpoint: Optional[Checkpoint] = None,
             show_progress: Optional[bool] = False,
+            progress_monitor: Optional[ProgressMonitor] = None,
             **kwargs: Any) -> None:
         """
         Executes the extraction process for a given set of nodes using the specified handler,
@@ -443,7 +445,26 @@ class LexicalGraphIndex():
                 progress during extraction and build stages.
             show_progress (Optional[bool], optional): Indicates whether to display progress during
                 the pipeline execution.
+            progress_monitor (Optional[ProgressMonitor], optional): A monitor to receive progress
+                callbacks as documents complete LLM extraction. Receives
+                increment_llm_processed_documents and increment_llm_processed_chunks calls at
+                document boundaries.
             **kwargs (Any): Additional keyword arguments for pipeline configurations or overrides.
+
+        Example::
+
+            from graphrag_toolkit.lexical_graph import ProgressMonitor, NoOpProgressMonitor
+
+            class MyMonitor(NoOpProgressMonitor):
+                def __init__(self):
+                    self.docs_done = 0
+
+                def increment_llm_processed_documents(self, count=1):
+                    self.docs_done += count
+                    print(f"Extracted {self.docs_done} documents")
+
+            monitor = MyMonitor()
+            index.extract(nodes, progress_monitor=monitor)
         """
 
         if not self.tenant_id.is_default_tenant():
@@ -471,10 +492,17 @@ class LexicalGraphIndex():
             **kwargs
         )
 
-        if handler:
-            nodes | extraction_pipeline | Pipe(handler.accept) | build_pipeline | sink
+        if progress_monitor:
+            extraction_monitor = self._create_extraction_monitor_pipe(progress_monitor)
+            if handler:
+                nodes | extraction_pipeline | extraction_monitor | Pipe(handler.accept) | build_pipeline | sink
+            else:
+                nodes | extraction_pipeline | extraction_monitor | build_pipeline | sink
         else:
-            nodes | extraction_pipeline | build_pipeline | sink
+            if handler:
+                nodes | extraction_pipeline | Pipe(handler.accept) | build_pipeline | sink
+            else:
+                nodes | extraction_pipeline | build_pipeline | sink
 
     def build(
             self,
@@ -482,6 +510,7 @@ class LexicalGraphIndex():
             handler: Optional[NodeHandler] = None,
             checkpoint: Optional[Checkpoint] = None,
             show_progress: Optional[bool] = False,
+            progress_monitor: Optional[ProgressMonitor] = None,
             **kwargs: Any) -> None:
         """
         Builds an indexing pipeline for processing nodes, constructing a graph, and creating
@@ -497,6 +526,12 @@ class LexicalGraphIndex():
                 progress of the build pipeline. Defaults to None.
             show_progress (Optional[bool]): A flag indicating whether to show progress during
                 pipeline execution. Defaults to False.
+            progress_monitor (Optional[ProgressMonitor]): A monitor to receive progress
+                callbacks as documents complete graph and vector indexing. Receives
+                increment_graph_processed_documents, increment_graph_processed_chunks,
+                increment_vector_processed_documents, and increment_vector_processed_chunks
+                calls at document batch boundaries. Graph and vector increments fire together
+                since both stages execute within the same worker process.
             **kwargs (Any): Additional keyword arguments for extending or customizing the
                 pipeline behavior.
 
@@ -527,6 +562,7 @@ class LexicalGraphIndex():
             include_domain_labels=build_config.include_domain_labels,
             include_local_entities=build_config.include_local_entities,
             tenant_id=self.tenant_id,
+            progress_monitor=progress_monitor,
             **kwargs
         )
 
@@ -539,6 +575,7 @@ class LexicalGraphIndex():
             handler: Optional[NodeHandler] = None,
             checkpoint: Optional[Checkpoint] = None,
             show_progress: Optional[bool] = False,
+            progress_monitor: Optional[ProgressMonitor] = None,
             **kwargs: Any
     ) -> None:
         """
@@ -552,6 +589,10 @@ class LexicalGraphIndex():
             handler (Optional[NodeHandler]): A handler object to manage processed nodes. Defaults to None.
             checkpoint (Optional[Checkpoint]): A checkpoint object for resuming pipelines. Defaults to None.
             show_progress (Optional[bool]): Boolean flag to display pipeline progress. Defaults to False.
+            progress_monitor (Optional[ProgressMonitor]): A monitor to receive progress
+                callbacks across both extraction and build stages. The same instance receives
+                LLM increment calls during extraction, then graph/vector increment calls
+                during build.
             **kwargs (Any): Additional parameters to pass to pipelines.
         """
 
@@ -591,11 +632,32 @@ class LexicalGraphIndex():
             include_domain_labels=build_config.include_domain_labels,
             include_local_entities=build_config.include_local_entities,
             tenant_id=self.tenant_id,
+            progress_monitor=progress_monitor,
             **kwargs
         )
 
         sink_fn = sink if not handler else Pipe(handler)
-        nodes | extraction_pipeline | build_pipeline | sink_fn
+        if progress_monitor:
+            extraction_monitor = self._create_extraction_monitor_pipe(progress_monitor)
+            nodes | extraction_pipeline | extraction_monitor | build_pipeline | sink_fn
+        else:
+            nodes | extraction_pipeline | build_pipeline | sink_fn
+
+    @staticmethod
+    def _create_extraction_monitor_pipe(progress_monitor: ProgressMonitor) -> Pipe:
+        def _monitor_extraction(source_documents):
+            for doc in source_documents:
+                # TODO: Chunk-level reporting is batched at document boundaries.
+                # All chunks for a document are reported at once, not as each chunk
+                # finishes within a worker process. A future improvement could use
+                # multiprocessing-safe mechanisms for true per-chunk progress.
+                try:
+                    progress_monitor.increment_llm_processed_documents(1)
+                    progress_monitor.increment_llm_processed_chunks(len(doc.nodes))
+                except Exception:
+                    logger.warning("ProgressMonitor raised an exception during extraction tracking", exc_info=True)
+                yield doc
+        return Pipe(_monitor_extraction)
 
     def get_stats(self) -> Dict[str, Any]:
 

--- a/lexical-graph/tests/unit/test_progress_monitor.py
+++ b/lexical-graph/tests/unit/test_progress_monitor.py
@@ -1,0 +1,141 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import logging
+
+from graphrag_toolkit.lexical_graph.indexing.progress_monitor import ProgressMonitor, NoOpProgressMonitor
+
+
+class TestProgressMonitorABC:
+
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            ProgressMonitor()
+
+    def test_must_implement_all_methods(self):
+        class IncompleteMonitor(ProgressMonitor):
+            def increment_llm_processed_documents(self, count=1):
+                pass
+
+        with pytest.raises(TypeError):
+            IncompleteMonitor()
+
+
+class TestNoOpProgressMonitor:
+
+    def test_can_instantiate(self):
+        monitor = NoOpProgressMonitor()
+        assert monitor is not None
+
+    def test_all_methods_callable(self):
+        monitor = NoOpProgressMonitor()
+        monitor.increment_llm_processed_documents()
+        monitor.increment_llm_processed_documents(5)
+        monitor.increment_llm_processed_chunks()
+        monitor.increment_llm_processed_chunks(10)
+        monitor.increment_graph_processed_documents()
+        monitor.increment_graph_processed_documents(3)
+        monitor.increment_graph_processed_chunks()
+        monitor.increment_graph_processed_chunks(7)
+        monitor.increment_vector_processed_documents()
+        monitor.increment_vector_processed_documents(2)
+        monitor.increment_vector_processed_chunks()
+        monitor.increment_vector_processed_chunks(8)
+
+    def test_subclass_override_subset(self):
+        class DocCountMonitor(NoOpProgressMonitor):
+            def __init__(self):
+                self.doc_count = 0
+
+            def increment_llm_processed_documents(self, count=1):
+                self.doc_count += count
+
+        monitor = DocCountMonitor()
+        monitor.increment_llm_processed_documents()
+        monitor.increment_llm_processed_documents(4)
+        monitor.increment_llm_processed_chunks(10)
+        monitor.increment_graph_processed_documents(2)
+
+        assert monitor.doc_count == 5
+
+
+class TestExtractionMonitorPipe:
+
+    def test_extraction_monitor_fires_correctly(self):
+        from unittest.mock import MagicMock
+        from pipe import Pipe
+        from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo
+
+        monitor = MagicMock(spec=NoOpProgressMonitor)
+
+        node1 = TextNode(text="chunk1", id_="c1")
+        node1.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id="src1")
+        node2 = TextNode(text="chunk2", id_="c2")
+        node2.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id="src1")
+        node3 = TextNode(text="chunk3", id_="c3")
+        node3.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id="src1")
+
+        doc = SourceDocument(nodes=[node1, node2, node3])
+
+        extraction_monitor = LexicalGraphIndex._create_extraction_monitor_pipe(monitor)
+
+        result = list([doc] | extraction_monitor)
+
+        assert len(result) == 1
+        assert result[0] is doc
+        monitor.increment_llm_processed_documents.assert_called_once_with(1)
+        monitor.increment_llm_processed_chunks.assert_called_once_with(3)
+
+    def test_extraction_monitor_multiple_documents(self):
+        from unittest.mock import MagicMock
+        from pipe import Pipe
+        from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo
+
+        monitor = MagicMock(spec=NoOpProgressMonitor)
+
+        doc1 = SourceDocument(nodes=[
+            TextNode(text="a", id_="a1"),
+            TextNode(text="b", id_="a2"),
+        ])
+        doc2 = SourceDocument(nodes=[
+            TextNode(text="c", id_="b1"),
+        ])
+
+        extraction_monitor = LexicalGraphIndex._create_extraction_monitor_pipe(monitor)
+
+        result = list([doc1, doc2] | extraction_monitor)
+
+        assert len(result) == 2
+        assert monitor.increment_llm_processed_documents.call_count == 2
+        calls = monitor.increment_llm_processed_chunks.call_args_list
+        assert calls[0][0][0] == 2
+        assert calls[1][0][0] == 1
+
+
+class TestMonitorExceptionHandling:
+
+    def test_extraction_monitor_exception_does_not_crash(self, caplog):
+        from unittest.mock import MagicMock
+        from pipe import Pipe
+        from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode
+
+        monitor = MagicMock(spec=NoOpProgressMonitor)
+        monitor.increment_llm_processed_documents.side_effect = RuntimeError("monitor error")
+
+        doc = SourceDocument(nodes=[TextNode(text="chunk", id_="c1")])
+
+        extraction_monitor = LexicalGraphIndex._create_extraction_monitor_pipe(monitor)
+
+        with caplog.at_level(logging.WARNING):
+            result = list([doc] | extraction_monitor)
+
+        assert len(result) == 1
+        assert result[0] is doc
+        assert "ProgressMonitor raised an exception" in caplog.text

--- a/lexical-graph/tests/unit/test_progress_monitor.py
+++ b/lexical-graph/tests/unit/test_progress_monitor.py
@@ -117,11 +117,158 @@ class TestExtractionMonitorPipe:
         assert calls[1][0][0] == 1
 
 
+class TestBuildPipelineMonitor:
+
+    def _make_build_pipeline(self, monitor):
+        from unittest.mock import MagicMock, patch
+        from graphrag_toolkit.lexical_graph.indexing.build.build_pipeline import BuildPipeline
+        from llama_index.core.ingestion import IngestionPipeline
+
+        pipeline = BuildPipeline.__new__(BuildPipeline)
+        pipeline.inner_pipeline = MagicMock(spec=IngestionPipeline)
+        pipeline.num_workers = 1
+        pipeline.batch_size = 100
+        pipeline.batch_writes_enabled = False
+        pipeline.batch_write_size = 10
+        pipeline.include_domain_labels = False
+        pipeline.include_local_entities = False
+        pipeline.node_builders = MagicMock()
+        pipeline.node_builders.return_value = []
+        pipeline.node_filter = MagicMock(return_value=[])
+        pipeline.pipeline_kwargs = {}
+        pipeline.progress_monitor = monitor
+        return pipeline
+
+    def test_build_monitor_fires_for_single_batch(self):
+        from unittest.mock import MagicMock, patch
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode
+
+        monitor = MagicMock(spec=NoOpProgressMonitor)
+        pipeline = self._make_build_pipeline(monitor)
+
+        doc1 = SourceDocument(nodes=[TextNode(text="a", id_="a1"), TextNode(text="b", id_="a2")])
+        doc2 = SourceDocument(nodes=[TextNode(text="c", id_="c1")])
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.build.build_pipeline.run_pipeline', return_value=[]):
+            list(pipeline.build([doc1, doc2]))
+
+        monitor.increment_graph_processed_documents.assert_called_once_with(2)
+        monitor.increment_graph_processed_chunks.assert_called_once_with(3)
+        monitor.increment_vector_processed_documents.assert_called_once_with(2)
+        monitor.increment_vector_processed_chunks.assert_called_once_with(3)
+
+    def test_build_monitor_fires_per_batch(self):
+        from unittest.mock import MagicMock, patch
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode
+
+        monitor = MagicMock(spec=NoOpProgressMonitor)
+        pipeline = self._make_build_pipeline(monitor)
+        pipeline.batch_size = 1  # force one doc per batch
+
+        doc1 = SourceDocument(nodes=[TextNode(text="a", id_="a1"), TextNode(text="b", id_="a2")])
+        doc2 = SourceDocument(nodes=[TextNode(text="c", id_="c1")])
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.build.build_pipeline.run_pipeline', return_value=[]):
+            list(pipeline.build([doc1, doc2]))
+
+        assert monitor.increment_graph_processed_documents.call_count == 2
+        assert monitor.increment_vector_processed_documents.call_count == 2
+        chunk_calls = [c[0][0] for c in monitor.increment_graph_processed_chunks.call_args_list]
+        assert chunk_calls == [2, 1]
+
+    def test_build_monitor_exception_does_not_crash(self, caplog):
+        from unittest.mock import MagicMock, patch
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode
+
+        monitor = MagicMock(spec=NoOpProgressMonitor)
+        monitor.increment_graph_processed_documents.side_effect = RuntimeError("monitor error")
+        pipeline = self._make_build_pipeline(monitor)
+
+        doc = SourceDocument(nodes=[TextNode(text="a", id_="a1")])
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.build.build_pipeline.run_pipeline', return_value=[]):
+            with caplog.at_level(logging.WARNING):
+                list(pipeline.build([doc]))
+
+        assert "ProgressMonitor raised an exception" in caplog.text
+
+    def test_build_monitor_not_called_when_none(self):
+        from unittest.mock import MagicMock, patch
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from llama_index.core.schema import TextNode
+
+        pipeline = self._make_build_pipeline(monitor=None)
+        doc = SourceDocument(nodes=[TextNode(text="a", id_="a1")])
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.build.build_pipeline.run_pipeline', return_value=[]):
+            list(pipeline.build([doc]))  # should not raise
+
+
+class TestExtractAndBuildMonitor:
+
+    def test_same_monitor_receives_llm_and_build_increments(self):
+        from unittest.mock import MagicMock, patch
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        from graphrag_toolkit.lexical_graph.indexing.progress_monitor import ProgressMonitor
+
+        call_log = []
+
+        class TrackingMonitor(NoOpProgressMonitor):
+            def increment_llm_processed_documents(self, count=1):
+                call_log.append(('llm_docs', count))
+
+            def increment_llm_processed_chunks(self, count=1):
+                call_log.append(('llm_chunks', count))
+
+            def increment_graph_processed_documents(self, count=1):
+                call_log.append(('graph_docs', count))
+
+            def increment_graph_processed_chunks(self, count=1):
+                call_log.append(('graph_chunks', count))
+
+            def increment_vector_processed_documents(self, count=1):
+                call_log.append(('vector_docs', count))
+
+            def increment_vector_processed_chunks(self, count=1):
+                call_log.append(('vector_chunks', count))
+
+        monitor = TrackingMonitor()
+
+        # Simulate the extraction monitor pipe firing (LLM stage)
+        from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
+        from llama_index.core.schema import TextNode
+
+        doc = SourceDocument(nodes=[TextNode(text="a", id_="a1"), TextNode(text="b", id_="a2")])
+
+        extraction_monitor = LexicalGraphIndex._create_extraction_monitor_pipe(monitor)
+        list([doc] | extraction_monitor)
+
+        # Simulate the build monitor firing (build stage)
+        monitor.increment_graph_processed_documents(1)
+        monitor.increment_graph_processed_chunks(2)
+        monitor.increment_vector_processed_documents(1)
+        monitor.increment_vector_processed_chunks(2)
+
+        assert ('llm_docs', 1) in call_log
+        assert ('llm_chunks', 2) in call_log
+        assert ('graph_docs', 1) in call_log
+        assert ('graph_chunks', 2) in call_log
+        assert ('vector_docs', 1) in call_log
+        assert ('vector_chunks', 2) in call_log
+
+        # LLM events should appear before graph/vector events
+        llm_idx = next(i for i, e in enumerate(call_log) if e[0] == 'llm_docs')
+        graph_idx = next(i for i, e in enumerate(call_log) if e[0] == 'graph_docs')
+        assert llm_idx < graph_idx
+
+
 class TestMonitorExceptionHandling:
 
     def test_extraction_monitor_exception_does_not_crash(self, caplog):
         from unittest.mock import MagicMock
-        from pipe import Pipe
         from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
         from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
         from llama_index.core.schema import TextNode

--- a/lexical-graph/tests/unit/test_progress_monitor.py
+++ b/lexical-graph/tests/unit/test_progress_monitor.py
@@ -64,7 +64,6 @@ class TestExtractionMonitorPipe:
 
     def test_extraction_monitor_fires_correctly(self):
         from unittest.mock import MagicMock
-        from pipe import Pipe
         from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
         from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
         from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo
@@ -91,7 +90,6 @@ class TestExtractionMonitorPipe:
 
     def test_extraction_monitor_multiple_documents(self):
         from unittest.mock import MagicMock
-        from pipe import Pipe
         from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
         from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
         from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo


### PR DESCRIPTION
## Description

Adds a pluggable ProgressMonitor interface for tracking pipeline progress at the document and chunk level across the LLM extraction, graph build, and vector indexing stages. Existing behavior is unchanged when no monitor is provided.

## Changes

New: lexical_graph/indexing/progress_monitor.py
  - ProgressMonitor — abstract base class with 6 increment methods (documents + chunks × 3 stages)
  - NoOpProgressMonitor — concrete no-op subclass; users needing only a subset of callbacks can subclass this instead of implementing all 6 abstract methods

Modified: LexicalGraphIndex.extract(), .build(), .extract_and_build()
  - Added optional progress_monitor: Optional[ProgressMonitor] = None parameter to all three methods
  - LLM stage: monitor receives increment_llm_processed_documents and increment_llm_processed_chunks after each SourceDocument completes extraction
  - Build stage: monitor receives graph and vector increment calls after each document batch completes in BuildPipeline.build(); graph and vector increments fire together since both stages run in the same worker process

Exported from graphrag_toolkit.lexical_graph for top-level discoverability.

### Design Notes

  - Granularity: Chunk counts are reported at document boundaries (all chunks for a document reported at once), not as each individual chunk finishes within a worker process. This avoids multiprocessing complexity. A TODO comment marks where true per-chunk streaming could be added in future.
  - Thread safety: Monitor methods are called only from the main process/thread (at document yield boundaries after results return from workers). No thread safety required of implementations.
  - Error isolation: All monitor calls are wrapped in try/except — a monitor that throws will log a warning and never crash the pipeline.

### Usage Example

```
  from graphrag_toolkit.lexical_graph import NoOpProgressMonitor

  class MyMonitor(NoOpProgressMonitor):
      def __init__(self):
          self.docs_done = 0

      def increment_llm_processed_documents(self, count=1):
          self.docs_done += count
          print(f"Extracted {self.docs_done} documents")

  index.extract_and_build(nodes, progress_monitor=MyMonitor())
```

## Problem

Related issue (if any): #

fixes: #317 

## Testing

Added `tests/unit/test_progress_monitor.py`

- [X] Unit tests added/updated
- [X] Integration tests added (as appropriate)
- [X] Existing tests pass (`pytest`)
- [X] Tested manually (describe below)

Tested manually using integration tests, and added progress monitory (logging) to workshop.  Debugging output shows: 

```

```

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
