### PR TITLE
[FEATURE] Add table extraction to AdvancedPDFReaderProvider (down-merge)

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/advanced_pdf_reader_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/advanced_pdf_reader_provider.py
@@ -28,18 +28,83 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
         # so read() cannot reach the bare `pymupdf` name without this.
         self._pymupdf = pymupdf
         self.config = config
+        self.extract_tables = config.extract_tables
         self.metadata_fn = config.metadata_fn
-        logger.debug("Initialized AdvancedPDFReaderProvider")
+        logger.debug(f"Initialized AdvancedPDFReaderProvider with extract_tables={config.extract_tables}")
+
+    def _find_tables(self, page, page_num):
+        """Return the tables detected on a page, or an empty list on failure."""
+        try:
+            return list(page.find_tables().tables)
+        except Exception as e:
+            logger.warning(f"Failed to detect tables on page {page_num}: {e}")
+            return []
+
+    @staticmethod
+    def _block_in_a_table(x0, y0, x1, y1, table_bboxes, threshold=0.5):
+        """True if more than `threshold` of a block's area lies inside any table
+        bbox (default: more than half), i.e. the block belongs to the table."""
+        block_area = max(0.0, x1 - x0) * max(0.0, y1 - y0)
+        if block_area == 0:
+            return False
+        for bx0, by0, bx1, by1 in table_bboxes:
+            overlap_w = max(0.0, min(x1, bx1) - max(x0, bx0))
+            overlap_h = max(0.0, min(y1, by1) - max(y0, by0))
+            if overlap_w * overlap_h > threshold * block_area:
+                return True
+        return False
+
+    def _page_text(self, page, tables):
+        """Page text with table-region text removed.
+
+        get_text() returns each table's cell text inline, and the table is also
+        appended as markdown, so without this the cell content would land in the
+        document twice and inflate downstream extraction (which dedups only on
+        exact-string output). Drop any text block sitting mostly inside a table's
+        bounding box, leaving the markdown as the table's single representation.
+        """
+        if not tables:
+            return page.get_text()
+        table_bboxes = [tuple(table.bbox) for table in tables]
+        kept = []
+        # "blocks" tuple layout: (x0, y0, x1, y1, text, block_no, block_type).
+        # block_type 1 is an image block (placeholder text); images are handled
+        # separately below, so keep only text blocks (type 0).
+        for block in page.get_text("blocks"):
+            x0, y0, x1, y1, block_text = block[:5]
+            block_type = block[6] if len(block) > 6 else 0
+            if block_type != 0:
+                continue
+            if not self._block_in_a_table(x0, y0, x1, y1, table_bboxes):
+                kept.append(block_text)
+        return "".join(kept)
+
+    def _append_tables(self, page_num, tables, text):
+        """Append each table to the text as a markdown block.
+
+        Returns the augmented text and the number of tables rendered. Row/column
+        relationships are preserved via the pipe-delimited markdown that pymupdf's
+        TableFinder produces. The count reflects tables actually written, not just
+        detected, so table_count never overstates what a consumer can find.
+        """
+        rendered = 0
+        for tbl_index, table in enumerate(tables):
+            try:
+                text += f"\n[TABLE_{page_num}_{tbl_index}]\n{table.to_markdown()}"
+                rendered += 1
+            except Exception as e:
+                logger.warning(f"Failed to render table {tbl_index} on page {page_num}: {e}")
+        return text, rendered
 
     def read(self, input_source) -> List[Document]:
         """Read PDF with text, images, and tables."""
         if not input_source:
             logger.error("No input source provided to AdvancedPDFReaderProvider")
             raise ValueError("input_source cannot be None or empty")
-
+        
         logger.info(f"Reading advanced PDF from: {input_source}")
         processed_paths, temp_files, original_paths = self._process_file_paths(input_source)
-
+        
         try:
             pdf_path = processed_paths[0]
             logger.debug(f"Opening PDF file: {pdf_path}")
@@ -48,7 +113,9 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
 
             for page_num in range(len(doc)):
                 page = doc[page_num]
-                text = page.get_text()
+
+                tables = self._find_tables(page, page_num) if self.extract_tables else []
+                text = self._page_text(page, tables)
 
                 image_list = page.get_images()
                 for img_index, img in enumerate(image_list):
