### PR TITLE
[CHORE] Add Amazon Nova model access to CloudFormation IAM policies

### DIFF
--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -694,7 +694,13 @@
                   "Fn::Sub": "arn:${AWS::Partition}:bedrock:*::foundation-model/anthropic.*"
                 },
                 {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*::foundation-model/amazon.nova*"
+                },
+                {
                   "Fn::Sub": "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:inference-profile/*.anthropic.*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:inference-profile/*.amazon.nova*"
                 },
                 {
                   "Fn::Sub": "arn:${AWS::Partition}:bedrock:${AWS::Region}::foundation-model/cohere.embed-english-v3"

--- a/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
+++ b/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
@@ -363,7 +363,13 @@
                   "Fn::Sub": "arn:${AWS::Partition}:bedrock:*::foundation-model/anthropic.*"
                 },
                 {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*::foundation-model/amazon.nova*"
+                },
+                {
                   "Fn::Sub": "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:inference-profile/*.anthropic.*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:inference-profile/*.amazon.nova*"
                 }
               ]
             },


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->

## Changes
- Added amazon.nova* foundation model ARN to the Bedrock IAM policy in 
graphrag-toolkit-tests.json
- Added amazon.nova* inference profile ARN to the same policy for cross-region inference support
- Added matching entries to 
graphrag-toolkit-neptune-db-opensearch-serverless.json

## Problem

The CloudFormation IAM policies only allowed Anthropic and OpenAI models for Bedrock invocation. Running benchmarks with Amazon Nova 2 (e.g. amazon.nova-2-lite-v1:0) for extraction and evaluation would fail with AccessDenied errors since the model ARNs weren't in the allowed resource list.

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
