### PR TITLE
fix(examples): update Neptune CFN templates for current SageMaker platform and Rules constraints

### DIFF
--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-aurora-postgres.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-aurora-postgres.json
@@ -890,7 +890,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-opensearch-serverless.json
@@ -746,7 +746,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-s3-vectors.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-s3-vectors.json
@@ -974,7 +974,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics.json
@@ -403,7 +403,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
@@ -1330,7 +1330,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres.json
@@ -1281,7 +1281,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -115,14 +115,9 @@
                     ]
                   },
                   {
-                    "Fn::Equals": [
+                    "Fn::EachMemberEquals": [
                       {
-                        "Fn::Select": [
-                          0,
-                          {
-                            "Ref": "ExistingSubnetIds"
-                          }
-                        ]
+                        "Ref": "ExistingSubnetIds"
                       },
                       ""
                     ]
@@ -146,14 +141,9 @@
                   {
                     "Fn::Not": [
                       {
-                        "Fn::Equals": [
+                        "Fn::EachMemberEquals": [
                           {
-                            "Fn::Select": [
-                              0,
-                              {
-                                "Ref": "ExistingSubnetIds"
-                              }
-                            ]
+                            "Ref": "ExistingSubnetIds"
                           },
                           ""
                         ]
@@ -1431,7 +1421,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-s3-vectors.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-s3-vectors.json
@@ -1439,7 +1439,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },


### PR DESCRIPTION
## Description

Two fixes to the lexical-graph Neptune CloudFormation templates. Both surface only on a live create-stack, which is why static review and validate-template never flagged them.

## Changes

- Bump `PlatformIdentifier` from `notebook-al2-v3` to `notebook-al2023-v1` across all eight lexical-graph Neptune templates.
- Remove `Fn::Select` from the `Rules` block in `graphrag-toolkit-neptune-db-opensearch-serverless.json`; replace with `Fn::EachMemberEquals`.

## Problem

AWS retired the Amazon Linux 2 notebook platforms. The templates were correct when written, but `al2-v3` now fails at create time with "notebook-al2-v3 is not supported" — the long-term fix proposed in #302.

The VPC-reuse feature added two subnet checks using `Fn::Select` inside the `Rules` block. `Fn::Select` isn't one of the intrinsic functions CloudFormation permits there, so the template rolled back at create-stack time on the existing-VPC path. `validate-template` and JSON linting both accept it, so it only shows up on a real deploy.

Related issue: #302

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Both fixes only reproduce on a live create-stack, so validation was a real deploy against the updated templates (not `validate-template`, which accepts both the retired platform ID and the disallowed `Fn::Select` silently).

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

## Still open

The neptune-db templates' client role is missing `neptune-db:GetGraphSummary`, which makes `get_schema()` fail with `AccessDenied` against a live Neptune DB. Left out of this PR to keep it to the two create-stack blockers; will follow up separately.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