@@ -63,25 +130,28 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
                     except Exception as e:
                         logger.warning(f"Failed to extract image {img_index} from page {page_num}: {e}")
 
+                text, table_count = self._append_tables(page_num, tables, text)
+
                 page_doc = Document(
                     text=text,
                     metadata={
                         'page_number': page_num + 1,
                         'source': 'advanced_pdf',
-                        'file_path': original_paths[0]
+                        'file_path': original_paths[0],
+                        'table_count': table_count
                     }
                 )
-
+                
                 if self.metadata_fn:
                     additional_metadata = self.metadata_fn(original_paths[0])
                     page_doc.metadata.update(additional_metadata)
-
+                
                 documents.append(page_doc)
-
+            
             doc.close()
             logger.info(f"Successfully read {len(documents)} page(s) from advanced PDF")
             return documents
-
+            
         except Exception as e:
             logger.error(f"Failed to read advanced PDF from {input_source}: {e}", exc_info=True)
             raise RuntimeError(f"Failed to read advanced PDF: {e}") from e

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/advanced_pdf_reader_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/advanced_pdf_reader_provider.py
@@ -18,13 +18,15 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
     def __init__(self, config: PDFReaderConfig):
 
         try:
-            import pymupdf 
+            import pymupdf
         except ImportError as e:
             raise ImportError(
                 "pymupdf package not found, install with 'pip install pymupdf'"
             ) from e
 
-
+        # Hold the module on the instance: the import above is local to __init__,
+        # so read() cannot reach the bare `pymupdf` name without this.
+        self._pymupdf = pymupdf
         self.config = config
         self.metadata_fn = config.metadata_fn
         logger.debug("Initialized AdvancedPDFReaderProvider")
@@ -34,25 +36,25 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
         if not input_source:
             logger.error("No input source provided to AdvancedPDFReaderProvider")
             raise ValueError("input_source cannot be None or empty")
-        
+
         logger.info(f"Reading advanced PDF from: {input_source}")
         processed_paths, temp_files, original_paths = self._process_file_paths(input_source)
-        
+
         try:
             pdf_path = processed_paths[0]
             logger.debug(f"Opening PDF file: {pdf_path}")
-            doc = pymupdf.open(pdf_path)
+            doc = self._pymupdf.open(pdf_path)
             documents = []
-            
+
             for page_num in range(len(doc)):
                 page = doc[page_num]
                 text = page.get_text()
-                
+
                 image_list = page.get_images()
                 for img_index, img in enumerate(image_list):
                     try:
                         xref = img[0]
-                        pix = pymupdf.Pixmap(doc, xref)
+                        pix = self._pymupdf.Pixmap(doc, xref)
                         if pix.n - pix.alpha < 4:
                             img_data = pix.tobytes("png")
                             img_b64 = base64.b64encode(img_data).decode()
@@ -60,7 +62,7 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
                         pix = None
                     except Exception as e:
                         logger.warning(f"Failed to extract image {img_index} from page {page_num}: {e}")
-                
+
                 page_doc = Document(
                     text=text,
                     metadata={
@@ -69,17 +71,17 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
                         'file_path': original_paths[0]
                     }
                 )
-                
+
                 if self.metadata_fn:
                     additional_metadata = self.metadata_fn(original_paths[0])
                     page_doc.metadata.update(additional_metadata)
-                
+
                 documents.append(page_doc)
-            
+
             doc.close()
             logger.info(f"Successfully read {len(documents)} page(s) from advanced PDF")
             return documents
-            
+
         except Exception as e:
             logger.error(f"Failed to read advanced PDF from {input_source}: {e}", exc_info=True)
             raise RuntimeError(f"Failed to read advanced PDF: {e}") from e

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/advanced_pdf_reader_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/advanced_pdf_reader_provider.py
@@ -32,12 +32,12 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
         self.metadata_fn = config.metadata_fn
         logger.debug(f"Initialized AdvancedPDFReaderProvider with extract_tables={config.extract_tables}")
 
-    def _find_tables(self, page, page_num):
+    def _find_tables(self, page, page_number):
         """Return the tables detected on a page, or an empty list on failure."""
         try:
             return list(page.find_tables().tables)
         except Exception as e:
-            logger.warning(f"Failed to detect tables on page {page_num}: {e}")
+            logger.warning(f"Failed to detect tables on page {page_number}: {e}")
             return []
 
     @staticmethod
