### PR TITLE
[CHORE] Pin third-party GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/byokg-rag-prerelease.yml
+++ b/.github/workflows/byokg-rag-prerelease.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -94,7 +94,7 @@ jobs:
           retention-days: 30
 
       - name: Attach artifacts to GitHub Pre-Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             byokg-rag/dist/*

--- a/.github/workflows/byokg-rag-release.yml
+++ b/.github/workflows/byokg-rag-release.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -96,7 +96,7 @@ jobs:
           retention-days: 30
 
       - name: Attach artifacts to GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             byokg-rag/dist/*
@@ -121,4 +121,4 @@ jobs:
   #     - name: Remove non-versioned dist copies
   #       run: rm -f dist/*-latest.*
   #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/byokg-rag-tests.yml
+++ b/.github/workflows/byokg-rag-tests.yml
@@ -71,7 +71,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Create virtual environment
         run: uv venv .venv

--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -121,7 +121,7 @@ jobs:
           done
 
       - name: Attach Artifacts to GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             lexical-graph/dist/*
@@ -149,4 +149,4 @@ jobs:
       - name: Remove non-versioned dist copies
         run: rm -f dist/*-latest.*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -71,7 +71,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Create virtual environment
         run: uv venv .venv


### PR DESCRIPTION
## Description

Pin the three third-party GitHub Actions used in the release, prerelease, and test workflows to full commit SHAs instead of moving version tags. A version tag can be repointed to a different commit upstream, so a compromised action could run arbitrary code in CI with access to the release OIDC token and repository write permissions. Pinning to a SHA makes each action version explicit and auditable. GitHub-owned (`actions/*`) and AWS-owned (`aws-actions/*`) actions are first-party and left on tags.

## Changes

- Pin `astral-sh/setup-uv@v7` to its commit SHA in `byokg-rag-release`, `byokg-rag-prerelease`, `byokg-rag-tests`, `lexical-graph-release`, and `lexical-graph-tests`.
- Pin `softprops/action-gh-release@v3` to its commit SHA in `byokg-rag-release`, `byokg-rag-prerelease`, and `lexical-graph-release`.
- Pin `pypa/gh-action-pypi-publish@release/v1` to the current `release/v1` head in `lexical-graph-release` (active publish step) and `byokg-rag-release` (commented-out publish step, so it's already correct if re-enabled).
- Add a `# v7` / `# v3` / `# release/v1` comment beside each pin, matching the existing `codeql-action` pin style, so Dependabot's `github-actions` ecosystem keeps proposing version bumps.

## Problem

Third-party actions were referenced by mutable version tag (`@v7`, `@v3`, `@release/v1`). A tag can be force-moved to a malicious commit upstream, which would then execute in the CI environment that holds the PyPI and GitHub release credentials. Pinning to an immutable SHA closes that path without blocking updates, since Dependabot still bumps pinned actions.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Verified each pinned SHA resolves to the exact tag it replaces (checked via `gh api repos/<action>/git/ref/tags/<tag>` and `gh api repos/<action>/git/tags/<sha>` for annotated tags). No runtime behavior change — each SHA is the commit the tag already pointed to. Confirmed the diff is scoped to only these 5 workflow files against current `main`.

## Checklist

- [x] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

No new files added (license-header item not applicable). No behavior change; the pinned commits are what the tags currently resolve to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.