### PR TITLE
[CHORE] Add build provenance attestations and checksums to release workflows

### DIFF
--- a/.github/workflows/byokg-rag-prerelease.yml
+++ b/.github/workflows/byokg-rag-prerelease.yml
@@ -95,21 +95,20 @@ jobs:
             examples/byokg-rag/byokg-notebooks-latest.zip
           retention-days: 30
 
+      - name: Generate checksums
+        working-directory: ${{ github.workspace }}
+        run: |
+          cd byokg-rag/dist && sha256sum *.whl *.tar.gz > SHA256SUMS && cd ${{ github.workspace }}
+          sha256sum examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip | sed 's|.*/||' >> byokg-rag/dist/SHA256SUMS
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             byokg-rag/dist/*.whl
             byokg-rag/dist/*.tar.gz
+            byokg-rag/dist/SHA256SUMS
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
-
-      - name: Generate checksums
-        run: |
-          sha256sum \
-            byokg-rag/dist/*.whl \
-            byokg-rag/dist/*.tar.gz \
-            examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip \
-            > byokg-rag/dist/SHA256SUMS
 
       - name: Attach artifacts to GitHub Pre-Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3

--- a/.github/workflows/byokg-rag-prerelease.yml
+++ b/.github/workflows/byokg-rag-prerelease.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  attestations: write
+  id-token: write
 
 jobs:
   pre-release-build:
@@ -92,6 +94,22 @@ jobs:
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
             examples/byokg-rag/byokg-notebooks-latest.zip
           retention-days: 30
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            byokg-rag/dist/*.whl
+            byokg-rag/dist/*.tar.gz
+            examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
+
+      - name: Generate checksums
+        run: |
+          sha256sum \
+            byokg-rag/dist/*.whl \
+            byokg-rag/dist/*.tar.gz \
+            examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip \
+            > byokg-rag/dist/SHA256SUMS
 
       - name: Attach artifacts to GitHub Pre-Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3

--- a/.github/workflows/byokg-rag-release.yml
+++ b/.github/workflows/byokg-rag-release.yml
@@ -16,6 +16,8 @@ jobs:
       version: ${{ steps.version.outputs.pypi_version }}
     permissions:
       contents: write
+      attestations: write
+      id-token: write
 
     defaults:
       run:
@@ -95,6 +97,22 @@ jobs:
             examples/byokg-rag/byokg-notebooks-latest.zip
           retention-days: 30
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            byokg-rag/dist/*.whl
+            byokg-rag/dist/*.tar.gz
+            examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
+
+      - name: Generate checksums
+        run: |
+          sha256sum \
+            byokg-rag/dist/*.whl \
+            byokg-rag/dist/*.tar.gz \
+            examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip \
+            > byokg-rag/dist/SHA256SUMS
+
       - name: Attach artifacts to GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
@@ -104,21 +122,25 @@ jobs:
             examples/byokg-rag/byokg-notebooks-latest.zip
           prerelease: false
 
-  # pypi-publish:
-  #   runs-on: ubuntu-latest
-  #   needs: release-build
-  #   permissions:
-  #     id-token: write
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/project/graphrag-byokg/${{ needs.release-build.outputs.version }}
-  #   steps:
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: byokg-rag-dist
-  #         path: dist/
-  #     - name: Remove non-versioned dist copies
-  #       run: rm -f dist/*-latest.*
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+  pypi-publish:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-latest
+    needs: release-build
+    permissions:
+      id-token: write
+      attestations: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/graphrag-byokg/${{ needs.release-build.outputs.version }}
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: byokg-rag-dist
+          path: dist/
+      - name: Remove non-versioned dist copies
+        run: rm -f dist/*-latest.*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          attestations: true

--- a/.github/workflows/byokg-rag-release.yml
+++ b/.github/workflows/byokg-rag-release.yml
@@ -97,21 +97,20 @@ jobs:
             examples/byokg-rag/byokg-notebooks-latest.zip
           retention-days: 30
 
+      - name: Generate checksums
+        working-directory: ${{ github.workspace }}
+        run: |
+          cd byokg-rag/dist && sha256sum *.whl *.tar.gz > SHA256SUMS && cd ${{ github.workspace }}
+          sha256sum examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip | sed 's|.*/||' >> byokg-rag/dist/SHA256SUMS
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             byokg-rag/dist/*.whl
             byokg-rag/dist/*.tar.gz
+            byokg-rag/dist/SHA256SUMS
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
-
-      - name: Generate checksums
-        run: |
-          sha256sum \
-            byokg-rag/dist/*.whl \
-            byokg-rag/dist/*.tar.gz \
-            examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip \
-            > byokg-rag/dist/SHA256SUMS
 
       - name: Attach artifacts to GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3

--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -16,6 +16,8 @@ on:
 
 permissions:
   contents: write
+  attestations: write
+  id-token: write
 
 jobs:
   release-build:
@@ -120,6 +122,24 @@ jobs:
             done
           done
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            lexical-graph/dist/*.whl
+            lexical-graph/dist/*.tar.gz
+            examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip
+            examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip
+
+      - name: Generate checksums
+        run: |
+          sha256sum \
+            lexical-graph/dist/*.whl \
+            lexical-graph/dist/*.tar.gz \
+            examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip \
+            examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip \
+            > lexical-graph/dist/SHA256SUMS
+
       - name: Attach Artifacts to GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
@@ -137,12 +157,13 @@ jobs:
     needs: release-build
     permissions:
       id-token: write
+      attestations: write
     environment:
       name: pypi
       url: https://pypi.org/project/graphrag-lexical-graph/${{ needs.release-build.outputs.version }}
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: lexical-graph-dist
           path: dist/
@@ -150,3 +171,5 @@ jobs:
         run: rm -f dist/*-latest.*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          attestations: true

--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -122,23 +122,22 @@ jobs:
             done
           done
 
+      - name: Generate checksums
+        working-directory: ${{ github.workspace }}
+        run: |
+          cd lexical-graph/dist && sha256sum *.whl *.tar.gz > SHA256SUMS && cd ${{ github.workspace }}
+          sha256sum examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip | sed 's|.*/||' >> lexical-graph/dist/SHA256SUMS
+          sha256sum examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip | sed 's|.*/||' >> lexical-graph/dist/SHA256SUMS
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             lexical-graph/dist/*.whl
             lexical-graph/dist/*.tar.gz
+            lexical-graph/dist/SHA256SUMS
             examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip
             examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip
-
-      - name: Generate checksums
-        run: |
-          sha256sum \
-            lexical-graph/dist/*.whl \
-            lexical-graph/dist/*.tar.gz \
-            examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip \
-            examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip \
-            > lexical-graph/dist/SHA256SUMS
 
       - name: Attach Artifacts to GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3


### PR DESCRIPTION
## Description

Enable artifact attestations and SHA-256 checksums for **all** release artifacts across all release workflows, following GitHub recommended patterns for supply chain security.

Consumers can verify artifact integrity via `gh attestation verify <artifact>` and SHA256SUMS files.

Reference: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

## Changes

- Add `attestations: write` and `id-token: write` permissions to release jobs
- Add `actions/attest-build-provenance@v2.4.0` (pinned to SHA) generating SLSA provenance for wheels, sdists, **and notebook zips**
- Generate `SHA256SUMS` covering all versioned release artifacts (wheels, sdists, notebook zips)
- Enable PyPI attestations (PEP 740) for both `lexical-graph` and `byokg-rag` publishing
- Re-enable `byokg-rag` `pypi-publish` job with OIDC Trusted Publishing and attestations
- Pin `actions/download-artifact` to commit SHA for consistency
- Attestation + checksums run **before** attaching artifacts (fail-safe: if attestation fails, artifacts are not published unsigned)

## Problem

Release artifacts attached to GitHub Releases had no signing, attestation, or checksums. Downstream consumers could not cryptographically verify that artifacts were produced by the official CI pipeline.

Related issue (if any): #

## Testing

- [x] YAML syntax validated (all 3 files pass `yaml.safe_load`)
- [x] Follows GitHub recommended attestation patterns
  - `actions/attest-build-provenance@v2.4.0` for SLSA build provenance (pinned to SHA)
  - `pypa/gh-action-pypi-publish` with `attestations: true` for PEP 740
  - SHA256SUMS for offline verification
- [x] Permissions scoped correctly (`attestations: write`, `id-token: write`)
- [x] All actions pinned to commit SHA (supply chain hardening)
- [x] Attestation covers all release artifacts (wheels, sdists, notebook zips)
- [x] Attestation runs before artifact attachment (fail-safe ordering)
- [x] `pypi-publish` guarded with `if: github.event.action == 'released'` on both packages
- [x] No behavioral change to existing build steps

### Verification after merge

After next release, verify attestations:
```bash
gh attestation verify <downloaded-artifact> --repo awslabs/graphrag-toolkit
sha256sum -c SHA256SUMS
```

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.