@@ -65,7 +65,9 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
         """
         if not tables:
             return page.get_text()
-        table_bboxes = [tuple(table.bbox) for table in tables]
+        # Skip tables with a missing/empty bbox: a None would raise in tuple()
+        # and a partial bbox would unpack short in _block_in_a_table.
+        table_bboxes = [tuple(table.bbox) for table in tables if table.bbox]
         kept = []
         # "blocks" tuple layout: (x0, y0, x1, y1, text, block_no, block_type).
         # block_type 1 is an image block (placeholder text); images are handled
@@ -79,7 +81,7 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
                 kept.append(block_text)
         return "".join(kept)
 
-    def _append_tables(self, page_num, tables, text):
+    def _append_tables(self, page_number, tables, text):
         """Append each table to the text as a markdown block.
 
         Returns the augmented text and the number of tables rendered. Row/column
@@ -90,10 +92,10 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
         rendered = 0
         for tbl_index, table in enumerate(tables):
             try:
-                text += f"\n[TABLE_{page_num}_{tbl_index}]\n{table.to_markdown()}"
+                text += f"\n[TABLE_{page_number}_{tbl_index}]\n{table.to_markdown()}"
                 rendered += 1
             except Exception as e:
-                logger.warning(f"Failed to render table {tbl_index} on page {page_num}: {e}")
+                logger.warning(f"Failed to render table {tbl_index} on page {page_number}: {e}")
         return text, rendered
 
     def read(self, input_source) -> List[Document]:
@@ -113,8 +115,12 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
 
             for page_num in range(len(doc)):
                 page = doc[page_num]
+                # 1-indexed page number used consistently across markers, log
+                # messages, and metadata (page_num itself stays 0-based for the
+                # doc[page_num] lookup).
+                page_number = page_num + 1
 
-                tables = self._find_tables(page, page_num) if self.extract_tables else []
+                tables = self._find_tables(page, page_number) if self.extract_tables else []
                 text = self._page_text(page, tables)
 
                 image_list = page.get_images()
@@ -125,17 +131,17 @@ class AdvancedPDFReaderProvider(LlamaIndexReaderProviderBase, S3FileMixin):
                         if pix.n - pix.alpha < 4:
                             img_data = pix.tobytes("png")
                             img_b64 = base64.b64encode(img_data).decode()
-                            text += f"\n[IMAGE_{page_num}_{img_index}: base64_data={img_b64[:100]}...]"
+                            text += f"\n[IMAGE_{page_number}_{img_index}: base64_data={img_b64[:100]}...]"
                         pix = None
                     except Exception as e:
-                        logger.warning(f"Failed to extract image {img_index} from page {page_num}: {e}")
+                        logger.warning(f"Failed to extract image {img_index} from page {page_number}: {e}")
 
