### PR TITLE
fix: remove repository-level security.md

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,3 +1,0 @@
-# Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
-


### PR DESCRIPTION
## Description

Remove the repository-level `security.md` so the GitHub organization-level security policy applies instead. Security vulnerability-reporting guidance is managed centrally at the org level; a per-repo policy file can diverge from that process even when its own contents are reasonable, which this one's were.

## Changes

- Delete `security.md` from the repository root.

## Problem

The repo carried its own `security.md`, overriding the org-managed vulnerability-reporting policy instead of deferring to it.

Related issue (if any): #

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Confirmed the file is gone and no other file in the repo references `security.md` by path.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
