### PR TITLE
Fix: create_config TypeError when read_timeout is passed via config

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/neptune_graph_stores.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/neptune_graph_stores.py
@@ -146,15 +146,11 @@ def create_config(config:Optional[str]=None):
 
     config_args.setdefault('max_pool_connections', DEFAULT_MAX_POOL_CONNECTIONS)
 
-    return Config(
-        retries={
-            'total_max_attempts': 1,
-            'mode': 'standard'
-        },
-        read_timeout=600,
-        user_agent_appid=f'graphrag-lexical-graph-{toolkit_version}',
-        **config_args
-    )
+    config_args.setdefault('read_timeout', 600)
+    config_args.setdefault('retries', {'total_max_attempts': 1, 'mode': 'standard'})
+    config_args.setdefault('user_agent_appid', f'graphrag-lexical-graph-{toolkit_version}')
+
+    return Config(**config_args)
 
 def create_property_assigment_fn_for_neptune(key:str, value:Any) -> Callable[[str], str]:
     """


### PR DESCRIPTION
Fixes #361.

## Problem

`create_config()` hardcodes `read_timeout=600` as a keyword argument AND spreads user config via `**config_args`. When a user passes `read_timeout` in their config JSON, Python raises:

```
TypeError: botocore.config.Config() got multiple values for keyword argument 'read_timeout'
```

Same issue affects `retries` and `user_agent_appid`.

## Fix

Use `setdefault()` for all hardcoded values — the same pattern already used for `max_pool_connections` on the line immediately above. User-provided values take precedence; defaults apply when absent.

```python
# Before (breaks):
return Config(read_timeout=600, **config_args)  # duplicate kwarg

# After (works):
config_args.setdefault('read_timeout', 600)
return Config(**config_args)                     # no conflict
```

## Impact

- 4-line change, no new logic
- All existing defaults preserved (non-breaking)
- Users can now configure `read_timeout`, `retries`, and `user_agent_appid`
- Critical for production deployments behind API Gateway / ALB / Lambda timeouts