### PR TITLE
Update boto3 api: remove readOnly param from neptune-graph client

### DIFF
--- a/byokg-rag/README.md
+++ b/byokg-rag/README.md
@@ -95,7 +95,7 @@ NOTE: Additional permissions may be required for Neptune Database (`neptune-db:*
 
 The `GraphQueryRetriever` blocks Cypher queries containing modification keywords (CREATE, MERGE, DELETE, SET, REMOVE, DROP, DETACH, CALL) to protect against LLM-generated or user-supplied queries that could modify graph data.
 
-**Neptune Database**: Write protection relies solely on application-level Cypher validation (`is_query_safe()`). For stronger guarantees, use Neptune Analytics (which supports server-enforced `readOnly=True`) or restrict the IAM role to `neptune-db:ReadDataViaQuery`.
+**Neptune Database and Neptune Analytics (Graph)**: Neither service supports a server-enforced `readOnly` query parameter. Write protection relies solely on application-level Cypher validation (`is_query_safe()`). For stronger server-side guarantees, restrict the IAM role to `neptune-db:ReadDataViaQuery` (Neptune DB) or `neptune-graph:ReadDataViaQuery` (Neptune Analytics).
 
 ## Performance
 

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -328,14 +328,19 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
 
     def execute_query(self, cypher, parameters={}, read_only=False):
         logger.info(f"GraphQuery:: {cypher}")
+        if read_only:
+            logger.warning(
+                "Neptune Graph does not support read-only query execution. "
+                "Write protection relies solely on application-level Cypher validation. "
+                "For stronger guarantees, restrict the IAM role "
+                "to neptune-graph:ReadDataViaQuery."
+            )
         query_args = dict(
             graphIdentifier=self.neptune_graph_id,
             queryString=cypher,
             parameters=parameters,
             language='OPEN_CYPHER'
         )
-        if read_only:
-            query_args['readOnly'] = True
         response = self.neptune_client.execute_query(**query_args)
         return json.loads(response['payload'].read())['results']
 
@@ -585,7 +590,7 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
             logger.warning(
                 "Neptune DB does not support read-only query execution. "
                 "Write protection relies solely on application-level Cypher validation. "
-                "For stronger guarantees, use Neptune Analytics or restrict the IAM role "
+                "For stronger guarantees, restrict the IAM role "
                 "to neptune-db:ReadDataViaQuery."
             )
         response = self.neptune_data_client.execute_open_cypher_query(

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -1812,6 +1812,7 @@ class TestNoUnescapedLabelSinks:
         assert not offenders, (
             'Value interpolated into a backtick-quoted identifier without '
             '_escape_cypher_label:\n' + '\n'.join(offenders)
+        )
 
 class TestNeptuneGraphReadOnlyParameterRejected:
     """Validates that the neptune-graph service model does not accept readOnly.

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -1089,8 +1089,8 @@ class TestNeptuneReadOnlyPropagation:
     """Tests for read_only parameter propagation in execute_query."""
 
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
-    def test_neptune_analytics_read_only_true_passes_to_api(self, mock_session, mock_neptune_client, mock_s3_client):
-        """When read_only=True, readOnly=True is passed to Neptune Analytics API."""
+    def test_neptune_analytics_read_only_true_does_not_pass_to_api(self, mock_session, mock_neptune_client, mock_s3_client, caplog):
+        """When read_only=True, readOnly is NOT passed to Neptune Analytics API (parameter removed from service)."""
         mock_session_instance = Mock()
         mock_session.return_value = mock_session_instance
         mock_session_instance.client.side_effect = lambda service, **kwargs: {
@@ -1110,9 +1110,10 @@ class TestNeptuneReadOnlyPropagation:
         store.execute_query("MATCH (n) RETURN n", read_only=True)
 
         call_args = mock_neptune_client.execute_query.call_args[1]
-        assert call_args['readOnly'] is True
+        assert 'readOnly' not in call_args
         assert call_args['queryString'] == "MATCH (n) RETURN n"
         assert call_args['language'] == 'OPEN_CYPHER'
+        assert "does not support read-only query execution" in caplog.text
 
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
     def test_neptune_analytics_read_only_false_omits_param(self, mock_session, mock_neptune_client, mock_s3_client):
@@ -1811,4 +1812,34 @@ class TestNoUnescapedLabelSinks:
         assert not offenders, (
             'Value interpolated into a backtick-quoted identifier without '
             '_escape_cypher_label:\n' + '\n'.join(offenders)
+
+class TestNeptuneGraphReadOnlyParameterRejected:
+    """Validates that the neptune-graph service model does not accept readOnly.
+
+    Uses botocore's parameter validation directly (no network call, no boto3.client).
+    If this test starts failing, it means the service model re-added readOnly
+    and we could consider passing it again.
+    """
+
+    def test_neptune_graph_rejects_read_only_parameter(self):
+        """The neptune-graph execute_query API rejects readOnly in input validation."""
+        import botocore.session
+        from botocore.validate import ParamValidator
+
+        session = botocore.session.get_session()
+        service_model = session.get_service_model('neptune-graph')
+        operation_model = service_model.operation_model('ExecuteQuery')
+        input_shape = operation_model.input_shape
+
+        validator = ParamValidator()
+        params = {
+            'graphIdentifier': 'test-graph',
+            'queryString': 'MATCH (n) RETURN n LIMIT 1',
+            'language': 'OPEN_CYPHER',
+            'readOnly': True,
+        }
+        report = validator.validate(params, input_shape)
+        assert report.has_errors(), (
+            "Expected readOnly to be rejected by the neptune-graph service model. "
+            "If this fails, the API now accepts readOnly and we should consider re-enabling it."
         )

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/byokg_cypher_safety.py
@@ -25,7 +25,11 @@ class CypherSafetyCheck(IntegrationTestBase):
     3. Unicode lookalike keywords are blocked
     4. The block_graph_modification flag works correctly
     5. Legitimate read queries still execute successfully
-    6. The Neptune Analytics readOnly parameter rejects writes at driver level
+
+    Note: Neither Neptune Graph (Analytics) nor Neptune DB support a read-only
+    query execution parameter. Write protection relies on application-level
+    Cypher validation. For stronger server-side guarantees, restrict the IAM
+    role to neptune-graph:ReadDataViaQuery or neptune-db:ReadDataViaQuery.
     """
 
     @property

--- a/integration-tests/test-scripts/on-start.sh
+++ b/integration-tests/test-scripts/on-start.sh
@@ -24,6 +24,11 @@ pip install torch sentence_transformers
 
 python -m spacy download en_core_web_sm
 
+# Pin boto3/botocore/aiobotocore to compatible versions. aiobotocore constrains
+# botocore to a narrow range; without pinning, other installs can pull a boto3
+# that imports symbols missing from the allowed botocore (e.g. DocumentModifiedShape).
+pip install boto3==1.43.0 botocore==1.43.0 aiobotocore==3.7.0
+
 source /home/ec2-user/anaconda3/bin/deactivate
 
 EOF


### PR DESCRIPTION
## Description

[FIX] The boto3 neptune-graph client no longer accepts the readOnly parameter.  Remove this parameter from calls and update readme. 

## Changes

 - execute_query no longer accepts readOnly in the boto3 neptune-graph client (same as neptune-db). 
 - Update unit tests
 - Update integration tests
 - Update documentation and warnings

## Problem

[FIX] The boto3 neptune-graph client no longer accepts the readOnly parameter.  Remove this parameter from calls and update readme. 

Related issue (if any): #372 updates the boto3 client

## Testing

- [X] Unit tests added/updated
- [X] Integration tests added (as appropriate)
- [X] Existing tests pass (`pytest`)
- [X] Tested manually (describe below)

Integration tests run: lexical.short, byokg.short

## Checklist

- [X] Code follows existing style and conventions
- [X] License headers present on new files
- [X] Documentation updated (if applicable)
- [X] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
