### PR TITLE
fix(examples): update Neptune CFN templates for current SageMaker platform and Rules constraints

### DIFF
--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-aurora-postgres.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-aurora-postgres.json
@@ -890,7 +890,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-opensearch-serverless.json
@@ -746,7 +746,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-s3-vectors.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-s3-vectors.json
@@ -974,7 +974,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics.json
@@ -403,7 +403,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
@@ -1330,7 +1330,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres.json
@@ -1281,7 +1281,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -1275,7 +1275,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-s3-vectors.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-s3-vectors.json
@@ -1439,7 +1439,7 @@
         "InstanceType": {
           "Ref": "NotebookInstanceType"
         },
-        "PlatformIdentifier": "notebook-al2-v3",
+        "PlatformIdentifier": "notebook-al2023-v1",
         "NotebookInstanceName": {
           "Fn::Sub": "aws-neptune-${ApplicationId}"
         },


### PR DESCRIPTION
## Description

update Neptune CFN templates for current SageMaker platform and Rules constraints

Bump the notebook PlatformIdentifier from the retired notebook-al2-v3 to notebook-al2023-v1 across all eight lexical-graph Neptune templates. AWS retired the Amazon Linux 2 notebook platforms, so stacks using al2-v3 now fail at create time with "notebook-al2-v3 is not supported".

In graphrag-toolkit-neptune-db-opensearch-serverless.json, replace the two Fn::Select-based subnet checks in the Rules block with Fn::EachMemberEquals. Fn::Select is not among the intrinsic functions permitted inside Rules, so the template rolled back at create-stack time on the VPC-reuse path.

## Changes

## Problem

Downmerge: 

Related PR (if any): #375 

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
