### PR TITLE
Update llama-index dependencies (lexical graph 3.18.x)

### DIFF
--- a/byokg-rag/README.md
+++ b/byokg-rag/README.md
@@ -95,7 +95,7 @@ NOTE: Additional permissions may be required for Neptune Database (`neptune-db:*
 
 The `GraphQueryRetriever` blocks Cypher queries containing modification keywords (CREATE, MERGE, DELETE, SET, REMOVE, DROP, DETACH, CALL) to protect against LLM-generated or user-supplied queries that could modify graph data.
 
-**Neptune Database**: Write protection relies solely on application-level Cypher validation (`is_query_safe()`). For stronger guarantees, use Neptune Analytics (which supports server-enforced `readOnly=True`) or restrict the IAM role to `neptune-db:ReadDataViaQuery`.
+**Neptune Database and Neptune Analytics (Graph)**: Neither service supports a server-enforced `readOnly` query parameter. Write protection relies solely on application-level Cypher validation (`is_query_safe()`). For stronger server-side guarantees, restrict the IAM role to `neptune-db:ReadDataViaQuery` (Neptune DB) or `neptune-graph:ReadDataViaQuery` (Neptune Analytics).
 
 ## Performance
 

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -300,14 +300,19 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
 
     def execute_query(self, cypher, parameters={}, read_only=False):
         logger.info(f"GraphQuery:: {cypher}")
+        if read_only:
+            logger.warning(
+                "Neptune Graph does not support read-only query execution. "
+                "Write protection relies solely on application-level Cypher validation. "
+                "For stronger guarantees, restrict the IAM role "
+                "to neptune-graph:ReadDataViaQuery."
+            )
         query_args = dict(
             graphIdentifier=self.neptune_graph_id,
             queryString=cypher,
             parameters=parameters,
             language='OPEN_CYPHER'
         )
-        if read_only:
-            query_args['readOnly'] = True
         response = self.neptune_client.execute_query(**query_args)
         return json.loads(response['payload'].read())['results']
 
@@ -557,7 +562,7 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
             logger.warning(
                 "Neptune DB does not support read-only query execution. "
                 "Write protection relies solely on application-level Cypher validation. "
-                "For stronger guarantees, use Neptune Analytics or restrict the IAM role "
+                "For stronger guarantees, restrict the IAM role "
                 "to neptune-db:ReadDataViaQuery."
             )
         response = self.neptune_data_client.execute_open_cypher_query(

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -1,12 +1,12 @@
 --only-binary :all:
 
-boto3>=1.40.61
-botocore>=1.40.61
+boto3==1.40.61
+botocore==1.40.61
 colorama==0.4.6
 faiss-cpu==1.9.0
 langchain_huggingface==0.3.1
 langchain_aws==0.2.33
-llama-index-embeddings-bedrock==0.8.0
+llama-index-embeddings-bedrock==0.8.2
 numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/requirements.txt
@@ -1,12 +1,12 @@
 --only-binary :all:
 
-boto3==1.40.61
-botocore==1.40.61
+boto3>=1.40.61
+botocore>=1.40.61
 colorama==0.4.6
 faiss-cpu==1.9.0
 langchain_huggingface==0.3.1
 langchain_aws==0.2.33
-llama-index-embeddings-bedrock==0.8.2
+llama-index-embeddings-bedrock>=0.8.2
 numpy>=1.24.0,<2.0.0
 pydantic>=2.8.2
 pyyaml==6.0.3

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -1087,8 +1087,8 @@ class TestNeptuneReadOnlyPropagation:
     """Tests for read_only parameter propagation in execute_query."""
 
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
-    def test_neptune_analytics_read_only_true_passes_to_api(self, mock_session, mock_neptune_client, mock_s3_client):
-        """When read_only=True, readOnly=True is passed to Neptune Analytics API."""
+    def test_neptune_analytics_read_only_true_does_not_pass_to_api(self, mock_session, mock_neptune_client, mock_s3_client, caplog):
+        """When read_only=True, readOnly is NOT passed to Neptune Analytics API (parameter removed from service)."""
         mock_session_instance = Mock()
         mock_session.return_value = mock_session_instance
         mock_session_instance.client.side_effect = lambda service, **kwargs: {
@@ -1108,9 +1108,10 @@ class TestNeptuneReadOnlyPropagation:
         store.execute_query("MATCH (n) RETURN n", read_only=True)
 
         call_args = mock_neptune_client.execute_query.call_args[1]
-        assert call_args['readOnly'] is True
+        assert 'readOnly' not in call_args
         assert call_args['queryString'] == "MATCH (n) RETURN n"
         assert call_args['language'] == 'OPEN_CYPHER'
+        assert "does not support read-only query execution" in caplog.text
 
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
     def test_neptune_analytics_read_only_false_omits_param(self, mock_session, mock_neptune_client, mock_s3_client):
@@ -1236,3 +1237,35 @@ class TestNeptuneReadOnlyPropagation:
         call_args = mock_neptune_data_client.execute_open_cypher_query.call_args[1]
         assert 'readOnly' not in call_args
         assert call_args['openCypherQuery'] == "MATCH (n) RETURN n"
+
+
+class TestNeptuneGraphReadOnlyParameterRejected:
+    """Validates that the neptune-graph service model does not accept readOnly.
+
+    Uses botocore's parameter validation directly (no network call, no boto3.client).
+    If this test starts failing, it means the service model re-added readOnly
+    and we could consider passing it again.
+    """
+
+    def test_neptune_graph_rejects_read_only_parameter(self):
+        """The neptune-graph execute_query API rejects readOnly in input validation."""
+        import botocore.session
+        from botocore.validate import ParamValidator
+
+        session = botocore.session.get_session()
+        service_model = session.get_service_model('neptune-graph')
+        operation_model = service_model.operation_model('ExecuteQuery')
+        input_shape = operation_model.input_shape
+
+        validator = ParamValidator()
+        params = {
+            'graphIdentifier': 'test-graph',
+            'queryString': 'MATCH (n) RETURN n LIMIT 1',
+            'language': 'OPEN_CYPHER',
+            'readOnly': True,
+        }
+        report = validator.validate(params, input_shape)
+        assert report.has_errors(), (
+            "Expected readOnly to be rejected by the neptune-graph service model. "
+            "If this fails, the API now accepts readOnly and we should consider re-enabling it."
+        )

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
@@ -21,7 +21,11 @@ class CypherSafetyCheck(IntegrationTestBase):
     3. Unicode lookalike keywords are blocked
     4. The block_graph_modification flag works correctly
     5. Legitimate read queries still execute successfully
-    6. The Neptune Analytics readOnly parameter rejects writes at driver level
+
+    Note: Neither Neptune Graph (Analytics) nor Neptune DB support a read-only
+    query execution parameter. Write protection relies on application-level
+    Cypher validation. For stronger server-side guarantees, restrict the IAM
+    role to neptune-graph:ReadDataViaQuery or neptune-db:ReadDataViaQuery.
     """
 
     @property

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
@@ -1,13 +1,13 @@
 --only-binary :all:
 
 anthropic-bedrock==0.8.0
-boto3>=1.40.61
-botocore>=1.40.61
+boto3==1.40.61
+botocore==1.40.61
 json2xml==5.2.0
-llama-index-core==0.14.20
-llama-index-embeddings-bedrock==0.8.0
-llama-index-llms-anthropic==0.11.2
-llama-index-llms-bedrock-converse==0.14.6
+llama-index-core==0.14.23
+llama-index-embeddings-bedrock==0.8.2
+llama-index-llms-anthropic==0.11.8
+llama-index-llms-bedrock-converse==0.14.16
 lru-dict==1.3.0
 pipe==2.2
 python-dotenv==1.2.2

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
@@ -1,13 +1,13 @@
 --only-binary :all:
 
 anthropic-bedrock==0.8.0
-boto3==1.40.61
-botocore==1.40.61
+boto3>=1.40.61
+botocore>=1.40.61
 json2xml==5.2.0
-llama-index-core==0.14.23
-llama-index-embeddings-bedrock==0.8.2
-llama-index-llms-anthropic==0.11.8
-llama-index-llms-bedrock-converse==0.14.16
+llama-index-core>=0.14.23
+llama-index-embeddings-bedrock>=0.8.2
+llama-index-llms-anthropic>=0.11.8
+llama-index-llms-bedrock-converse>=0.14.16
 lru-dict==1.3.0
 pipe==2.2
 python-dotenv==1.2.2


### PR DESCRIPTION
## Description

follow-up for https://github.com/awslabs/graphrag-toolkit/pull/372, #374 

## Changes

Update llama=index dependencies, and lock to specific version:

```
llama-index-core>=0.14.23
llama-index-embeddings-bedrock>=0.8.2
llama-index-llms-anthropic>=0.11.8
llama-index-llms-bedrock-converse>=0.14.16
```

[FIX] The boto3 neptune-graph client no longer accepts the readOnly parameter. Remove this parameter from calls and update readme.

## Problem

Related issue (if any): #372 #374 

## Testing

Integration tests run: lexical.short, byokg.short

- [X] Unit tests added/updated
- [X] Integration tests added (as appropriate)
- [X] Existing tests pass (`pytest`)
- [X] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