-                text, table_count = self._append_tables(page_num, tables, text)
+                text, table_count = self._append_tables(page_number, tables, text)
 
                 page_doc = Document(
                     text=text,
                     metadata={
-                        'page_number': page_num + 1,
+                        'page_number': page_number,
                         'source': 'advanced_pdf',
                         'file_path': original_paths[0],
                         'table_count': table_count

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/reader_provider_config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/reader_provider_config.py
@@ -10,6 +10,7 @@ from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config
 @dataclass
 class PDFReaderConfig(ReaderProviderConfig):
     return_full_document: bool = False
+    extract_tables: bool = True  # AdvancedPDFReaderProvider only: parse tables to markdown
     metadata_fn: Optional[Callable[[str], Dict[str, Any]]] = None
 
 @dataclass

--- a/lexical-graph/tests/unit/indexing/load/readers/providers/test_advanced_pdf_reader_provider.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/providers/test_advanced_pdf_reader_provider.py
@@ -1,26 +1,31 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import builtins
+
 import pytest
-import sys
 
-def test_raises_exception_if_dependencies_not_installed():
-    # Clean up any mocked providers module from other tests
-    if 'graphrag_toolkit.lexical_graph.indexing.load.readers.providers' in sys.modules:
-        providers_module = sys.modules['graphrag_toolkit.lexical_graph.indexing.load.readers.providers']
-        # Only remove if it's a Mock object (from other tests)
-        if hasattr(providers_module, '_mock_name'):
-            del sys.modules['graphrag_toolkit.lexical_graph.indexing.load.readers.providers']
-    
-    from graphrag_toolkit.lexical_graph.indexing.load.readers.providers import AdvancedPDFReaderProvider
-    from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import PDFReaderConfig 
+from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.advanced_pdf_reader_provider import (
+    AdvancedPDFReaderProvider,
+)
+from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import (
+    PDFReaderConfig,
+)
 
-    with pytest.raises(ImportError) as exc_info:  
-            reader = AdvancedPDFReaderProvider(PDFReaderConfig())
+
+def test_raises_exception_if_dependencies_not_installed(monkeypatch):
+    # Force the pymupdf import to fail regardless of whether it is installed,
+    # so the test is deterministic in any environment.
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pymupdf":
+            raise ImportError("No module named 'pymupdf'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as exc_info:
+        AdvancedPDFReaderProvider(PDFReaderConfig())
 
     assert exc_info.value.args[0] == "pymupdf package not found, install with 'pip install pymupdf'"
-    
-  
-
-
-    

--- a/lexical-graph/tests/unit/indexing/load/readers/providers/test_advanced_pdf_table_extraction.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/providers/test_advanced_pdf_table_extraction.py
@@ -50,6 +50,19 @@ def _make_two_table_pdf(path):
     return str(path)
 
 
+def _make_two_page_pdf(path):
+    """Write a two-page PDF: page 1 has a table, page 2 has none."""
+    doc = pymupdf.open()
+    p1 = doc.new_page()
+    p1.insert_text((60, 40), "Page one")
+    _draw_grid(p1, [["Region", "Revenue"], ["East", "100"]])
+    p2 = doc.new_page()
+    p2.insert_text((60, 40), "Page two, no table")
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
 def test_extracts_table_as_markdown_preserving_rows_and_cols(tmp_path):
     pdf = _make_pdf(tmp_path / "table.pdf", with_table=True)
     docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
@@ -66,7 +79,7 @@ def test_extracts_table_as_markdown_preserving_rows_and_cols(tmp_path):
 def test_table_block_is_marked(tmp_path):
     pdf = _make_pdf(tmp_path / "table.pdf", with_table=True)
     docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
-    assert "[TABLE_0_0]" in docs[0].text
+    assert "[TABLE_1_0]" in docs[0].text
 
 
 def test_extract_tables_false_skips_table_parsing(tmp_path):
@@ -74,7 +87,7 @@ def test_extract_tables_false_skips_table_parsing(tmp_path):
     docs = AdvancedPDFReaderProvider(PDFReaderConfig(extract_tables=False)).read(pdf)
 
     text = docs[0].text
-    assert "[TABLE_0_0]" not in text
+    assert "[TABLE_1_0]" not in text
     assert "|Region|Revenue|" not in text
     assert docs[0].metadata["table_count"] == 0
     # Raw page text is still returned.
@@ -97,10 +110,27 @@ def test_multiple_tables_on_a_page(tmp_path):
 
     text = docs[0].text
     assert docs[0].metadata["table_count"] == 2
-    assert "[TABLE_0_0]" in text
-    assert "[TABLE_0_1]" in text
+    assert "[TABLE_1_0]" in text
+    assert "[TABLE_1_1]" in text
     assert "|Region|Revenue|" in text
     assert "|Product|Units|" in text
+
+
+def test_page_numbering_and_counts_across_pages(tmp_path):
+    """Two-page PDF: page numbers are 1-indexed and per-page table_count is
+    independent (page 1 has a table, page 2 has none)."""
+    pdf = _make_two_page_pdf(tmp_path / "two_pages.pdf")
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
+
+    assert len(docs) == 2
+
+    assert docs[0].metadata["page_number"] == 1
+    assert docs[0].metadata["table_count"] == 1
+    assert "[TABLE_1_0]" in docs[0].text
+
+    assert docs[1].metadata["page_number"] == 2
+    assert docs[1].metadata["table_count"] == 0
+    assert "[TABLE_" not in docs[1].text
 
 
 def test_cell_text_is_not_duplicated(tmp_path):
@@ -161,7 +191,7 @@ def test_table_count_excludes_render_failures(tmp_path):
         def to_markdown(self):
             raise ValueError("nope")
 
-    text, count = provider._append_tables(0, [_GoodTable(), _BadTable()], "body")
+    text, count = provider._append_tables(1, [_GoodTable(), _BadTable()], "body")
     assert count == 1
-    assert "[TABLE_0_0]" in text
-    assert "[TABLE_0_1]" not in text
+    assert "[TABLE_1_0]" in text
+    assert "[TABLE_1_1]" not in text

--- a/lexical-graph/tests/unit/indexing/load/readers/providers/test_advanced_pdf_table_extraction.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/providers/test_advanced_pdf_table_extraction.py
@@ -1,0 +1,167 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+pymupdf = pytest.importorskip("pymupdf")
+
+from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.advanced_pdf_reader_provider import (
+    AdvancedPDFReaderProvider,
+)
+from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import (
+    PDFReaderConfig,
+)
+
+
+def _draw_grid(page, rows, x0=60, y0=60, cw=140, ch=30):
+    """Draw a ruled grid table that find_tables() detects."""
+    n_rows, n_cols = len(rows), len(rows[0])
+    for r in range(n_rows + 1):
+        y = y0 + r * ch
+        page.draw_line((x0, y), (x0 + n_cols * cw, y))
+    for c in range(n_cols + 1):
+        x = x0 + c * cw
+        page.draw_line((x, y0), (x, y0 + n_rows * ch))
+    for r in range(n_rows):
+        for c in range(n_cols):
+            page.insert_text((x0 + c * cw + 5, y0 + r * ch + 20), rows[r][c])
+
+
+def _make_pdf(path, with_table=True):
+    """Write a one-page PDF, optionally with a single ruled grid table."""
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((60, 40), "Quarterly results")
+    if with_table:
+        _draw_grid(page, [["Region", "Revenue"], ["East", "100"], ["West", "250"]])
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+def _make_two_table_pdf(path):
+    """Write a one-page PDF with two separate ruled grid tables."""
+    doc = pymupdf.open()
+    page = doc.new_page()
+    _draw_grid(page, [["Region", "Revenue"], ["East", "100"]], y0=60)
+    _draw_grid(page, [["Product", "Units"], ["Widget", "42"]], y0=260)
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+def test_extracts_table_as_markdown_preserving_rows_and_cols(tmp_path):
+    pdf = _make_pdf(tmp_path / "table.pdf", with_table=True)
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
+
+    assert len(docs) == 1
+    text = docs[0].text
+    # Row/column relationships survive as a pipe-delimited markdown table.
+    assert "|Region|Revenue|" in text
+    assert "|East|100|" in text
+    assert "|West|250|" in text
+    assert docs[0].metadata["table_count"] == 1
+
+
+def test_table_block_is_marked(tmp_path):
+    pdf = _make_pdf(tmp_path / "table.pdf", with_table=True)
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
+    assert "[TABLE_0_0]" in docs[0].text
+
+
+def test_extract_tables_false_skips_table_parsing(tmp_path):
+    pdf = _make_pdf(tmp_path / "table.pdf", with_table=True)
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig(extract_tables=False)).read(pdf)
+
+    text = docs[0].text
+    assert "[TABLE_0_0]" not in text
+    assert "|Region|Revenue|" not in text
+    assert docs[0].metadata["table_count"] == 0
+    # Raw page text is still returned.
+    assert "Region" in text
+
+
+def test_page_without_tables_reports_zero(tmp_path):
+    pdf = _make_pdf(tmp_path / "plain.pdf", with_table=False)
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
+
+    assert len(docs) == 1
+    assert docs[0].metadata["table_count"] == 0
+    assert docs[0].metadata["source"] == "advanced_pdf"
+    assert "Quarterly results" in docs[0].text
+
+
+def test_multiple_tables_on_a_page(tmp_path):
+    pdf = _make_two_table_pdf(tmp_path / "two.pdf")
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig()).read(pdf)
+
+    text = docs[0].text
+    assert docs[0].metadata["table_count"] == 2
+    assert "[TABLE_0_0]" in text
+    assert "[TABLE_0_1]" in text
+    assert "|Region|Revenue|" in text
+    assert "|Product|Units|" in text
+
+
+def test_cell_text_is_not_duplicated(tmp_path):
+    """Strip-then-append: each cell value lands once, not twice.
+    get_text() includes the table cells inline, so without stripping the
+    table region every value would appear both inline and in the markdown.
+    """
+    pdf = _make_pdf(tmp_path / "table.pdf", with_table=True)
+    docs = AdvancedPDFReaderProvider(PDFReaderConfig(extract_tables=True)).read(pdf)
+
+    text = docs[0].text
+    assert text.count("Region") == 1
+    assert text.count("East") == 1
+    assert text.count("250") == 1
+    assert "Quarterly results" in text
+
+
+def test_page_text_excludes_image_blocks(tmp_path):
+    """blocks mode returns image blocks too; only text blocks are kept so image
+    placeholders never leak into the page text."""
+    provider = AdvancedPDFReaderProvider(PDFReaderConfig())
+
+    class _Table:
+        bbox = (0, 0, 10, 10)
+
+    class _Page:
+        def get_text(self, mode=None):
+            return [
+                (100, 100, 200, 120, "Outside text\n", 0, 0),
+                (300, 300, 400, 400, "<image: DeviceRGB, width 8>", 1, 1),
+            ]
+
+    text = provider._page_text(_Page(), [_Table()])
+    assert "Outside text" in text
+    assert "<image" not in text
+
+
+def test_find_tables_failure_is_swallowed(tmp_path):
+    """A page whose find_tables() raises yields an empty table list."""
+    provider = AdvancedPDFReaderProvider(PDFReaderConfig())
+
+    class _BoomPage:
+        def find_tables(self):
+            raise RuntimeError("boom")
+
+    assert provider._find_tables(_BoomPage(), 0) == []
+
+
+def test_table_count_excludes_render_failures(tmp_path):
+    """A table that fails to_markdown() is skipped and not counted."""
+    provider = AdvancedPDFReaderProvider(PDFReaderConfig())
+
+    class _GoodTable:
+        def to_markdown(self):
+            return "|a|b|\n|---|---|\n|1|2|"
+
+    class _BadTable:
+        def to_markdown(self):
+            raise ValueError("nope")
+
+    text, count = provider._append_tables(0, [_GoodTable(), _BadTable()], "body")
+    assert count == 1
+    assert "[TABLE_0_0]" in text
+    assert "[TABLE_0_1]" not in text

--- a/lexical-graph/tests/unit/indexing/load/readers/test_base_reader_provider.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/test_base_reader_provider.py
@@ -7,11 +7,21 @@ import sys
 from unittest.mock import Mock
 from llama_index.core.schema import Document
 
-# Mock the providers module to avoid loading optional dependencies
-sys.modules['graphrag_toolkit.lexical_graph.indexing.load.readers.providers'] = Mock()
+# Temporarily mock the providers module so we can import BaseReaderProvider
+# without triggering imports of optional dependencies (e.g. pandas, PyGithub).
+# The mock is removed immediately after so it does not pollute sys.modules for
+# other tests that verify ImportError behavior of those same providers.
+_providers_key = 'graphrag_toolkit.lexical_graph.indexing.load.readers.providers'
+_original = sys.modules.get(_providers_key)
+sys.modules[_providers_key] = Mock()
 
 from graphrag_toolkit.lexical_graph.indexing.load.readers.base_reader_provider import BaseReaderProvider
 from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config_base import ReaderProviderConfig
+
+if _original is None:
+    del sys.modules[_providers_key]
+else:
+    sys.modules[_providers_key] = _original
 
 
 class TestBaseReaderProviderInitialization:

--- a/lexical-graph/tests/unit/indexing/load/readers/test_llama_index_reader_provider_base.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/test_llama_index_reader_provider_base.py
@@ -7,11 +7,22 @@ from unittest.mock import Mock
 from llama_index.core.schema import Document
 from llama_index.core.readers.base import BaseReader
 
-# Mock the providers module to avoid loading optional dependencies
-sys.modules['graphrag_toolkit.lexical_graph.indexing.load.readers.providers'] = Mock()
+# Temporarily mock the providers module so we can import
+# LlamaIndexReaderProviderBase without triggering imports of optional
+# dependencies (e.g. pandas, PyGithub).  The mock is removed immediately
+# after the import so it does not pollute sys.modules for other tests
+# that verify ImportError behavior of those same providers.
+_providers_key = 'graphrag_toolkit.lexical_graph.indexing.load.readers.providers'
+_original = sys.modules.get(_providers_key)
+sys.modules[_providers_key] = Mock()
 
 from graphrag_toolkit.lexical_graph.indexing.load.readers.llama_index_reader_provider_base import LlamaIndexReaderProviderBase
 from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config_base import ReaderProviderConfig
+
+if _original is None:
+    del sys.modules[_providers_key]
+else:
+    sys.modules[_providers_key] = _original
 
 
 class TestLlamaIndexReaderProviderBaseInitialization:

--- a/lexical-graph/tests/unit/indexing/load/readers/test_pydantic_reader_provider_base.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/test_pydantic_reader_provider_base.py
@@ -7,11 +7,21 @@ from unittest.mock import Mock
 from llama_index.core.schema import Document
 from llama_index.core.readers.base import BasePydanticReader
 
-# Mock the providers module to avoid loading optional dependencies
-sys.modules['graphrag_toolkit.lexical_graph.indexing.load.readers.providers'] = Mock()
+# Temporarily mock the providers module so we can import PydanticReaderProviderBase
+# without triggering imports of optional dependencies (e.g. pandas, PyGithub).
+# The mock is removed immediately after so it does not pollute sys.modules for
+# other tests that verify ImportError behavior of those same providers.
+_providers_key = 'graphrag_toolkit.lexical_graph.indexing.load.readers.providers'
+_original = sys.modules.get(_providers_key)
+sys.modules[_providers_key] = Mock()
 
 from graphrag_toolkit.lexical_graph.indexing.load.readers.pydantic_reader_provider_base import PydanticReaderProviderBase
 from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config_base import ReaderProviderConfig
+
+if _original is None:
+    del sys.modules[_providers_key]
+else:
+    sys.modules[_providers_key] = _original
 
 
 class TestPydanticReaderProviderBaseInitialization:

--- a/lexical-graph/tests/unit/indexing/load/readers/test_reader_provider_config.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/test_reader_provider_config.py
@@ -6,8 +6,13 @@ import sys
 from dataclasses import fields
 from unittest.mock import Mock
 
-# Mock the providers module to avoid loading optional dependencies
-sys.modules['graphrag_toolkit.lexical_graph.indexing.load.readers.providers'] = Mock()
+# Temporarily mock the providers module so we can import reader configs
+# without triggering imports of optional dependencies (e.g. pandas, PyGithub).
+# The mock is removed immediately after so it does not pollute sys.modules for
+# other tests that verify ImportError behavior of those same providers.
+_providers_key = 'graphrag_toolkit.lexical_graph.indexing.load.readers.providers'
+_original = sys.modules.get(_providers_key)
+sys.modules[_providers_key] = Mock()
 
 from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import (
     PDFReaderConfig,
@@ -37,6 +42,11 @@ from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config
     OutlookReaderConfig,
     UniversalDirectoryReaderConfig
 )
+
+if _original is None:
+    del sys.modules[_providers_key]
+else:
+    sys.modules[_providers_key] = _original
 
 
 class TestPDFReaderConfig:

--- a/lexical-graph/tests/unit/retrieval/test_deprecated_imports.py
+++ b/lexical-graph/tests/unit/retrieval/test_deprecated_imports.py
@@ -144,7 +144,8 @@ class TestUnknownAttributeRaises:
             getattr(module, 'TotallyFakeName')
 
     @given(name=st.text(min_size=1, max_size=30).filter(
-        lambda n: n not in _ALL_DEPRECATED_NAMES and n not in _NON_DEPRECATED_NAMES and n.isidentifier()
+        lambda n: n not in _ALL_DEPRECATED_NAMES and n not in _NON_DEPRECATED_NAMES
+        and n.isidentifier() and not (n.startswith('__') and n.endswith('__'))
     ))
     @settings(max_examples=20)
     def test_random_names_raise_attribute_error(self, name):


### PR DESCRIPTION
## Description

[FEATURE] Add table extraction to AdvancedPDFReaderProvider

## Changes

See

- #329 

Found polluting imports in tests that affect the global imports and cause test failures in other files. 

Summary of test fixes: 
  1. 4 test files (test_base_reader_provider.py, test_llama_index_reader_provider_base.py, test_pydantic_reader_provider_base.py, test_reader_provider_config.py) — cleaned up the sys.modules mock after import so it doesn't pollute other tests that verify ImportError behavior.
  2. test_deprecated_imports.py — excluded dunder names (__dict__, etc.) from the hypothesis-generated identifiers since those are standard module attributes that won't raise AttributeError.


## Problem

Related issue (if any): downmerge #329 

## Testing

N/A

## Checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
