### PR TITLE
Update llama-index dependencies

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -1,12 +1,12 @@
 --only-binary :all:
 
-boto3>=1.40.61
-botocore>=1.40.61
+boto3==1.40.61
+botocore==1.40.61
 colorama==0.4.6
 faiss-cpu==1.9.0
 langchain_huggingface==0.3.1
 langchain_aws==0.2.33
-llama-index-embeddings-bedrock==0.8.0
+llama-index-embeddings-bedrock==0.8.2
 numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -1,12 +1,12 @@
 --only-binary :all:
 
-boto3==1.40.61
-botocore==1.40.61
+boto3>=1.40.61
+botocore>=1.40.61
 colorama==0.4.6
 faiss-cpu==1.9.0
 langchain_huggingface==0.3.1
 langchain_aws==0.2.33
-llama-index-embeddings-bedrock==0.8.2
+llama-index-embeddings-bedrock>=0.8.2
 numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
@@ -1,13 +1,13 @@
 --only-binary :all:
 
 anthropic-bedrock==0.8.0
-boto3>=1.40.61
-botocore>=1.40.61
+boto3==1.40.61
+botocore==1.40.61
 json2xml==5.2.0
-llama-index-core==0.14.20
-llama-index-embeddings-bedrock==0.8.0
-llama-index-llms-anthropic==0.11.2
-llama-index-llms-bedrock-converse==0.14.6
+llama-index-core==0.14.23
+llama-index-embeddings-bedrock==0.8.2
+llama-index-llms-anthropic==0.11.8
+llama-index-llms-bedrock-converse==0.14.16
 lru-dict==1.3.0
 pipe==2.2
 python-dotenv==1.2.2

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
@@ -1,13 +1,13 @@
 --only-binary :all:
 
 anthropic-bedrock==0.8.0
-boto3==1.40.61
-botocore==1.40.61
+boto3>=1.40.61
+botocore>=1.40.61
 json2xml==5.2.0
-llama-index-core==0.14.23
-llama-index-embeddings-bedrock==0.8.2
-llama-index-llms-anthropic==0.11.8
-llama-index-llms-bedrock-converse==0.14.16
+llama-index-core>=0.14.23
+llama-index-embeddings-bedrock>=0.8.2
+llama-index-llms-anthropic>=0.11.8
+llama-index-llms-bedrock-converse>=0.14.16
 lru-dict==1.3.0
 pipe==2.2
 python-dotenv==1.2.2


### PR DESCRIPTION
## Description

Update llama=index dependencies, and lock to specific version: 
```
boto3==1.40.61
botocore==1.40.61
llama-index-core==0.14.23
llama-index-embeddings-bedrock==0.8.2
llama-index-llms-anthropic==0.11.8
llama-index-llms-bedrock-converse==0.14.16
```

## Changes

see above

## Problem

llama-index dependencies may conflict with other botocore users.  

## Testing

- [ ] Unit tests added/updated
- [X] Integration tests run (lexical.short, lexical.long)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
