### PR TITLE
[FEATURE] Add OpenSearch Serverless AOSS NextGen vector store support

### DIFF
--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json
@@ -1,0 +1,2121 @@
+{
+  "Description": "Creates a lexical-graph environment (VPC, Neptune Database, OpenSearch Serverless NextGen vector search collection, and SageMaker notebook)",
+  "Parameters": {
+    "ApplicationId": {
+      "Description": "Application id (used to name all resources in the environment)",
+      "Type": "String",
+      "Default": "graphrag-toolkit",
+      "AllowedPattern": "[a-z][a-z0-9-]*",
+      "MaxLength": 16,
+      "MinLength": 3,
+      "ConstraintDescription": "Must start with a lowercase letter, contain between 3 and 16 characters, and contain only lowercase letters, numbers and the hyphen"
+    },
+    "NeptuneEngineVersion": {
+      "Description": "Neptune DB engine version",
+      "Type": "String",
+      "Default": "1.4.7.0"
+    },
+    "NeptuneDbInstanceType": {
+      "Description": "Neptune DB instance type (use db.serverless to provision a Neptune Serverless cluster)",
+      "Type": "String",
+      "Default": "db.r8g.large",
+      "AllowedValues": [
+        "db.serverless",
+        "db.r8g.large",
+        "db.r8g.xlarge",
+        "db.r8g.2xlarge",
+        "db.r8g.4xlarge"
+      ],
+      "ConstraintDescription": "Must be a valid Neptune instance type."
+    },
+    "MinNCU": {
+      "Description": "Min number of NCUs (default 2.5, relevant only when instance type is db.serverless).",
+      "Type": "Number",
+      "Default": 2.5,
+      "MaxValue": 128,
+      "MinValue": 1
+    },
+    "MaxNCU": {
+      "Description": "Max number of NCUs (default 128, relevant only when instance type is db.serverless).",
+      "Type": "Number",
+      "Default": 32,
+      "MaxValue": 128,
+      "MinValue": 1
+    },
+    "EnableAuditLog": {
+      "Description": "Enable database auditing logging",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [
+        "true",
+        "false"
+      ]
+    },
+    "IamPolicyArn": {
+      "Type": "String",
+      "Description": "Space-separated ARNs of one or more additional IAM policies to be attached to the GraphRAG client IAM role (optional)",
+      "Default": ""
+    },
+    "NotebookInstanceType": {
+      "Description": "SageMaker notebook instance type (use ml.p3.2xlarge to provision a GPU instance)",
+      "Type": "String",
+      "Default": "ml.m5.xlarge",
+      "AllowedValues": [
+        "ml.m5.xlarge",
+        "ml.m5.2xlarge",
+        "ml.m5.4xlarge",
+        "ml.p3.2xlarge"
+      ],
+      "ConstraintDescription": "Must be a valid SageMaker instance type."
+    },
+    "ExampleNotebooksURL": {
+      "Type": "String",
+      "Description": "URL of a zip file containing example notebooks to be installed on SageMaker instance (optional)",
+      "Default": "https://github.com/awslabs/graphrag-toolkit/releases/latest/download/lexical-graph-examples-latest.zip"
+    },
+    "AllowPublicAccess": {
+      "Description": "Allow public access to the OpenSearch Serverless collection endpoint. Set to 'true' to enable public access, or 'false' to restrict access to the VPC (recommended)",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [
+        "true",
+        "false"
+      ]
+    },
+    "ModelId": {
+      "Description": "Bedrock model id or profile for extraction and response LLMs",
+      "Type": "String",
+      "Default": "global.anthropic.claude-sonnet-4-6"
+    },
+    "ExistingVpcId": {
+      "Description": "Optional existing VPC ID to reuse. If provided, ExistingSubnetIds must also be provided. Leave empty to create a new VPC.",
+      "Type": "String",
+      "Default": ""
+    },
+    "ExistingSubnetIds": {
+      "Description": "Optional comma-separated list of existing subnet IDs (minimum 2, spanning at least 2 AZs). The first subnet must have outbound internet access (e.g. public subnet with IGW or private subnet with NAT) as it is used for the SageMaker notebook. If provided, ExistingVpcId must also be provided. Leave empty to create new subnets.",
+      "Type": "CommaDelimitedList",
+      "Default": ""
+    }
+  },
+  "Rules": {
+    "VpcAndSubnetsBothOrNeither": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Or": [
+              {
+                "Fn::And": [
+                  {
+                    "Fn::Equals": [
+                      {
+                        "Ref": "ExistingVpcId"
+                      },
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::EachMemberEquals": [
+                      {
+                        "Ref": "ExistingSubnetIds"
+                      },
+                      ""
+                    ]
+                  }
+                ]
+              },
+              {
+                "Fn::And": [
+                  {
+                    "Fn::Not": [
+                      {
+                        "Fn::Equals": [
+                          {
+                            "Ref": "ExistingVpcId"
+                          },
+                          ""
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Fn::Not": [
+                      {
+                        "Fn::EachMemberEquals": [
+                          {
+                            "Ref": "ExistingSubnetIds"
+                          },
+                          ""
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "Both ExistingVpcId and ExistingSubnetIds must be provided together, or both must be left empty."
+        }
+      ]
+    }
+  },
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "Setup"
+          },
+          "Parameters": [
+            "ApplicationId"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Neptune"
+          },
+          "Parameters": [
+            "NeptuneEngineVersion",
+            "NeptuneDbInstanceType",
+            "MinNCU",
+            "MaxNCU",
+            "EnableAuditLog"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Bedrock"
+          },
+          "Parameters": [
+            "ModelId"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Notebook"
+          },
+          "Parameters": [
+            "NotebookInstanceType",
+            "ExampleNotebooksURL",
+            "IamPolicyArn"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Networking"
+          },
+          "Parameters": [
+            "ExistingVpcId",
+            "ExistingSubnetIds"
+          ]
+        }
+      ]
+    }
+  },
+  "Conditions": {
+    "CreateVPC": {
+      "Fn::Equals": [
+        {
+          "Ref": "ExistingVpcId"
+        },
+        ""
+      ]
+    },
+    "ExampleNotebooksURLIsNotBlank": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "ExampleNotebooksURL"
+            },
+            ""
+          ]
+        }
+      ]
+    },
+    "IsS3ExampleNotebooksURL": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::Split": [
+                ":",
+                {
+                  "Ref": "ExampleNotebooksURL"
+                }
+              ]
+            }
+          ]
+        },
+        "s3"
+      ]
+    },
+    "IsIadRegion": {
+      "Fn::Equals": [
+        {
+          "Ref": "AWS::Region"
+        },
+        "us-east-1"
+      ]
+    },
+    "AZ3NotPresent": {
+      "Fn::Or": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "ca-central-1"
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AWS::Region"
+            },
+            "us-west-1"
+          ]
+        }
+      ]
+    },
+    "AZ3Present": {
+      "Fn::Not": [
+        {
+          "Condition": "AZ3NotPresent"
+        }
+      ]
+    },
+    "AZ3PresentAndCreateVPC": {
+      "Fn::And": [
+        {
+          "Condition": "AZ3Present"
+        },
+        {
+          "Condition": "CreateVPC"
+        }
+      ]
+    },
+    "AddIamPolicyArn": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "IamPolicyArn"
+            },
+            ""
+          ]
+        }
+      ]
+    },
+    "AuditLogEnabled": {
+      "Fn::Equals": [
+        {
+          "Ref": "EnableAuditLog"
+        },
+        "true"
+      ]
+    },
+    "EnablePublicAccess": {
+      "Fn::Equals": [
+        {
+          "Ref": "AllowPublicAccess"
+        },
+        "true"
+      ]
+    },
+    "EnableVpcAccess": {
+      "Fn::Not": [
+        {
+          "Condition": "EnablePublicAccess"
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "NeptuneDBSubnetGroup": {
+      "Type": "AWS::Neptune::DBSubnetGroup",
+      "Properties": {
+        "DBSubnetGroupDescription": "Neptune DB subnet group",
+        "DBSubnetGroupName": {
+          "Fn::Sub": "${ApplicationId}-subnet"
+        },
+        "SubnetIds": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Fn::If": [
+                "AZ3NotPresent",
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  }
+                ],
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  },
+                  {
+                    "Ref": "Subnet3"
+                  }
+                ]
+              ]
+            },
+            {
+              "Ref": "ExistingSubnetIds"
+            }
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-subnet"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "GraphRAGClientSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupName": {
+          "Fn::Sub": "${ApplicationId}-client-sg"
+        },
+        "VpcId": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
+        },
+        "GroupDescription": "GraphRAG client security group",
+        "SecurityGroupEgress": [
+          {
+            "FromPort": "443",
+            "ToPort": "443",
+            "IpProtocol": "tcp",
+            "CidrIp": "0.0.0.0/0",
+            "Description": "HTTPS egress"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-client-sg"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "NeptuneSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupName": {
+          "Fn::Sub": "${ApplicationId}-neptune-sg"
+        },
+        "VpcId": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
+        },
+        "GroupDescription": "GraphRAG Neptune security group",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-neptune-sg"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "GraphRAGClientSecurityGroupEgress": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "FromPort": 8182,
+        "ToPort": 8182,
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "NeptuneSecurityGroup",
+            "GroupId"
+          ]
+        },
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GraphRAGClientSecurityGroup",
+            "GroupId"
+          ]
+        }
+      }
+    },
+    "GraphRAGClientSecurityGroupSelfIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Condition": "EnableVpcAccess",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "FromPort": 443,
+        "ToPort": 443,
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GraphRAGClientSecurityGroup",
+            "GroupId"
+          ]
+        },
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GraphRAGClientSecurityGroup",
+            "GroupId"
+          ]
+        },
+        "Description": "HTTPS access to OpenSearch Serverless VPC endpoint"
+      }
+    },
+    "NeptuneSecurityGroupIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "FromPort": 8182,
+        "ToPort": 8182,
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GraphRAGClientSecurityGroup",
+            "GroupId"
+          ]
+        },
+        "GroupId": {
+          "Fn::GetAtt": [
+            "NeptuneSecurityGroup",
+            "GroupId"
+          ]
+        }
+      }
+    },
+    "GraphRAGClientRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "sagemaker.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "ManagedPolicyArns": {
+          "Fn::If": [
+            "AddIamPolicyArn",
+            {
+              "Fn::Split": [
+                " ",
+                {
+                  "Ref": "IamPolicyArn"
+                }
+              ]
+            },
+            [
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          ]
+        },
+        "Path": "/graphrag-toolkit/"
+      }
+    },
+    "GraphRAGClientRolePolicy": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "ManagedPolicyName": {
+          "Fn::Sub": "${ApplicationId}-graphrag-client-policy"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "S3ListBucketAndGetObject",
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+              ],
+              "Resource": [
+                {
+                  "Fn::If": [
+                    "IsIadRegion",
+                    "arn:aws:s3:::aws-neptune-notebook",
+                    {
+                      "Fn::Sub": "arn:aws:s3:::aws-neptune-notebook-${AWS::Region}"
+                    }
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "IsIadRegion",
+                    "arn:aws:s3:::aws-neptune-notebook/*",
+                    {
+                      "Fn::Sub": "arn:aws:s3:::aws-neptune-notebook-${AWS::Region}/*"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Sid": "LogGroupAccess",
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/sagemaker/*"
+                }
+              ]
+            },
+            {
+              "Sid": "SageMakerNotebookAccess",
+              "Effect": "Allow",
+              "Action": "sagemaker:DescribeNotebookInstance",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/*"
+                }
+              ]
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "GraphRAGClientRole"
+          }
+        ],
+        "Path": "/graphrag-toolkit/"
+      }
+    },
+    "BedrockInvokeModelPolicy": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "ManagedPolicyName": {
+          "Fn::Sub": "${ApplicationId}-bedrock-invoke-model-policy"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:InvokeModelWithResponseStream"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*::foundation-model/anthropic.*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*::foundation-model/amazon.nova*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:inference-profile/*.anthropic.*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:*:${AWS::AccountId}:inference-profile/*.amazon.nova*"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:${AWS::Region}::foundation-model/cohere.embed-english-v3"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:bedrock:${AWS::Region}::foundation-model/cohere.rerank-v3-5:0"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "bedrock:Rerank"
+              ],
+              "Resource": [
+                "*"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "GraphRAGClientRole"
+          }
+        ],
+        "Path": "/graphrag-toolkit/"
+      }
+    },
+    "OpenSearchServerlessAPIAccessAllPolicy": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "ManagedPolicyName": {
+          "Fn::Sub": "${ApplicationId}-aoss-api-access-all-policy"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "aoss:APIAccessAll",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${partition}:aoss:${region}:${accountId}:collection/${collectionId}",
+                    {
+                      "partition": {
+                        "Ref": "AWS::Partition"
+                      },
+                      "region": {
+                        "Ref": "AWS::Region"
+                      },
+                      "accountId": {
+                        "Ref": "AWS::AccountId"
+                      },
+                      "collectionId": {
+                        "Fn::GetAtt": [
+                          "OpenSearchServerless",
+                          "Id"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "GraphRAGClientRole"
+          }
+        ],
+        "Path": "/graphrag-toolkit/"
+      }
+    },
+    "NeptuneDBDataAccessQueryingPolicy": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "ManagedPolicyName": {
+          "Fn::Sub": "${ApplicationId}-neptune-db-querying-policy"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "neptune-db:ReadDataViaQuery"
+              ],
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:neptune-db:"
+                    },
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Fn::GetAtt": [
+                        "NeptuneDBCluster",
+                        "ClusterResourceId"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              },
+              "Condition": {
+                "StringEquals": {
+                  "neptune-db:QueryLanguage": "OpenCypher"
+                }
+              }
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "GraphRAGClientRole"
+          }
+        ],
+        "Path": "/graphrag-toolkit/"
+      }
+    },
+    "NeptuneDBDataAccessIndexingPolicy": {
+      "Type": "AWS::IAM::ManagedPolicy",
+      "Properties": {
+        "ManagedPolicyName": {
+          "Fn::Sub": "${ApplicationId}-neptune-db-indexing-policy"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "neptune-db:WriteDataViaQuery",
+                "neptune-db:DeleteDataViaQuery",
+                "neptune-db:ReadDataViaQuery"
+              ],
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:neptune-db:"
+                    },
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId"
+                    },
+                    ":",
+                    {
+                      "Fn::GetAtt": [
+                        "NeptuneDBCluster",
+                        "ClusterResourceId"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              },
+              "Condition": {
+                "StringEquals": {
+                  "neptune-db:QueryLanguage": "OpenCypher"
+                }
+              }
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "GraphRAGClientRole"
+          }
+        ],
+        "Path": "/graphrag-toolkit/"
+      }
+    },
+    "NeptuneDBClusterParameterGroup": {
+      "Type": "AWS::Neptune::DBClusterParameterGroup",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "neptune-cluster-params-${ApplicationId}"
+        },
+        "Family": "neptune1.4",
+        "Description": "Neptune cluster parameter group",
+        "Parameters": {
+          "neptune_enable_audit_log": {
+            "Fn::If": [
+              "AuditLogEnabled",
+              1,
+              0
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "neptune-cluster-params-${ApplicationId}"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "NeptuneDBParameterGroup": {
+      "Type": "AWS::Neptune::DBParameterGroup",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "neptune-params-${ApplicationId}"
+        },
+        "Family": "neptune1.4",
+        "Description": "Neptune parameter group",
+        "Parameters": {
+          "neptune_query_timeout": 60000
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "neptune-params-${ApplicationId}"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "NeptuneDBCluster": {
+      "Type": "AWS::Neptune::DBCluster",
+      "Properties": {
+        "DBClusterIdentifier": {
+          "Fn::Sub": "${ApplicationId}-cluster"
+        },
+        "EngineVersion": {
+          "Ref": "NeptuneEngineVersion"
+        },
+        "DBSubnetGroupName": {
+          "Ref": "NeptuneDBSubnetGroup"
+        },
+        "VpcSecurityGroupIds": [
+          {
+            "Ref": "NeptuneSecurityGroup"
+          }
+        ],
+        "DBClusterParameterGroupName": {
+          "Ref": "NeptuneDBClusterParameterGroup"
+        },
+        "Port": "8182",
+        "IamAuthEnabled": true,
+        "ServerlessScalingConfiguration": {
+          "MaxCapacity": {
+            "Ref": "MaxNCU"
+          },
+          "MinCapacity": {
+            "Ref": "MinNCU"
+          }
+        },
+        "StorageEncrypted": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-cluster"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      },
+      "DependsOn": [
+        "NeptuneDBSubnetGroup",
+        "NeptuneDBClusterParameterGroup"
+      ]
+    },
+    "NeptuneDBInstance": {
+      "Type": "AWS::Neptune::DBInstance",
+      "Properties": {
+        "DBInstanceIdentifier": {
+          "Fn::Sub": "${ApplicationId}-db-1"
+        },
+        "DBClusterIdentifier": {
+          "Ref": "NeptuneDBCluster"
+        },
+        "DBInstanceClass": {
+          "Ref": "NeptuneDbInstanceType"
+        },
+        "DBParameterGroupName": {
+          "Ref": "NeptuneDBParameterGroup"
+        },
+        "AutoMinorVersionUpgrade": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-db-1"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      },
+      "DependsOn": [
+        "NeptuneDBCluster",
+        "NeptuneDBParameterGroup"
+      ]
+    },
+    "OpenSearchServerlessCollectionGroup": {
+      "Type": "AWS::OpenSearchServerless::CollectionGroup",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "${ApplicationId}-cg"
+        },
+        "Generation": "NEXTGEN",
+        "StandbyReplicas": "ENABLED",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-cg"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "OpenSearchServerless": {
+      "DependsOn": [
+        "OpenSearchServerlessEncryptionPolicy",
+        "OpenSearchServerlessCollectionGroup"
+      ],
+      "Type": "AWS::OpenSearchServerless::Collection",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "${ApplicationId}-collection"
+        },
+        "CollectionGroupName": {
+          "Fn::Sub": "${ApplicationId}-cg"
+        },
+        "StandbyReplicas": "ENABLED",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-collection"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ],
+        "Type": "VECTORSEARCH"
+      }
+    },
+    "OpenSearchSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupName": {
+          "Fn::Sub": "${ApplicationId}-opensearch-sg"
+        },
+        "VpcId": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
+        },
+        "GroupDescription": "Security group for OpenSearch Serverless VPC endpoint",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 443,
+            "ToPort": 443,
+            "SourceSecurityGroupId": {
+              "Fn::GetAtt": [
+                "GraphRAGClientSecurityGroup",
+                "GroupId"
+              ]
+            },
+            "Description": "HTTPS access from GraphRAG client"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-opensearch-sg"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "OpenSearchServerlessVpcEndpoint": {
+      "Type": "AWS::OpenSearchServerless::VpcEndpoint",
+      "Condition": "EnableVpcAccess",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "${ApplicationId}-vpce"
+        },
+        "VpcId": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "VPC"
+            },
+            {
+              "Ref": "ExistingVpcId"
+            }
+          ]
+        },
+        "SubnetIds": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Fn::If": [
+                "AZ3Present",
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  },
+                  {
+                    "Ref": "Subnet3"
+                  }
+                ],
+                [
+                  {
+                    "Ref": "Subnet1"
+                  },
+                  {
+                    "Ref": "Subnet2"
+                  }
+                ]
+              ]
+            },
+            {
+              "Ref": "ExistingSubnetIds"
+            }
+          ]
+        },
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "OpenSearchSecurityGroup",
+              "GroupId"
+            ]
+          }
+        ]
+      }
+    },
+    "OpenSearchServerlessNetworkPolicy": {
+      "Type": "AWS::OpenSearchServerless::SecurityPolicy",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "${ApplicationId}-network"
+        },
+        "Policy": {
+          "Fn::If": [
+            "EnablePublicAccess",
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "[",
+                  "  {",
+                  "    \"Rules\": [",
+                  "      {",
+                  "        \"Resource\": [",
+                  "          \"collection/",
+                  {
+                    "Fn::Sub": "${ApplicationId}-collection"
+                  },
+                  "\"",
+                  "        ],",
+                  "        \"ResourceType\": \"dashboard\"",
+                  "      },",
+                  "      {",
+                  "        \"Resource\": [",
+                  "          \"collection/",
+                  {
+                    "Fn::Sub": "${ApplicationId}-collection"
+                  },
+                  "\"",
+                  "        ],",
+                  "        \"ResourceType\": \"collection\"",
+                  "      }",
+                  "    ],",
+                  "    \"AllowFromPublic\": true",
+                  "  }",
+                  "]"
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "[",
+                  "  {",
+                  "    \"Rules\": [",
+                  "      {",
+                  "        \"Resource\": [",
+                  "          \"collection/",
+                  {
+                    "Fn::Sub": "${ApplicationId}-collection"
+                  },
+                  "\"",
+                  "        ],",
+                  "        \"ResourceType\": \"dashboard\"",
+                  "      },",
+                  "      {",
+                  "        \"Resource\": [",
+                  "          \"collection/",
+                  {
+                    "Fn::Sub": "${ApplicationId}-collection"
+                  },
+                  "\"",
+                  "        ],",
+                  "        \"ResourceType\": \"collection\"",
+                  "      }",
+                  "    ],",
+                  "    \"SourceVPCEs\": [\"",
+                  {
+                    "Ref": "OpenSearchServerlessVpcEndpoint"
+                  },
+                  "\"]",
+                  "  }",
+                  "]"
+                ]
+              ]
+            }
+          ]
+        },
+        "Type": "network"
+      }
+    },
+    "OpenSearchServerlessEncryptionPolicy": {
+      "Type": "AWS::OpenSearchServerless::SecurityPolicy",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "${ApplicationId}-encryption"
+        },
+        "Policy": {
+          "Fn::Join": [
+            "",
+            [
+              "{",
+              "  \"Rules\": [",
+              "    {",
+              "      \"Resource\": [",
+              "        \"collection/",
+              {
+                "Fn::Sub": "${ApplicationId}-collection"
+              },
+              "\"",
+              "      ],",
+              "      \"ResourceType\": \"collection\"",
+              "    }",
+              "  ],",
+              "  \"AWSOwnedKey\": true",
+              "}"
+            ]
+          ]
+        },
+        "Type": "encryption"
+      }
+    },
+    "OpenSearchServerlessAccessPolicy": {
+      "Type": "AWS::OpenSearchServerless::AccessPolicy",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "${ApplicationId}-access"
+        },
+        "Policy": {
+          "Fn::Join": [
+            "",
+            [
+              "[",
+              "  {",
+              "    \"Rules\": [",
+              "      {",
+              "        \"Resource\": [",
+              "          \"collection/",
+              {
+                "Fn::Sub": "${ApplicationId}-collection"
+              },
+              "\"",
+              "        ],",
+              "        \"Permission\": [",
+              "          \"aoss:CreateCollectionItems\",",
+              "          \"aoss:DeleteCollectionItems\",",
+              "          \"aoss:UpdateCollectionItems\",",
+              "          \"aoss:DescribeCollectionItems\"",
+              "        ],",
+              "        \"ResourceType\": \"collection\"",
+              "      },",
+              "      {",
+              "        \"Resource\": [",
+              "          \"index/",
+              {
+                "Fn::Sub": "${ApplicationId}-collection"
+              },
+              "/*\"",
+              "        ],",
+              "        \"Permission\": [",
+              "          \"aoss:CreateIndex\",",
+              "          \"aoss:DeleteIndex\",",
+              "          \"aoss:UpdateIndex\",",
+              "          \"aoss:DescribeIndex\",",
+              "          \"aoss:ReadDocument\",",
+              "          \"aoss:WriteDocument\"",
+              "        ],",
+              "        \"ResourceType\": \"index\"",
+              "      }",
+              "    ],",
+              "    \"Principal\": [\"",
+              {
+                "Fn::GetAtt": [
+                  "GraphRAGClientRole",
+                  "Arn"
+                ]
+              },
+              "\"]",
+              "  }",
+              "]"
+            ]
+          ]
+        },
+        "Type": "data"
+      }
+    },
+    "NeptuneNotebookInstance": {
+      "Type": "AWS::SageMaker::NotebookInstance",
+      "Properties": {
+        "InstanceType": {
+          "Ref": "NotebookInstanceType"
+        },
+        "PlatformIdentifier": "notebook-al2023-v1",
+        "NotebookInstanceName": {
+          "Fn::Sub": "aws-neptune-${ApplicationId}"
+        },
+        "SubnetId": {
+          "Fn::If": [
+            "CreateVPC",
+            {
+              "Ref": "Subnet4"
+            },
+            {
+              "Fn::Select": [
+                0,
+                {
+                  "Ref": "ExistingSubnetIds"
+                }
+              ]
+            }
+          ]
+        },
+        "SecurityGroupIds": [
+          {
+            "Ref": "GraphRAGClientSecurityGroup"
+          }
+        ],
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "GraphRAGClientRole",
+            "Arn"
+          ]
+        },
+        "LifecycleConfigName": {
+          "Fn::GetAtt": [
+            "NeptuneNotebookInstanceLifecycleConfig",
+            "NotebookInstanceLifecycleConfigName"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "NeptuneNotebookInstanceLifecycleConfig": {
+      "Type": "AWS::SageMaker::NotebookInstanceLifecycleConfig",
+      "Properties": {
+        "OnStart": [
+          {
+            "Content": {
+              "Fn::Base64": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "#!/bin/bash\n\n",
+                    "sudo -u ec2-user -i <<'EOF'\n",
+                    "\n",
+                    "sudo pip install packaging==24.2\n",
+                    "echo \"export STACK_ID=",
+                    {
+                      "Ref": "AWS::StackId"
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export EXTRACTION_MODEL=",
+                    {
+                      "Ref": "ModelId"
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export EMBEDDINGS_MODEL=cohere.embed-english-v3\" >> ~/.bashrc\n",
+                    "echo \"export EMBEDDINGS_DIMENSIONS=1024\" >> ~/.bashrc\n",
+                    "echo \"export RESPONSE_MODEL=",
+                    {
+                      "Ref": "ModelId"
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export EVALUATION_MODEL=",
+                    {
+                      "Ref": "ModelId"
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_NOTEBOOK_AUTH_MODE=IAM\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_NOTEBOOK_SSL=True\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_NOTEBOOK_IAM_PROVIDER=ROLE\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_NOTEBOOK_PORT=",
+                    {
+                      "Fn::GetAtt": [
+                        "NeptuneDBCluster",
+                        "Port"
+                      ]
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_STORE=",
+                    {
+                      "Fn::Sub": [
+                        "neptune-db://${graphid}",
+                        {
+                          "graphid": {
+                            "Fn::GetAtt": [
+                              "NeptuneDBCluster",
+                              "Endpoint"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export VECTOR_STORE=",
+                    {
+                      "Fn::Sub": [
+                        "aoss://${endpoint}",
+                        {
+                          "endpoint": {
+                            "Fn::GetAtt": [
+                              "OpenSearchServerless",
+                              "CollectionEndpoint"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_NOTEBOOK_SERVICE=neptune-db\" >> ~/.bashrc\n",
+                    "echo \"export GRAPH_NOTEBOOK_HOST=",
+                    {
+                      "Fn::GetAtt": [
+                        "NeptuneDBCluster",
+                        "Endpoint"
+                      ]
+                    },
+                    "\" >> ~/.bashrc\n",
+                    "echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> ~/.bashrc\n\n",
+                    "aws s3 cp s3://",
+                    {
+                      "Fn::If": [
+                        "IsIadRegion",
+                        "aws-neptune-notebook",
+                        {
+                          "Fn::Sub": "aws-neptune-notebook-${AWS::Region}"
+                        }
+                      ]
+                    },
+                    "/graph_notebook.tar.gz /tmp/graph_notebook.tar.gz\n",
+                    "rm -rf /tmp/graph_notebook\n",
+                    "tar -zxvf /tmp/graph_notebook.tar.gz -C /tmp\n",
+                    "chmod +x /tmp/graph_notebook/install_jl4x.sh\n",
+                    "/tmp/graph_notebook/install_jl4x.sh\n",
+                    "\n",
+                    "cd /home/ec2-user/SageMaker\n",
+                    "if [ ! -d graphrag-toolkit ]; then\n",
+                    "  mkdir graphrag-toolkit\n",
+                    "  chmod -R 777 graphrag-toolkit\n",
+                    {
+                      "Fn::If": [
+                        "ExampleNotebooksURLIsNotBlank",
+                        {
+                          "Fn::If": [
+                            "IsS3ExampleNotebooksURL",
+                            {
+                              "Fn::Join": [
+                                "",
+                                [
+                                  "  aws s3 cp \"",
+                                  {
+                                    "Ref": "ExampleNotebooksURL"
+                                  },
+                                  "\" lexical-graph-examples.zip\n",
+                                  "  unzip lexical-graph-examples.zip -d graphrag-toolkit\n",
+                                  "  rm -rf lexical-graph-examples.zip\n"
+                                ]
+                              ]
+                            },
+                            {
+                              "Fn::Join": [
+                                "",
+                                [
+                                  "  curl -L \"",
+                                  {
+                                    "Ref": "ExampleNotebooksURL"
+                                  },
+                                  "\" -o \"lexical-graph-examples.zip\"\n",
+                                  "  unzip lexical-graph-examples.zip -d graphrag-toolkit\n",
+                                  "  rm -rf lexical-graph-examples.zip\n"
+                                ]
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Ref": "AWS::NoValue"
+                        }
+                      ]
+                    },
+                    "  cd graphrag-toolkit\n",
+                    "  echo \"export STACK_ID=",
+                    {
+                      "Ref": "AWS::StackId"
+                    },
+                    "\" >> .env\n",
+                    "  echo \"export GRAPH_STORE=",
+                    {
+                      "Fn::Sub": [
+                        "neptune-db://${graphid}",
+                        {
+                          "graphid": {
+                            "Fn::GetAtt": [
+                              "NeptuneDBCluster",
+                              "Endpoint"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "\" >> .env\n",
+                    "  echo \"export VECTOR_STORE=",
+                    {
+                      "Fn::Sub": [
+                        "aoss://${endpoint}",
+                        {
+                          "endpoint": {
+                            "Fn::GetAtt": [
+                              "OpenSearchServerless",
+                              "CollectionEndpoint"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "\" >> .env\n",
+                    "  echo \"export EXTRACTION_MODEL=",
+                    {
+                      "Ref": "ModelId"
+                    },
+                    "\" >> .env\n",
+                    "  echo \"export EMBEDDINGS_MODEL=cohere.embed-english-v3\" >> .env\n",
+                    "  echo \"export EMBEDDINGS_DIMENSIONS=1024\" >> .env\n",
+                    "  echo \"export RESPONSE_MODEL=",
+                    {
+                      "Ref": "ModelId"
+                    },
+                    "\" >> .env\n",
+                    "  echo \"export EVALUATION_MODEL=",
+                    {
+                      "Ref": "ModelId"
+                    },
+                    "\" >> .env\n",
+                    "  if [ -f \"./run_test_suite.sh\" ]\n",
+                    "  then\n",
+                    "    echo \"Running test suite\"\n",
+                    "    screen -m -d sh run_test_suite.sh\n",
+                    "  else\n",
+                    "    echo \"No test suite\"\n",
+                    "  fi\n",
+                    "fi\n",
+                    "EOF"
+                  ]
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ElasticIP1": {
+      "Type": "AWS::EC2::EIP",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "Domain": "VPC"
+      }
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "CidrBlock": "172.30.0.0/16",
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-vpc"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          }
+        ]
+      }
+    },
+    "PublicRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "DependsOn": [
+        "VPC"
+      ]
+    },
+    "PrivateRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "DependsOn": [
+        "VPC"
+      ]
+    },
+    "IGWAtt": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "InternetGatewayId": {
+          "Ref": "IGW"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "DependsOn": [
+        "VPC",
+        "IGW"
+      ]
+    },
+    "IGW": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-igw"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
+            }
+          }
+        ]
+      }
+    },
+    "NATGW": {
+      "Type": "AWS::EC2::NatGateway",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "ElasticIP1",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "Subnet4"
+        }
+      }
+    },
+    "PublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "IGW"
+        },
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        }
+      },
+      "DependsOn": [
+        "IGWAtt"
+      ]
+    },
+    "PrivateRoute": {
+      "Type": "AWS::EC2::Route",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "NATGW"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      },
+      "DependsOn": [
+        "IGWAtt"
+      ]
+    },
+    "Subnet1": {
+      "Type": "AWS::EC2::Subnet",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "CidrBlock": "172.30.1.0/24",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": ""
+            }
+          ]
+        }
+      }
+    },
+    "Subnet2": {
+      "Type": "AWS::EC2::Subnet",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "CidrBlock": "172.30.2.0/24",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            1,
+            {
+              "Fn::GetAZs": ""
+            }
+          ]
+        }
+      }
+    },
+    "Subnet3": {
+      "Type": "AWS::EC2::Subnet",
+      "Condition": "AZ3PresentAndCreateVPC",
+      "Properties": {
+        "CidrBlock": "172.30.3.0/24",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            2,
+            {
+              "Fn::GetAZs": ""
+            }
+          ]
+        }
+      }
+    },
+    "Subnet4": {
+      "Type": "AWS::EC2::Subnet",
+      "Condition": "CreateVPC",
+      "Properties": {
+        "CidrBlock": "172.30.4.0/24",
+        "MapPublicIpOnLaunch": "true",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": ""
+            }
+          ]
+        }
+      }
+    },
+    "SubnetRTAssociation1": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "CreateVPC",
+      "DependsOn": [
+        "Subnet1",
+        "PrivateRouteTable"
+      ],
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "Subnet1"
+        }
+      }
+    },
+    "SubnetRTAssociation2": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "CreateVPC",
+      "DependsOn": [
+        "Subnet2",
+        "PrivateRouteTable"
+      ],
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "Subnet2"
+        }
+      }
+    },
+    "SubnetRTAssociation3": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "AZ3PresentAndCreateVPC",
+      "DependsOn": [
+        "Subnet3",
+        "PrivateRouteTable"
+      ],
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "Subnet3"
+        }
+      }
+    },
+    "SubnetRTAssociation4": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Condition": "CreateVPC",
+      "DependsOn": [
+        "Subnet4",
+        "PublicRouteTable"
+      ],
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        },
+        "SubnetId": {
+          "Ref": "Subnet4"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "NeptuneClusterId": {
+      "Description": "Neptune cluster id",
+      "Value": {
+        "Ref": "NeptuneDBCluster"
+      }
+    },
+    "NeptuneClusterEndpoint": {
+      "Description": "Neptune cluster endpoint",
+      "Value": {
+        "Fn::GetAtt": [
+          "NeptuneDBCluster",
+          "Endpoint"
+        ]
+      }
+    },
+    "GraphRAGClientSecurityGroup": {
+      "Description": "GraphRAG client security group",
+      "Value": {
+        "Ref": "GraphRAGClientSecurityGroup"
+      }
+    },
+    "OpenSearchCollectionEndpoint": {
+      "Description": "OpenSearch Serverless collection endpoint",
+      "Value": {
+        "Fn::GetAtt": [
+          "OpenSearchServerless",
+          "CollectionEndpoint"
+        ]
+      }
+    },
+    "NeptuneSagemakerNotebook": {
+      "Description": "SageMaker notebook URL",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Fn::Select": [
+                1,
+                {
+                  "Fn::Split": [
+                    "/",
+                    {
+                      "Ref": "NeptuneNotebookInstance"
+                    }
+                  ]
+                }
+              ]
+            },
+            ".notebook.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".sagemaker.aws/nbclassic/tree"
+          ]
+        ]
+      }
+    },
+    "VPC": {
+      "Description": "VPC",
+      "Value": {
+        "Fn::If": [
+          "CreateVPC",
+          {
+            "Ref": "VPC"
+          },
+          {
+            "Ref": "ExistingVpcId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
+++ b/integration-tests/cloudformation-templates/graphrag-toolkit-tests.json
@@ -20,6 +20,7 @@
       "Default": "neptune-db-aoss",
       "AllowedValues": [
         "neptune-db-aoss",
+        "neptune-db-aoss-nextgen",
         "neptune-db-postgresql",
         "neptune-db-s3vectors",
         "neptune-graph",
@@ -94,6 +95,15 @@
     "EnvTypeMap": {
       "neptune-db-aoss": {
         "TemplateName": "graphrag-toolkit-neptune-db-opensearch-serverless.json",
+        "IncludeEngineVersion": "True",
+        "IncludeSSHCIDR": "False",
+        "IncludeNeptuneInstanceType": "True",
+        "IncludeAllowPublicAccess": "True",
+        "IncludeDbPassword": "False",
+        "IncludeExistingVpc": "True"
+      },
+      "neptune-db-aoss-nextgen": {
+        "TemplateName": "graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json",
         "IncludeEngineVersion": "True",
         "IncludeSSHCIDR": "False",
         "IncludeNeptuneInstanceType": "True",

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/__init__.py
@@ -39,7 +39,7 @@ except RuntimeError as e:
     pass  
 
 from .tenant_id import TenantId, DEFAULT_TENANT_ID, DEFAULT_TENANT_NAME, TenantIdType, to_tenant_id
-from .config import GraphRAGConfig as GraphRAGConfig, LLMType, EmbeddingType
+from .config import GraphRAGConfig as GraphRAGConfig, LLMType, EmbeddingType, OpenSearchServerlessGeneration
 from .errors import ModelError, BatchJobError, IndexError, GraphQueryError, ConfigurationError
 from .logging import set_logging_config, set_advanced_logging_config
 from .lexical_graph_query_engine import LexicalGraphQueryEngine

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -50,7 +50,7 @@ DEFAULT_INCLUDE_CLASSIFICATION_IN_ENTITY_ID = True
 DEFAULT_ENABLE_CACHE = False
 DEFAULT_METADATA_DATETIME_SUFFIXES = ['_date', '_datetime']
 DEFAULT_OPENSEARCH_ENGINE = 'nmslib'
-DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN = False
+DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN = None
 DEFAULT_ENABLE_VERSIONING = False
 DEFAULT_CHUNK_EXTERNAL_PROPERTIES = None
 DEFAULT_LOCAL_OUTPUT_DIR = 'output'  # Local staging directory for batch files (use /tmp for EKS)
@@ -1176,13 +1176,16 @@ class _GraphRAGConfig:
         self._opensearch_engine = opensearch_engine
 
     @property
-    def opensearch_serverless_nextgen(self) -> bool:
+    def opensearch_serverless_nextgen(self) -> Optional[bool]:
+        """None means unset: index_exists() auto-detects NextGen vs Classic by trying
+        Classic first and retrying with NextGen only if the collection rejects it. Set to
+        True/False (or the env var) to force one mapping and skip auto-detection."""
         if self._opensearch_serverless_nextgen is None:
             self._opensearch_serverless_nextgen = string_to_bool(os.environ.get('OPENSEARCH_SERVERLESS_NEXTGEN'), DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN)
         return self._opensearch_serverless_nextgen
 
     @opensearch_serverless_nextgen.setter
-    def opensearch_serverless_nextgen(self, opensearch_serverless_nextgen: bool) -> None:
+    def opensearch_serverless_nextgen(self, opensearch_serverless_nextgen: Optional[bool]) -> None:
         self._opensearch_serverless_nextgen = opensearch_serverless_nextgen
 
     @property

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -14,6 +14,7 @@ from botocore.exceptions import SSOTokenLoadError
 
 import threading
 import logging
+from enum import Enum
 from dataclasses import dataclass, field
 from typing import Optional, Union, Dict, Set, List
 from boto3 import Session as Boto3Session
@@ -50,7 +51,7 @@ DEFAULT_INCLUDE_CLASSIFICATION_IN_ENTITY_ID = True
 DEFAULT_ENABLE_CACHE = False
 DEFAULT_METADATA_DATETIME_SUFFIXES = ['_date', '_datetime']
 DEFAULT_OPENSEARCH_ENGINE = 'nmslib'
-DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN = None
+DEFAULT_OPENSEARCH_SERVERLESS_GENERATION = None
 DEFAULT_ENABLE_VERSIONING = False
 DEFAULT_CHUNK_EXTERNAL_PROPERTIES = None
 DEFAULT_LOCAL_OUTPUT_DIR = 'output'  # Local staging directory for batch files (use /tmp for EKS)
@@ -96,6 +97,33 @@ def string_to_bool(s, default_value: bool):
         or None.
     """
     return s.lower() in ['true'] if s else default_value
+
+
+class OpenSearchServerlessGeneration(str, Enum):
+    """AOSS collection generation. Values match the ``generation`` field returned by the
+    OpenSearch Serverless ``BatchGetCollectionGroup`` API, so a member can be compared
+    against that field directly."""
+    CLASSIC = 'CLASSIC'
+    NEXTGEN = 'NEXTGEN'
+
+    @classmethod
+    def parse(cls, value):
+        """Coerce a value to a generation. ``None`` or ``''`` means unset (auto-detect).
+        Accepts an enum member or a case-insensitive string (``'classic'``/``'nextgen'``).
+        Raises ValueError for anything else."""
+        if value is None or value == '':
+            return None
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value).strip().upper())
+        except ValueError as e:
+            valid = ', '.join(m.value for m in cls)
+            raise ValueError(
+                f"Invalid OpenSearch Serverless generation '{value}'. Expected one of {valid} "
+                f"(case-insensitive), or unset for auto-detection."
+            ) from e
+
 
 class ResilientClient:
     """
@@ -292,7 +320,7 @@ class _GraphRAGConfig:
     _enable_cache: Optional[bool] = None
     _metadata_datetime_suffixes: Optional[List[str]] = None
     _opensearch_engine: Optional[str] = None
-    _opensearch_serverless_nextgen: Optional[bool] = None
+    _opensearch_serverless_generation: Optional['OpenSearchServerlessGeneration'] = None
     _opensearch_serverless_nextgen_compression: Optional[str] = None
     _enable_versioning = None
     _chunk_external_properties: Optional[Dict[str, str]] = None
@@ -1176,17 +1204,20 @@ class _GraphRAGConfig:
         self._opensearch_engine = opensearch_engine
 
     @property
-    def opensearch_serverless_nextgen(self) -> Optional[bool]:
-        """None means unset: index_exists() auto-detects NextGen vs Classic by trying
-        Classic first and retrying with NextGen only if the collection rejects it. Set to
-        True/False (or the env var) to force one mapping and skip auto-detection."""
-        if self._opensearch_serverless_nextgen is None:
-            self._opensearch_serverless_nextgen = string_to_bool(os.environ.get('OPENSEARCH_SERVERLESS_NEXTGEN'), DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN)
-        return self._opensearch_serverless_nextgen
+    def opensearch_serverless_generation(self) -> Optional['OpenSearchServerlessGeneration']:
+        """Unset (None) auto-detects Classic vs NextGen: index_exists() tries the Classic
+        mapping first and retries with NextGen only if the collection rejects it. Set to
+        OpenSearchServerlessGeneration.CLASSIC or .NEXTGEN (or the OPENSEARCH_SERVERLESS_GENERATION
+        env var, 'classic'/'nextgen') to force one mapping and skip auto-detection."""
+        if self._opensearch_serverless_generation is None:
+            self._opensearch_serverless_generation = OpenSearchServerlessGeneration.parse(
+                os.environ.get('OPENSEARCH_SERVERLESS_GENERATION', DEFAULT_OPENSEARCH_SERVERLESS_GENERATION)
+            )
+        return self._opensearch_serverless_generation
 
-    @opensearch_serverless_nextgen.setter
-    def opensearch_serverless_nextgen(self, opensearch_serverless_nextgen: Optional[bool]) -> None:
-        self._opensearch_serverless_nextgen = opensearch_serverless_nextgen
+    @opensearch_serverless_generation.setter
+    def opensearch_serverless_generation(self, opensearch_serverless_generation) -> None:
+        self._opensearch_serverless_generation = OpenSearchServerlessGeneration.parse(opensearch_serverless_generation)
 
     @property
     def opensearch_serverless_nextgen_compression(self) -> Optional[str]:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -50,6 +50,7 @@ DEFAULT_INCLUDE_CLASSIFICATION_IN_ENTITY_ID = True
 DEFAULT_ENABLE_CACHE = False
 DEFAULT_METADATA_DATETIME_SUFFIXES = ['_date', '_datetime']
 DEFAULT_OPENSEARCH_ENGINE = 'nmslib'
+DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN = False
 DEFAULT_ENABLE_VERSIONING = False
 DEFAULT_CHUNK_EXTERNAL_PROPERTIES = None
 DEFAULT_LOCAL_OUTPUT_DIR = 'output'  # Local staging directory for batch files (use /tmp for EKS)
@@ -291,6 +292,8 @@ class _GraphRAGConfig:
     _enable_cache: Optional[bool] = None
     _metadata_datetime_suffixes: Optional[List[str]] = None
     _opensearch_engine: Optional[str] = None
+    _opensearch_serverless_nextgen: Optional[bool] = None
+    _opensearch_serverless_nextgen_compression: Optional[str] = None
     _enable_versioning = None
     _chunk_external_properties: Optional[Dict[str, str]] = None
     _local_output_dir: Optional[str] = None
@@ -1171,6 +1174,26 @@ class _GraphRAGConfig:
     @opensearch_engine.setter
     def opensearch_engine(self, opensearch_engine: str) -> None:
         self._opensearch_engine = opensearch_engine
+
+    @property
+    def opensearch_serverless_nextgen(self) -> bool:
+        if self._opensearch_serverless_nextgen is None:
+            self._opensearch_serverless_nextgen = string_to_bool(os.environ.get('OPENSEARCH_SERVERLESS_NEXTGEN'), DEFAULT_OPENSEARCH_SERVERLESS_NEXTGEN)
+        return self._opensearch_serverless_nextgen
+
+    @opensearch_serverless_nextgen.setter
+    def opensearch_serverless_nextgen(self, opensearch_serverless_nextgen: bool) -> None:
+        self._opensearch_serverless_nextgen = opensearch_serverless_nextgen
+
+    @property
+    def opensearch_serverless_nextgen_compression(self) -> Optional[str]:
+        if self._opensearch_serverless_nextgen_compression is None:
+            self._opensearch_serverless_nextgen_compression = os.environ.get('OPENSEARCH_SERVERLESS_NEXTGEN_COMPRESSION')
+        return self._opensearch_serverless_nextgen_compression
+
+    @opensearch_serverless_nextgen_compression.setter
+    def opensearch_serverless_nextgen_compression(self, opensearch_serverless_nextgen_compression: Optional[str]) -> None:
+        self._opensearch_serverless_nextgen_compression = opensearch_serverless_nextgen_compression
 
     @property
     def enable_versioning(self) -> bool:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
@@ -253,12 +253,12 @@ def _is_nextgen_incompatible_field_error(e:'RequestError') -> bool:
     return match is not None and match.group(1) in _NEXTGEN_UNSUPPORTED_FIELDS
 
 
-def _build_index_mapping(dimensions) -> Dict:
-    """Builds the knn_vector index mapping for the current GraphRAGConfig engine settings:
-    NextGen (opensearch_serverless_nextgen), faiss, or nmslib (the default)."""
+def _build_index_mapping(dimensions, nextgen: bool) -> Dict:
+    """Builds the knn_vector index mapping: NextGen if nextgen is True, otherwise Classic
+    (faiss, or nmslib as the default)."""
     embedding_field = 'embedding'
 
-    if GraphRAGConfig.opensearch_serverless_nextgen:
+    if nextgen:
 
         embedding_mapping = {
             "type": "knn_vector",
@@ -323,28 +323,48 @@ def _build_index_mapping(dimensions) -> Dict:
     }
 
 
-def _handle_index_create_request_error(e:'RequestError', index_name, endpoint) -> None:
+def _handle_index_create_request_error(e:'RequestError', index_name, endpoint, nextgen: bool) -> None:
     """Classifies a RequestError from client.indices.create(). Returns normally (logged,
-    non-fatal) unless the collection rejected a Classic-only field, in which case it
-    raises an actionable ValueError."""
+    non-fatal) unless the collection rejected a Classic-only field with auto-detection
+    unable to help (nextgen was forced False), in which case it raises an actionable
+    ValueError."""
     if e.error == 'resource_already_exists_exception':
         logger.debug(f'OpenSearch index already exists [index_name: {index_name}, endpoint: {endpoint}]')
         return
 
-    # Guarded on the flag since the NextGen mapping branch never sends 'engine'/'mode' --
-    # a genuinely different illegal_argument_exception while nextgen=True shouldn't be
-    # misreported as a config hint.
-    if _is_nextgen_incompatible_field_error(e) and not GraphRAGConfig.opensearch_serverless_nextgen:
+    if _is_nextgen_incompatible_field_error(e) and not nextgen:
         raise ValueError(
             f"OpenSearch index creation failed [index_name: {index_name}, endpoint: {endpoint}] because "
             f"the target collection rejected a Classic-only field ({_request_error_reason(e)}). This "
             f"usually means the collection is an AOSS NextGen collection, which does not support the "
-            f"'engine' or 'mode' knn_vector parameters. Set GraphRAGConfig.opensearch_serverless_nextgen "
-            f"= True (or the OPENSEARCH_SERVERLESS_NEXTGEN environment variable) to use NextGen-compatible "
-            f"index mappings."
+            f"'engine' or 'mode' knn_vector parameters. GraphRAGConfig.opensearch_serverless_nextgen is "
+            f"explicitly set to False, which forces the Classic mapping and skips auto-detection -- unset "
+            f"it (or the OPENSEARCH_SERVERLESS_NEXTGEN env var) to auto-detect NextGen collections, or set "
+            f"it to True to force NextGen-compatible index mappings."
         ) from e
 
     logger.exception('Error creating an OpenSearch index')
+
+
+def _create_or_check_index(client, index_name, idx_conf, writeable, endpoint) -> bool:
+    exists = client.indices.exists(index=index_name)
+    if not exists and writeable:
+        logger.debug(f'Creating OpenSearch index [index_name: {index_name}, endpoint: {endpoint}]')
+        client.indices.create(index=index_name, body=idx_conf)
+        exists = True
+    return exists
+
+
+def _try_create_index(client, index_name, dimensions, writeable, endpoint, nextgen: bool, allow_retry: bool) -> bool:
+    idx_conf = _build_index_mapping(dimensions, nextgen)
+    try:
+        return _create_or_check_index(client, index_name, idx_conf, writeable, endpoint)
+    except RequestError as e:
+        if allow_retry and _is_nextgen_incompatible_field_error(e):
+            logger.debug(f'Classic mapping rejected by a NextGen collection, retrying with the NextGen mapping [index_name: {index_name}, endpoint: {endpoint}]')
+            return _try_create_index(client, index_name, dimensions, writeable, endpoint, nextgen=True, allow_retry=False)
+        _handle_index_create_request_error(e, index_name, endpoint, nextgen)
+        return False
 
 
 def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
@@ -356,6 +376,12 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
     the `writeable` flag is True, it will create an index using the provided
     dimensions and a predefined method for handling knn_vector elements.
 
+    Whether the index is created with a NextGen or Classic knn_vector mapping is
+    controlled by GraphRAGConfig.opensearch_serverless_nextgen. When that's unset
+    (None), this auto-detects: it tries the Classic mapping first and, if the
+    collection rejects it as NextGen-incompatible, retries once with the NextGen
+    mapping. Set the flag to True or False to force one mapping and skip detection.
+
     Args:
         endpoint: The OpenSearch endpoint to connect to.
         index_name: The name of the index to check for existence.
@@ -366,27 +392,21 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
         bool: True if the index exists (or is created successfully), False otherwise.
 
     Raises:
-        ValueError: If index creation fails because a Classic-only knn_vector field
-            (engine/mode) was sent to an AOSS NextGen collection. See
-            GraphRAGConfig.opensearch_serverless_nextgen.
+        ValueError: If a Classic-only knn_vector field (engine/mode) was rejected by an
+            AOSS NextGen collection and GraphRAGConfig.opensearch_serverless_nextgen was
+            explicitly set to False, so auto-detection didn't get a chance to retry.
     """
     client = create_os_client(endpoint, pool_maxsize=1)
-    idx_conf = _build_index_mapping(dimensions)
-
-    index_exists = False
+    nextgen_override = GraphRAGConfig.opensearch_serverless_nextgen
 
     try:
-        index_exists = client.indices.exists(index=index_name)
-        if not index_exists and writeable:
-            logger.debug(f'Creating OpenSearch index [index_name: {index_name}, endpoint: {endpoint}]')
-            client.indices.create(index=index_name, body=idx_conf)
-            index_exists = True
-    except RequestError as e:
-        _handle_index_create_request_error(e, index_name, endpoint)
+        return _try_create_index(
+            client, index_name, dimensions, writeable, endpoint,
+            nextgen=bool(nextgen_override),
+            allow_retry=(nextgen_override is None),
+        )
     finally:
         client.close()
-
-    return index_exists
         
     
 def create_opensearch_vector_client(endpoint, index_name, dimensions, embed_model, client_kwargs=None):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import re
 import time
 import uuid
 from typing import List, Any, Optional, Iterable, Dict
@@ -229,6 +230,10 @@ def index_is_available(client, index_name):
 
 _NEXTGEN_UNSUPPORTED_FIELDS = ('engine', 'mode')
 
+# A bare substring check on the field name would also match it appearing incidentally
+# elsewhere in a longer message, so match the exact rejection phrasing instead.
+_UNSUPPORTED_FIELD_PATTERN = re.compile(r"Field parameter '(\w+)' is not supported")
+
 
 def _request_error_reason(e:'RequestError') -> str:
     info = e.info
@@ -244,7 +249,102 @@ def _is_nextgen_incompatible_field_error(e:'RequestError') -> bool:
     if e.error != 'illegal_argument_exception':
         return False
     reason = _request_error_reason(e)
-    return any(f"'{field}'" in reason for field in _NEXTGEN_UNSUPPORTED_FIELDS)
+    match = _UNSUPPORTED_FIELD_PATTERN.search(reason)
+    return match is not None and match.group(1) in _NEXTGEN_UNSUPPORTED_FIELDS
+
+
+def _build_index_mapping(dimensions) -> Dict:
+    """Builds the knn_vector index mapping for the current GraphRAGConfig engine settings:
+    NextGen (opensearch_serverless_nextgen), faiss, or nmslib (the default)."""
+    embedding_field = 'embedding'
+
+    if GraphRAGConfig.opensearch_serverless_nextgen:
+
+        embedding_mapping = {
+            "type": "knn_vector",
+            "dimension": dimensions,
+            "space_type": "l2",
+        }
+
+        if GraphRAGConfig.opensearch_serverless_nextgen_compression:
+            embedding_mapping["compression_level"] = GraphRAGConfig.opensearch_serverless_nextgen_compression
+
+        return {
+            "settings": {"index": {"knn": True}},
+            "mappings": {
+                "date_detection": False,
+                "properties": {
+                    embedding_field: embedding_mapping,
+                }
+            }
+        }
+
+    if GraphRAGConfig.opensearch_engine.lower() == 'faiss':
+
+        method = {
+            "name": "hnsw",
+            "space_type": "l2",
+            "engine": "faiss"
+        }
+
+        return {
+            "settings": {"index": {"knn": True}},
+            "mappings": {
+                "date_detection": False,
+                "properties": {
+                    embedding_field: {
+                        "type": "knn_vector",
+                        "dimension": dimensions,
+                        "method": method,
+                    },
+                }
+            }
+        }
+
+    method = {
+        "name": "hnsw",
+        "space_type": "l2",
+        "engine": "nmslib",
+        "parameters": {"ef_construction": 256, "m": 48},
+    }
+
+    return {
+        "settings": {"index": {"knn": True, "knn.algo_param.ef_search": 100}},
+        "mappings": {
+            "date_detection": False,
+            "properties": {
+                embedding_field: {
+                    "type": "knn_vector",
+                    "dimension": dimensions,
+                    "method": method,
+                },
+            }
+        }
+    }
+
+
+def _handle_index_create_request_error(e:'RequestError', index_name, endpoint) -> None:
+    """Classifies a RequestError from client.indices.create(). Returns normally (logged,
+    non-fatal) unless the collection rejected a Classic-only field, in which case it
+    raises an actionable ValueError."""
+    if e.error == 'resource_already_exists_exception':
+        logger.debug(f'OpenSearch index already exists [index_name: {index_name}, endpoint: {endpoint}]')
+        return
+
+    # Guarded on the flag since the NextGen mapping branch never sends 'engine'/'mode' --
+    # a genuinely different illegal_argument_exception while nextgen=True shouldn't be
+    # misreported as a config hint.
+    if _is_nextgen_incompatible_field_error(e) and not GraphRAGConfig.opensearch_serverless_nextgen:
+        raise ValueError(
+            f"OpenSearch index creation failed [index_name: {index_name}, endpoint: {endpoint}] because "
+            f"the target collection rejected a Classic-only field ({_request_error_reason(e)}). This "
+            f"usually means the collection is an AOSS NextGen collection, which does not support the "
+            f"'engine' or 'mode' knn_vector parameters. Set GraphRAGConfig.opensearch_serverless_nextgen "
+            f"= True (or the OPENSEARCH_SERVERLESS_NEXTGEN environment variable) to use NextGen-compatible "
+            f"index mappings."
+        ) from e
+
+    logger.exception('Error creating an OpenSearch index')
 
 
 def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
@@ -271,74 +371,7 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
             GraphRAGConfig.opensearch_serverless_nextgen.
     """
     client = create_os_client(endpoint, pool_maxsize=1)
-
-    embedding_field = 'embedding'
-
-    if GraphRAGConfig.opensearch_serverless_nextgen:
-
-        embedding_mapping = {
-            "type": "knn_vector",
-            "dimension": dimensions,
-            "space_type": "l2",
-        }
-
-        if GraphRAGConfig.opensearch_serverless_nextgen_compression:
-            embedding_mapping["compression_level"] = GraphRAGConfig.opensearch_serverless_nextgen_compression
-
-        idx_conf = {
-            "settings": {"index": {"knn": True}},
-            "mappings": {
-                "date_detection": False,
-                "properties": {
-                    embedding_field: embedding_mapping,
-                }
-            }
-        }
-
-    elif GraphRAGConfig.opensearch_engine.lower() == 'faiss':
-
-        method = {
-            "name": "hnsw",
-            "space_type": "l2",
-            "engine": "faiss"
-        }
-
-        idx_conf = {
-            "settings": {"index": {"knn": True}},
-            "mappings": {
-                "date_detection": False,
-                "properties": {
-                    embedding_field: {
-                        "type": "knn_vector",
-                        "dimension": dimensions,
-                        "method": method,
-                    },
-                }
-            }
-        }
-
-    else:
-
-        method = {
-            "name": "hnsw",
-            "space_type": "l2",
-            "engine": "nmslib",
-            "parameters": {"ef_construction": 256, "m": 48},
-        }
-
-        idx_conf = {
-            "settings": {"index": {"knn": True, "knn.algo_param.ef_search": 100}},
-            "mappings": {
-                "date_detection": False,
-                "properties": {
-                    embedding_field: {
-                        "type": "knn_vector",
-                        "dimension": dimensions,
-                        "method": method,
-                    },
-                }
-            }
-        }
+    idx_conf = _build_index_mapping(dimensions)
 
     index_exists = False
 
@@ -349,22 +382,7 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
             client.indices.create(index=index_name, body=idx_conf)
             index_exists = True
     except RequestError as e:
-        if e.error == 'resource_already_exists_exception':
-            logger.debug(f'OpenSearch index already exists [index_name: {index_name}, endpoint: {endpoint}]')
-        elif _is_nextgen_incompatible_field_error(e) and not GraphRAGConfig.opensearch_serverless_nextgen:
-            # The NextGen mapping branch above never sends 'engine'/'mode', so this can only
-            # happen with the Classic mapping. Guarded on the flag so a genuinely different
-            # illegal_argument_exception while nextgen=True isn't misreported as a config hint.
-            raise ValueError(
-                f"OpenSearch index creation failed [index_name: {index_name}, endpoint: {endpoint}] because "
-                f"the target collection rejected a Classic-only field ({_request_error_reason(e)}). This "
-                f"usually means the collection is an AOSS NextGen collection, which does not support the "
-                f"'engine' or 'mode' knn_vector parameters. Set GraphRAGConfig.opensearch_serverless_nextgen "
-                f"= True (or the OPENSEARCH_SERVERLESS_NEXTGEN environment variable) to use NextGen-compatible "
-                f"index mappings."
-            ) from e
-        else:
-            logger.exception('Error creating an OpenSearch index')
+        _handle_index_create_request_error(e, index_name, endpoint)
     finally:
         client.close()
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
@@ -18,7 +18,7 @@ from llama_index.core.vector_stores.types import MetadataFilters
 
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig, is_datetime_key, format_datetime
 from graphrag_toolkit.lexical_graph.versioning import  VALID_FROM, VALID_TO, TIMESTAMP_LOWER_BOUND, TIMESTAMP_UPPER_BOUND
-from graphrag_toolkit.lexical_graph.config import GraphRAGConfig, EmbeddingType
+from graphrag_toolkit.lexical_graph.config import GraphRAGConfig, EmbeddingType, OpenSearchServerlessGeneration
 from graphrag_toolkit.lexical_graph.storage.vector import VectorIndex, to_embedded_query
 from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
@@ -337,10 +337,10 @@ def _handle_index_create_request_error(e:'RequestError', index_name, endpoint, n
             f"OpenSearch index creation failed [index_name: {index_name}, endpoint: {endpoint}] because "
             f"the target collection rejected a Classic-only field ({_request_error_reason(e)}). This "
             f"usually means the collection is an AOSS NextGen collection, which does not support the "
-            f"'engine' or 'mode' knn_vector parameters. GraphRAGConfig.opensearch_serverless_nextgen is "
-            f"explicitly set to False, which forces the Classic mapping and skips auto-detection -- unset "
-            f"it (or the OPENSEARCH_SERVERLESS_NEXTGEN env var) to auto-detect NextGen collections, or set "
-            f"it to True to force NextGen-compatible index mappings."
+            f"'engine' or 'mode' knn_vector parameters. GraphRAGConfig.opensearch_serverless_generation is "
+            f"explicitly set to CLASSIC, which forces the Classic mapping and skips auto-detection -- unset "
+            f"it (or the OPENSEARCH_SERVERLESS_GENERATION env var) to auto-detect NextGen collections, or set "
+            f"it to NEXTGEN to force NextGen-compatible index mappings."
         ) from e
 
     logger.exception('Error creating an OpenSearch index')
@@ -377,10 +377,11 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
     dimensions and a predefined method for handling knn_vector elements.
 
     Whether the index is created with a NextGen or Classic knn_vector mapping is
-    controlled by GraphRAGConfig.opensearch_serverless_nextgen. When that's unset
+    controlled by GraphRAGConfig.opensearch_serverless_generation. When that's unset
     (None), this auto-detects: it tries the Classic mapping first and, if the
     collection rejects it as NextGen-incompatible, retries once with the NextGen
-    mapping. Set the flag to True or False to force one mapping and skip detection.
+    mapping. Set it to OpenSearchServerlessGeneration.CLASSIC or .NEXTGEN to force
+    one mapping and skip detection.
 
     Args:
         endpoint: The OpenSearch endpoint to connect to.
@@ -393,17 +394,17 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
 
     Raises:
         ValueError: If a Classic-only knn_vector field (engine/mode) was rejected by an
-            AOSS NextGen collection and GraphRAGConfig.opensearch_serverless_nextgen was
-            explicitly set to False, so auto-detection didn't get a chance to retry.
+            AOSS NextGen collection and GraphRAGConfig.opensearch_serverless_generation was
+            explicitly set to CLASSIC, so auto-detection didn't get a chance to retry.
     """
     client = create_os_client(endpoint, pool_maxsize=1)
-    nextgen_override = GraphRAGConfig.opensearch_serverless_nextgen
+    generation = GraphRAGConfig.opensearch_serverless_generation
 
     try:
         return _try_create_index(
             client, index_name, dimensions, writeable, endpoint,
-            nextgen=bool(nextgen_override),
-            allow_retry=(nextgen_override is None),
+            nextgen=(generation == OpenSearchServerlessGeneration.NEXTGEN),
+            allow_retry=(generation is None),
         )
     finally:
         client.close()

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
@@ -233,7 +233,10 @@ _NEXTGEN_UNSUPPORTED_FIELDS = ('engine', 'mode')
 def _request_error_reason(e:'RequestError') -> str:
     info = e.info
     if isinstance(info, dict):
-        return info.get('error', {}).get('reason', str(info))
+        error = info.get('error')
+        if isinstance(error, dict):
+            return error.get('reason', str(info))
+        return str(error) if error is not None else str(info)
     return str(info or '')
 
 
@@ -261,6 +264,11 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
 
     Returns:
         bool: True if the index exists (or is created successfully), False otherwise.
+
+    Raises:
+        ValueError: If index creation fails because a Classic-only knn_vector field
+            (engine/mode) was sent to an AOSS NextGen collection. See
+            GraphRAGConfig.opensearch_serverless_nextgen.
     """
     client = create_os_client(endpoint, pool_maxsize=1)
 
@@ -597,6 +605,9 @@ class OpenSearchIndex(VectorIndex):
         Returns:
             OpensearchVectorClient: The initialized or cached OpenSearch vector
                 client instance.
+
+        Raises:
+            ValueError: See index_exists().
         """
         if self._client:
             if self._client._index != self.underlying_index_name():
@@ -721,6 +732,8 @@ class OpenSearchIndex(VectorIndex):
         Raises:
             IndexError:
                 If the index is marked as read-only.
+            ValueError:
+                See index_exists().
         """
         if not self.writeable:
             raise IndexError(f'Index {self.index_name} is read-only')
@@ -833,6 +846,9 @@ class OpenSearchIndex(VectorIndex):
         Returns:
             List[TopKResult]: A list of processed results containing the top-k nodes ordered by
                 relevance score.
+
+        Raises:
+            ValueError: See index_exists().
         """
         query_bundle = to_embedded_query(query_bundle, self.embed_model)
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
@@ -225,7 +225,23 @@ def index_is_available(client, index_name):
 
     except Exception as err:
         return False
-    
+
+
+_NEXTGEN_UNSUPPORTED_FIELDS = ('engine', 'mode')
+
+
+def _request_error_reason(e:'RequestError') -> str:
+    info = e.info
+    if isinstance(info, dict):
+        return info.get('error', {}).get('reason', str(info))
+    return str(info or '')
+
+
+def _is_nextgen_incompatible_field_error(e:'RequestError') -> bool:
+    if e.error != 'illegal_argument_exception':
+        return False
+    reason = _request_error_reason(e)
+    return any(f"'{field}'" in reason for field in _NEXTGEN_UNSUPPORTED_FIELDS)
 
 
 def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
@@ -250,7 +266,28 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
 
     embedding_field = 'embedding'
 
-    if GraphRAGConfig.opensearch_engine.lower() == 'faiss':
+    if GraphRAGConfig.opensearch_serverless_nextgen:
+
+        embedding_mapping = {
+            "type": "knn_vector",
+            "dimension": dimensions,
+            "space_type": "l2",
+        }
+
+        if GraphRAGConfig.opensearch_serverless_nextgen_compression:
+            embedding_mapping["compression_level"] = GraphRAGConfig.opensearch_serverless_nextgen_compression
+
+        idx_conf = {
+            "settings": {"index": {"knn": True}},
+            "mappings": {
+                "date_detection": False,
+                "properties": {
+                    embedding_field: embedding_mapping,
+                }
+            }
+        }
+
+    elif GraphRAGConfig.opensearch_engine.lower() == 'faiss':
 
         method = {
             "name": "hnsw",
@@ -306,6 +343,18 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
     except RequestError as e:
         if e.error == 'resource_already_exists_exception':
             logger.debug(f'OpenSearch index already exists [index_name: {index_name}, endpoint: {endpoint}]')
+        elif _is_nextgen_incompatible_field_error(e) and not GraphRAGConfig.opensearch_serverless_nextgen:
+            # The NextGen mapping branch above never sends 'engine'/'mode', so this can only
+            # happen with the Classic mapping. Guarded on the flag so a genuinely different
+            # illegal_argument_exception while nextgen=True isn't misreported as a config hint.
+            raise ValueError(
+                f"OpenSearch index creation failed [index_name: {index_name}, endpoint: {endpoint}] because "
+                f"the target collection rejected a Classic-only field ({_request_error_reason(e)}). This "
+                f"usually means the collection is an AOSS NextGen collection, which does not support the "
+                f"'engine' or 'mode' knn_vector parameters. Set GraphRAGConfig.opensearch_serverless_nextgen "
+                f"= True (or the OPENSEARCH_SERVERLESS_NEXTGEN environment variable) to use NextGen-compatible "
+                f"index mappings."
+            ) from e
         else:
             logger.exception('Error creating an OpenSearch index')
     finally:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/opensearch_vector_indexes.py
@@ -399,6 +399,11 @@ def index_exists(endpoint, index_name, dimensions, writeable) -> bool:
     """
     client = create_os_client(endpoint, pool_maxsize=1)
     generation = GraphRAGConfig.opensearch_serverless_generation
+    # When unset, generation is detected reactively: try Classic, retry NextGen on
+    # rejection (see _try_create_index). A deterministic alternative is the AOSS
+    # BatchGetCollectionGroup `generation` field, but it needs boto3>=1.43.17 and
+    # aoss:BatchGetCollection[Group] on every client role, so it's deferred with an
+    # AccessDenied fallback to this reactive path. See awslabs/graphrag-toolkit#399.
 
     try:
         return _try_create_index(

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/repair_opensearch_vector_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/repair_opensearch_vector_store.py
@@ -144,8 +144,14 @@ def repair_opensearch_vector_store(graph_store_info:str, vector_store_info:str, 
         for index_name in ALL_EMBEDDING_INDEXES:
             
             logger.info(f'Processing index [tenant_id: {tenant_id}, index: {index_name}, batch_size: {batch_size}]')
-            
-            if index_exists(tenant_id, index_name, vector_store):
+
+            try:
+                this_index_exists = index_exists(tenant_id, index_name, vector_store)
+            except ValueError as e:
+                logger.error(f'  Skipping index due to misconfiguration [tenant_id: {tenant_id}, index: {index_name}]: {e}')
+                continue
+
+            if this_index_exists:
                 
                 index_total_doc_ids = 0
                 index_total_deleted_doc_ids = 0

--- a/lexical-graph/tests/unit/storage/vector/_opensearch_test_support.py
+++ b/lexical-graph/tests/unit/storage/vector/_opensearch_test_support.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared opensearchpy/llama_index mock bootstrap, so opensearch_vector_indexes tests
+run without the optional opensearch-py / llama-index-vector-stores-opensearch packages.
+
+Every test file that imports opensearch_vector_indexes must call install_opensearch_mocks()
+before that import, and use these same Fake*Error classes rather than defining their own:
+the module under test binds `from opensearchpy.exceptions import ...` once, at first import,
+and that binding is cached for the rest of the process. Separate private classes per file
+would make `except RequestError` match only whichever file's mocks happened to load first.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+class FakeNotFoundError(Exception):
+    def __init__(self, status_code=404, error="not found", info=None):
+        super().__init__(error)
+        self.status_code = status_code
+        self.error = error
+        self.info = info
+
+
+class FakeRequestError(Exception):
+    def __init__(self, status_code=400, error="illegal_argument_exception", info=None):
+        super().__init__(error)
+        self.status_code = status_code
+        self.error = error
+        self.info = info
+
+
+def install_opensearch_mocks():
+    """Install fake opensearch modules into sys.modules so the source can import."""
+    import llama_index
+
+    fake_exceptions_mod = types.ModuleType("opensearchpy.exceptions")
+    fake_exceptions_mod.NotFoundError = FakeNotFoundError
+    fake_exceptions_mod.RequestError = FakeRequestError
+
+    fake_opensearch_mod = types.ModuleType("opensearchpy")
+    fake_opensearch_mod.OpenSearch = MagicMock(name="OpenSearch")
+    fake_opensearch_mod.AsyncOpenSearch = MagicMock(name="AsyncOpenSearch")
+    fake_opensearch_mod.AWSV4SignerAsyncAuth = MagicMock(name="AWSV4SignerAsyncAuth")
+    fake_opensearch_mod.AsyncHttpConnection = MagicMock(name="AsyncHttpConnection")
+    fake_opensearch_mod.Urllib3AWSV4SignerAuth = MagicMock(name="Urllib3AWSV4SignerAuth")
+    fake_opensearch_mod.Urllib3HttpConnection = MagicMock(name="Urllib3HttpConnection")
+    fake_opensearch_mod.exceptions = fake_exceptions_mod
+
+    fake_llama_vs_mod = types.ModuleType("llama_index.vector_stores")
+    fake_llama_os_mod = types.ModuleType("llama_index.vector_stores.opensearch")
+
+    class _FakeOpensearchVectorClient:
+        _get_opensearch_version = None
+        _bulk_ingest_embeddings = None
+
+    fake_llama_os_mod.OpensearchVectorClient = _FakeOpensearchVectorClient
+    fake_llama_vs_mod.opensearch = fake_llama_os_mod
+    llama_index.vector_stores = fake_llama_vs_mod
+
+    sys.modules["opensearchpy"] = fake_opensearch_mod
+    sys.modules["opensearchpy.exceptions"] = fake_exceptions_mod
+    sys.modules["llama_index.vector_stores"] = fake_llama_vs_mod
+    sys.modules["llama_index.vector_stores.opensearch"] = fake_llama_os_mod

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_clients.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_clients.py
@@ -10,62 +10,12 @@ Covers:
   - OpenSearchIndex.client property (index exists, index does not exist)
 """
 
-import sys
-import types
 import pytest
 from unittest.mock import MagicMock, patch
 
+from ._opensearch_test_support import install_opensearch_mocks, FakeNotFoundError as _NotFoundError
 
-# ---------------------------------------------------------------------------
-# Bootstrap: inject fake opensearch modules before the source module loads
-# ---------------------------------------------------------------------------
-
-def _install_opensearch_mocks():
-    """Install fake opensearch modules into sys.modules so the source can import."""
-    import llama_index
-
-    fake_exceptions_mod = types.ModuleType("opensearchpy.exceptions")
-
-    class _NotFoundError(Exception):
-        def __init__(self, status_code=404, error="not found", info=None):
-            super().__init__(error)
-            self.status_code = status_code
-
-    class _RequestError(Exception):
-        pass
-
-    fake_exceptions_mod.NotFoundError = _NotFoundError
-    fake_exceptions_mod.RequestError = _RequestError
-
-    fake_opensearch_mod = types.ModuleType("opensearchpy")
-    fake_opensearch_mod.OpenSearch = MagicMock(name="OpenSearch")
-    fake_opensearch_mod.AsyncOpenSearch = MagicMock(name="AsyncOpenSearch")
-    fake_opensearch_mod.AWSV4SignerAsyncAuth = MagicMock(name="AWSV4SignerAsyncAuth")
-    fake_opensearch_mod.AsyncHttpConnection = MagicMock(name="AsyncHttpConnection")
-    fake_opensearch_mod.Urllib3AWSV4SignerAuth = MagicMock(name="Urllib3AWSV4SignerAuth")
-    fake_opensearch_mod.Urllib3HttpConnection = MagicMock(name="Urllib3HttpConnection")
-    fake_opensearch_mod.exceptions = fake_exceptions_mod
-
-    fake_llama_vs_mod = types.ModuleType("llama_index.vector_stores")
-    fake_llama_os_mod = types.ModuleType("llama_index.vector_stores.opensearch")
-
-    class _FakeOpensearchVectorClient:
-        _get_opensearch_version = None
-        _bulk_ingest_embeddings = None
-
-    fake_llama_os_mod.OpensearchVectorClient = _FakeOpensearchVectorClient
-    fake_llama_vs_mod.opensearch = fake_llama_os_mod
-    llama_index.vector_stores = fake_llama_vs_mod
-
-    sys.modules["opensearchpy"] = fake_opensearch_mod
-    sys.modules["opensearchpy.exceptions"] = fake_exceptions_mod
-    sys.modules["llama_index.vector_stores"] = fake_llama_vs_mod
-    sys.modules["llama_index.vector_stores.opensearch"] = fake_llama_os_mod
-
-    return _NotFoundError
-
-
-_NotFoundError = _install_opensearch_mocks()
+install_opensearch_mocks()
 
 # Now import the module under test (mocks are in place)
 import graphrag_toolkit.lexical_graph.storage.vector.opensearch_vector_indexes as ovi  # noqa: E402

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
@@ -7,7 +7,9 @@ Covers:
   - NextGen mapping omits the `method` block and moves `space_type` to the
     field level, with no `compression_level` unless configured
   - NextGen mapping includes `compression_level` when configured
-  - Classic (faiss/nmslib) mappings are unchanged when nextgen is disabled
+  - Classic (faiss/nmslib) mappings are unaffected when nextgen is forced False
+  - Auto-detection (nextgen unset): tries Classic first, retries once with NextGen
+    only if the collection rejects it
 """
 
 from unittest.mock import MagicMock, patch
@@ -158,6 +160,73 @@ class TestNextGenIncompatibleFieldError:
         result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
         assert raised is None
         assert result is False
+
+
+def _run_index_exists_with_create_side_effects(nextgen, side_effects):
+    """Run index_exists() where client.indices.create() has the given side_effects list
+    (one entry per call, in order). Returns (result, raised, mock_client)."""
+    mock_client = MagicMock()
+    mock_client.indices.exists.return_value = False
+    mock_client.indices.create.side_effect = side_effects
+
+    with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
+        mock_cfg.opensearch_serverless_nextgen = nextgen
+        mock_cfg.opensearch_serverless_nextgen_compression = None
+        mock_cfg.opensearch_engine = 'nmslib'
+        with patch.object(ovi, "create_os_client", return_value=mock_client):
+            try:
+                return ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True), None, mock_client
+            except ValueError as e:
+                return None, e, mock_client
+
+
+def _is_nextgen_body(body):
+    return "method" not in body["mappings"]["properties"]["embedding"]
+
+
+class TestAutoDetectRetry:
+    """opensearch_serverless_nextgen=None (unset) auto-detects: try Classic first, retry
+    once with NextGen only if the collection rejects it as NextGen-incompatible."""
+
+    def test_tries_classic_mapping_first(self):
+        result, raised, mock_client = _run_index_exists_with_create_side_effects(nextgen=None, side_effects=[None])
+        assert raised is None
+        assert result is True
+        assert mock_client.indices.create.call_count == 1
+        body = mock_client.indices.create.call_args.kwargs["body"]
+        assert not _is_nextgen_body(body)
+
+    def test_retries_with_nextgen_mapping_on_rejection(self):
+        e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
+        result, raised, mock_client = _run_index_exists_with_create_side_effects(nextgen=None, side_effects=[e, None])
+        assert raised is None
+        assert result is True
+        assert mock_client.indices.create.call_count == 2
+        first_body = mock_client.indices.create.call_args_list[0].kwargs["body"]
+        second_body = mock_client.indices.create.call_args_list[1].kwargs["body"]
+        assert not _is_nextgen_body(first_body)
+        assert _is_nextgen_body(second_body)
+
+    def test_retries_at_most_once(self):
+        e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
+        result, raised, mock_client = _run_index_exists_with_create_side_effects(nextgen=None, side_effects=[e, e])
+        assert raised is None
+        assert result is False
+        assert mock_client.indices.create.call_count == 2
+
+    def test_explicit_false_does_not_retry_and_raises(self):
+        e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
+        result, raised, mock_client = _run_index_exists_with_create_side_effects(nextgen=False, side_effects=[e])
+        assert raised is not None
+        assert mock_client.indices.create.call_count == 1
+
+    def test_explicit_true_uses_nextgen_mapping_directly(self):
+        result, raised, mock_client = _run_index_exists_with_create_side_effects(nextgen=True, side_effects=[None])
+        assert raised is None
+        assert result is True
+        assert mock_client.indices.create.call_count == 1
+        body = mock_client.indices.create.call_args.kwargs["body"]
+        assert _is_nextgen_body(body)
 
 
 class TestIndexExistsLifecycle:

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
@@ -170,7 +170,7 @@ class TestNextGenIncompatibleFieldError:
 
     def test_raises_constructive_error_for_engine_field_rejection(self):
         e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
-        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        _, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
         assert raised is not None, "expected a ValueError to be raised"
         assert 'opensearch_serverless_nextgen' in str(raised)
         assert raised.__cause__ is e
@@ -178,7 +178,7 @@ class TestNextGenIncompatibleFieldError:
     def test_raises_constructive_error_for_mode_field_rejection(self):
         info = {'error': {'reason': "Field parameter 'mode' is not supported"}}
         e = _RequestError(400, 'illegal_argument_exception', info)
-        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        _, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
         assert raised is not None, "expected a ValueError to be raised"
         assert 'opensearch_serverless_nextgen' in str(raised)
 
@@ -255,3 +255,14 @@ class TestRequestErrorReason:
 
     def test_falls_back_to_empty_string_when_info_is_none(self):
         assert ovi._request_error_reason(_RequestError(400, 'illegal_argument_exception', None)) == ""
+
+    def test_handles_info_error_as_plain_string(self):
+        info = {'error': 'some string message', 'status': 400}
+        assert ovi._request_error_reason(_RequestError(400, 'illegal_argument_exception', info)) == 'some string message'
+
+    def test_raises_valueerror_not_attributeerror_when_info_error_is_a_string(self):
+        info = {'error': "Field parameter 'engine' is not supported", 'status': 400}
+        e = _RequestError(400, 'illegal_argument_exception', info)
+        _, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is not None, "expected a ValueError to be raised, not an AttributeError"
+        assert 'opensearch_serverless_nextgen' in str(raised)

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
@@ -10,60 +10,11 @@ Covers:
   - Classic (faiss/nmslib) mappings are unchanged when nextgen is disabled
 """
 
-import sys
-import types
 from unittest.mock import MagicMock, patch
 
+from ._opensearch_test_support import install_opensearch_mocks, FakeRequestError as _RequestError
 
-def _install_opensearch_mocks():
-    import llama_index
-
-    fake_exceptions_mod = types.ModuleType("opensearchpy.exceptions")
-
-    class _NotFoundError(Exception):
-        def __init__(self, status_code=404, error="not found", info=None):
-            super().__init__(error)
-            self.status_code = status_code
-
-    class _RequestError(Exception):
-        def __init__(self, status_code=400, error="illegal_argument_exception", info=None):
-            super().__init__(error)
-            self.status_code = status_code
-            self.error = error
-            self.info = info
-
-    fake_exceptions_mod.NotFoundError = _NotFoundError
-    fake_exceptions_mod.RequestError = _RequestError
-
-    fake_opensearch_mod = types.ModuleType("opensearchpy")
-    fake_opensearch_mod.OpenSearch = MagicMock(name="OpenSearch")
-    fake_opensearch_mod.AsyncOpenSearch = MagicMock(name="AsyncOpenSearch")
-    fake_opensearch_mod.AWSV4SignerAsyncAuth = MagicMock(name="AWSV4SignerAsyncAuth")
-    fake_opensearch_mod.AsyncHttpConnection = MagicMock(name="AsyncHttpConnection")
-    fake_opensearch_mod.Urllib3AWSV4SignerAuth = MagicMock(name="Urllib3AWSV4SignerAuth")
-    fake_opensearch_mod.Urllib3HttpConnection = MagicMock(name="Urllib3HttpConnection")
-    fake_opensearch_mod.exceptions = fake_exceptions_mod
-
-    fake_llama_vs_mod = types.ModuleType("llama_index.vector_stores")
-    fake_llama_os_mod = types.ModuleType("llama_index.vector_stores.opensearch")
-
-    class _FakeOpensearchVectorClient:
-        _get_opensearch_version = None
-        _bulk_ingest_embeddings = None
-
-    fake_llama_os_mod.OpensearchVectorClient = _FakeOpensearchVectorClient
-    fake_llama_vs_mod.opensearch = fake_llama_os_mod
-    llama_index.vector_stores = fake_llama_vs_mod
-
-    sys.modules["opensearchpy"] = fake_opensearch_mod
-    sys.modules["opensearchpy.exceptions"] = fake_exceptions_mod
-    sys.modules["llama_index.vector_stores"] = fake_llama_vs_mod
-    sys.modules["llama_index.vector_stores.opensearch"] = fake_llama_os_mod
-
-    return _RequestError
-
-
-_RequestError = _install_opensearch_mocks()
+install_opensearch_mocks()
 
 import graphrag_toolkit.lexical_graph.storage.vector.opensearch_vector_indexes as ovi  # noqa: E402
 
@@ -141,11 +92,7 @@ def _run_index_exists_with_create_error(nextgen, request_error):
         mock_cfg.opensearch_serverless_nextgen = nextgen
         mock_cfg.opensearch_serverless_nextgen_compression = None
         mock_cfg.opensearch_engine = 'nmslib'
-        # `ovi.RequestError` is bound at whichever sibling test module first imports `ovi` in
-        # this test session, so its class identity isn't reliable here. Patch it to our own
-        # class for the duration of the call so `except RequestError` in the source matches.
-        with patch.object(ovi, "create_os_client", return_value=mock_client), \
-             patch.object(ovi, "RequestError", _RequestError):
+        with patch.object(ovi, "create_os_client", return_value=mock_client):
             try:
                 return ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True), None
             except ValueError as e:
@@ -203,6 +150,15 @@ class TestNextGenIncompatibleFieldError:
         assert raised is None
         assert result is False
 
+    def test_field_name_mentioned_outside_the_rejection_pattern_not_raised(self):
+        # A bare substring check would misfire here; the field name only appears
+        # incidentally, not in the actual rejection phrasing.
+        info = {'error': {'reason': "Unknown option 'mode' in request body near 'engine' usage"}}
+        e = _RequestError(400, 'illegal_argument_exception', info)
+        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is None
+        assert result is False
+
 
 class TestIndexExistsLifecycle:
     """Pre-existing index_exists() behavior, unrelated to NextGen, exercised here since the
@@ -238,8 +194,7 @@ class TestIndexExistsLifecycle:
             mock_cfg.opensearch_serverless_nextgen = False
             mock_cfg.opensearch_serverless_nextgen_compression = None
             mock_cfg.opensearch_engine = 'nmslib'
-            with patch.object(ovi, "create_os_client", return_value=mock_client), \
-                 patch.object(ovi, "RequestError", _RequestError):
+            with patch.object(ovi, "create_os_client", return_value=mock_client):
                 try:
                     ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True)
                 except ValueError:

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
@@ -1,0 +1,257 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AOSS NextGen index mappings in index_exists().
+
+Covers:
+  - NextGen mapping omits the `method` block and moves `space_type` to the
+    field level, with no `compression_level` unless configured
+  - NextGen mapping includes `compression_level` when configured
+  - Classic (faiss/nmslib) mappings are unchanged when nextgen is disabled
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+def _install_opensearch_mocks():
+    import llama_index
+
+    fake_exceptions_mod = types.ModuleType("opensearchpy.exceptions")
+
+    class _NotFoundError(Exception):
+        def __init__(self, status_code=404, error="not found", info=None):
+            super().__init__(error)
+            self.status_code = status_code
+
+    class _RequestError(Exception):
+        def __init__(self, status_code=400, error="illegal_argument_exception", info=None):
+            super().__init__(error)
+            self.status_code = status_code
+            self.error = error
+            self.info = info
+
+    fake_exceptions_mod.NotFoundError = _NotFoundError
+    fake_exceptions_mod.RequestError = _RequestError
+
+    fake_opensearch_mod = types.ModuleType("opensearchpy")
+    fake_opensearch_mod.OpenSearch = MagicMock(name="OpenSearch")
+    fake_opensearch_mod.AsyncOpenSearch = MagicMock(name="AsyncOpenSearch")
+    fake_opensearch_mod.AWSV4SignerAsyncAuth = MagicMock(name="AWSV4SignerAsyncAuth")
+    fake_opensearch_mod.AsyncHttpConnection = MagicMock(name="AsyncHttpConnection")
+    fake_opensearch_mod.Urllib3AWSV4SignerAuth = MagicMock(name="Urllib3AWSV4SignerAuth")
+    fake_opensearch_mod.Urllib3HttpConnection = MagicMock(name="Urllib3HttpConnection")
+    fake_opensearch_mod.exceptions = fake_exceptions_mod
+
+    fake_llama_vs_mod = types.ModuleType("llama_index.vector_stores")
+    fake_llama_os_mod = types.ModuleType("llama_index.vector_stores.opensearch")
+
+    class _FakeOpensearchVectorClient:
+        _get_opensearch_version = None
+        _bulk_ingest_embeddings = None
+
+    fake_llama_os_mod.OpensearchVectorClient = _FakeOpensearchVectorClient
+    fake_llama_vs_mod.opensearch = fake_llama_os_mod
+    llama_index.vector_stores = fake_llama_vs_mod
+
+    sys.modules["opensearchpy"] = fake_opensearch_mod
+    sys.modules["opensearchpy.exceptions"] = fake_exceptions_mod
+    sys.modules["llama_index.vector_stores"] = fake_llama_vs_mod
+    sys.modules["llama_index.vector_stores.opensearch"] = fake_llama_os_mod
+
+    return _RequestError
+
+
+_RequestError = _install_opensearch_mocks()
+
+import graphrag_toolkit.lexical_graph.storage.vector.opensearch_vector_indexes as ovi  # noqa: E402
+
+
+def _capture_index_create_body(nextgen, compression=None, engine='nmslib'):
+    """Run index_exists() with a mocked OpenSearch client; return the create() body."""
+    mock_client = MagicMock()
+    mock_client.indices.exists.return_value = False
+
+    with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
+        mock_cfg.opensearch_serverless_nextgen = nextgen
+        mock_cfg.opensearch_serverless_nextgen_compression = compression
+        mock_cfg.opensearch_engine = engine
+        with patch.object(ovi, "create_os_client", return_value=mock_client):
+            ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True)
+
+    _, kwargs = mock_client.indices.create.call_args
+    return kwargs["body"]
+
+
+class TestNextGenMapping:
+
+    def test_no_method_block(self):
+        body = _capture_index_create_body(nextgen=True)
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert "method" not in embedding
+
+    def test_space_type_at_field_level(self):
+        body = _capture_index_create_body(nextgen=True)
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert embedding["space_type"] == "l2"
+
+    def test_no_ef_search_setting(self):
+        body = _capture_index_create_body(nextgen=True)
+        assert "knn.algo_param.ef_search" not in body["settings"]["index"]
+
+    def test_no_compression_level_by_default(self):
+        body = _capture_index_create_body(nextgen=True)
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert "compression_level" not in embedding
+
+    def test_compression_level_when_configured(self):
+        body = _capture_index_create_body(nextgen=True, compression="8x")
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert embedding["compression_level"] == "8x"
+
+    def test_dimension_preserved(self):
+        body = _capture_index_create_body(nextgen=True)
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert embedding["dimension"] == 1024
+
+
+class TestClassicMappingUnaffected:
+
+    def test_nmslib_method_unchanged_when_nextgen_disabled(self):
+        body = _capture_index_create_body(nextgen=False, engine='nmslib')
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert embedding["method"]["engine"] == "nmslib"
+        assert body["settings"]["index"]["knn.algo_param.ef_search"] == 100
+
+    def test_faiss_method_unchanged_when_nextgen_disabled(self):
+        body = _capture_index_create_body(nextgen=False, engine='faiss')
+        embedding = body["mappings"]["properties"]["embedding"]
+        assert embedding["method"]["engine"] == "faiss"
+        assert "knn.algo_param.ef_search" not in body["settings"]["index"]
+
+
+def _run_index_exists_with_create_error(nextgen, request_error):
+    """Run index_exists() where client.indices.create() raises request_error; return (result, raised)."""
+    mock_client = MagicMock()
+    mock_client.indices.exists.return_value = False
+    mock_client.indices.create.side_effect = request_error
+
+    with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
+        mock_cfg.opensearch_serverless_nextgen = nextgen
+        mock_cfg.opensearch_serverless_nextgen_compression = None
+        mock_cfg.opensearch_engine = 'nmslib'
+        # `ovi.RequestError` is bound at whichever sibling test module first imports `ovi` in
+        # this test session, so its class identity isn't reliable here. Patch it to our own
+        # class for the duration of the call so `except RequestError` in the source matches.
+        with patch.object(ovi, "create_os_client", return_value=mock_client), \
+             patch.object(ovi, "RequestError", _RequestError):
+            try:
+                return ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True), None
+            except ValueError as e:
+                return None, e
+
+
+# Shape observed live against a real AOSS NextGen collection rejecting a Classic mapping.
+_ENGINE_REJECTED_INFO = {
+    'error': {
+        'root_cause': [{
+            'type': 'illegal_argument_exception',
+            'reason': "OpenSearch exception [type=illegal_argument_exception, reason=Field parameter 'engine' is not supported]- server : [envoy]",
+        }],
+        'type': 'illegal_argument_exception',
+        'reason': "OpenSearch exception [type=illegal_argument_exception, reason=Field parameter 'engine' is not supported]- server : [envoy]",
+    },
+    'status': 400,
+}
+
+
+class TestNextGenIncompatibleFieldError:
+
+    def test_raises_constructive_error_for_engine_field_rejection(self):
+        e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
+        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is not None, "expected a ValueError to be raised"
+        assert 'opensearch_serverless_nextgen' in str(raised)
+        assert raised.__cause__ is e
+
+    def test_raises_constructive_error_for_mode_field_rejection(self):
+        info = {'error': {'reason': "Field parameter 'mode' is not supported"}}
+        e = _RequestError(400, 'illegal_argument_exception', info)
+        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is not None, "expected a ValueError to be raised"
+        assert 'opensearch_serverless_nextgen' in str(raised)
+
+    def test_does_not_raise_when_nextgen_already_enabled(self):
+        # Our NextGen mapping never sends 'engine'/'mode', so this scenario shouldn't occur in
+        # practice, but the guard must not misfire and mask a genuinely different failure.
+        e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
+        result, raised = _run_index_exists_with_create_error(nextgen=True, request_error=e)
+        assert raised is None
+        assert result is False
+
+    def test_unrelated_illegal_argument_error_not_raised(self):
+        info = {'error': {'reason': "some unrelated validation failure"}}
+        e = _RequestError(400, 'illegal_argument_exception', info)
+        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is None
+        assert result is False
+
+    def test_unrelated_error_type_not_raised(self):
+        e = _RequestError(409, 'some_other_exception', {'error': {'reason': "Field parameter 'engine' is not supported"}})
+        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is None
+        assert result is False
+
+
+class TestIndexExistsLifecycle:
+    """Pre-existing index_exists() behavior, unrelated to NextGen, exercised here since the
+    NextGen work touches the same function and this behavior had no test coverage before."""
+
+    def test_index_already_exists_skips_create(self):
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+
+        with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
+            mock_cfg.opensearch_serverless_nextgen = False
+            mock_cfg.opensearch_engine = 'nmslib'
+            with patch.object(ovi, "create_os_client", return_value=mock_client):
+                result = ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True)
+
+        assert result is True
+        mock_client.indices.create.assert_not_called()
+        mock_client.close.assert_called_once()
+
+    def test_resource_already_exists_exception_handled_without_raising(self):
+        e = _RequestError(400, 'resource_already_exists_exception', {'error': {'reason': 'already exists'}})
+        result, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
+        assert raised is None
+        assert result is False
+
+    def test_client_closed_even_when_create_raises(self):
+        e = _RequestError(400, 'illegal_argument_exception', {'error': {'reason': "Field parameter 'engine' is not supported"}})
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = False
+        mock_client.indices.create.side_effect = e
+
+        with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
+            mock_cfg.opensearch_serverless_nextgen = False
+            mock_cfg.opensearch_serverless_nextgen_compression = None
+            mock_cfg.opensearch_engine = 'nmslib'
+            with patch.object(ovi, "create_os_client", return_value=mock_client), \
+                 patch.object(ovi, "RequestError", _RequestError):
+                try:
+                    ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True)
+                except ValueError:
+                    pass
+
+        mock_client.close.assert_called_once()
+
+
+class TestRequestErrorReason:
+
+    def test_falls_back_to_str_when_info_is_not_a_dict(self):
+        assert ovi._request_error_reason(_RequestError(400, 'illegal_argument_exception', "plain string info")) == "plain string info"
+
+    def test_falls_back_to_empty_string_when_info_is_none(self):
+        assert ovi._request_error_reason(_RequestError(400, 'illegal_argument_exception', None)) == ""

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_nextgen.py
@@ -19,6 +19,15 @@ from ._opensearch_test_support import install_opensearch_mocks, FakeRequestError
 install_opensearch_mocks()
 
 import graphrag_toolkit.lexical_graph.storage.vector.opensearch_vector_indexes as ovi  # noqa: E402
+from graphrag_toolkit.lexical_graph.config import OpenSearchServerlessGeneration  # noqa: E402
+
+
+def _generation(nextgen):
+    """Map the tri-state test param to a generation override: True -> NEXTGEN,
+    False -> CLASSIC, None -> unset (auto-detect)."""
+    if nextgen is None:
+        return None
+    return OpenSearchServerlessGeneration.NEXTGEN if nextgen else OpenSearchServerlessGeneration.CLASSIC
 
 
 def _capture_index_create_body(nextgen, compression=None, engine='nmslib'):
@@ -27,7 +36,7 @@ def _capture_index_create_body(nextgen, compression=None, engine='nmslib'):
     mock_client.indices.exists.return_value = False
 
     with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
-        mock_cfg.opensearch_serverless_nextgen = nextgen
+        mock_cfg.opensearch_serverless_generation = _generation(nextgen)
         mock_cfg.opensearch_serverless_nextgen_compression = compression
         mock_cfg.opensearch_engine = engine
         with patch.object(ovi, "create_os_client", return_value=mock_client):
@@ -91,7 +100,7 @@ def _run_index_exists_with_create_error(nextgen, request_error):
     mock_client.indices.create.side_effect = request_error
 
     with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
-        mock_cfg.opensearch_serverless_nextgen = nextgen
+        mock_cfg.opensearch_serverless_generation = _generation(nextgen)
         mock_cfg.opensearch_serverless_nextgen_compression = None
         mock_cfg.opensearch_engine = 'nmslib'
         with patch.object(ovi, "create_os_client", return_value=mock_client):
@@ -121,7 +130,7 @@ class TestNextGenIncompatibleFieldError:
         e = _RequestError(400, 'illegal_argument_exception', _ENGINE_REJECTED_INFO)
         _, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
         assert raised is not None, "expected a ValueError to be raised"
-        assert 'opensearch_serverless_nextgen' in str(raised)
+        assert 'opensearch_serverless_generation' in str(raised)
         assert raised.__cause__ is e
 
     def test_raises_constructive_error_for_mode_field_rejection(self):
@@ -129,7 +138,7 @@ class TestNextGenIncompatibleFieldError:
         e = _RequestError(400, 'illegal_argument_exception', info)
         _, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
         assert raised is not None, "expected a ValueError to be raised"
-        assert 'opensearch_serverless_nextgen' in str(raised)
+        assert 'opensearch_serverless_generation' in str(raised)
 
     def test_does_not_raise_when_nextgen_already_enabled(self):
         # Our NextGen mapping never sends 'engine'/'mode', so this scenario shouldn't occur in
@@ -170,7 +179,7 @@ def _run_index_exists_with_create_side_effects(nextgen, side_effects):
     mock_client.indices.create.side_effect = side_effects
 
     with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
-        mock_cfg.opensearch_serverless_nextgen = nextgen
+        mock_cfg.opensearch_serverless_generation = _generation(nextgen)
         mock_cfg.opensearch_serverless_nextgen_compression = None
         mock_cfg.opensearch_engine = 'nmslib'
         with patch.object(ovi, "create_os_client", return_value=mock_client):
@@ -185,7 +194,7 @@ def _is_nextgen_body(body):
 
 
 class TestAutoDetectRetry:
-    """opensearch_serverless_nextgen=None (unset) auto-detects: try Classic first, retry
+    """opensearch_serverless_generation=None (unset) auto-detects: try Classic first, retry
     once with NextGen only if the collection rejects it as NextGen-incompatible."""
 
     def test_tries_classic_mapping_first(self):
@@ -238,7 +247,7 @@ class TestIndexExistsLifecycle:
         mock_client.indices.exists.return_value = True
 
         with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
-            mock_cfg.opensearch_serverless_nextgen = False
+            mock_cfg.opensearch_serverless_generation = OpenSearchServerlessGeneration.CLASSIC
             mock_cfg.opensearch_engine = 'nmslib'
             with patch.object(ovi, "create_os_client", return_value=mock_client):
                 result = ovi.index_exists("https://endpoint", "chunk", 1024, writeable=True)
@@ -260,7 +269,7 @@ class TestIndexExistsLifecycle:
         mock_client.indices.create.side_effect = e
 
         with patch.object(ovi, "GraphRAGConfig") as mock_cfg:
-            mock_cfg.opensearch_serverless_nextgen = False
+            mock_cfg.opensearch_serverless_generation = OpenSearchServerlessGeneration.CLASSIC
             mock_cfg.opensearch_serverless_nextgen_compression = None
             mock_cfg.opensearch_engine = 'nmslib'
             with patch.object(ovi, "create_os_client", return_value=mock_client):
@@ -289,4 +298,4 @@ class TestRequestErrorReason:
         e = _RequestError(400, 'illegal_argument_exception', info)
         _, raised = _run_index_exists_with_create_error(nextgen=False, request_error=e)
         assert raised is not None, "expected a ValueError to be raised, not an AttributeError"
-        assert 'opensearch_serverless_nextgen' in str(raised)
+        assert 'opensearch_serverless_generation' in str(raised)

--- a/lexical-graph/tests/unit/storage/vector/test_opensearch_vector_indexes.py
+++ b/lexical-graph/tests/unit/storage/vector/test_opensearch_vector_indexes.py
@@ -16,59 +16,11 @@ Covers:
   - mixed-case ids reach the query with case preserved (the regression)
 """
 
-import sys
-import types
 from unittest.mock import MagicMock, patch, PropertyMock
 
+from ._opensearch_test_support import install_opensearch_mocks
 
-# ---------------------------------------------------------------------------
-# Bootstrap: inject fake opensearch modules before the source module loads
-# (mirrors test_opensearch_clients.py so the suite runs without opensearchpy)
-# ---------------------------------------------------------------------------
-
-def _install_opensearch_mocks():
-    import llama_index
-
-    fake_exceptions_mod = types.ModuleType("opensearchpy.exceptions")
-
-    class _NotFoundError(Exception):
-        def __init__(self, status_code=404, error="not found", info=None):
-            super().__init__(error)
-            self.status_code = status_code
-
-    class _RequestError(Exception):
-        pass
-
-    fake_exceptions_mod.NotFoundError = _NotFoundError
-    fake_exceptions_mod.RequestError = _RequestError
-
-    fake_opensearch_mod = types.ModuleType("opensearchpy")
-    fake_opensearch_mod.OpenSearch = MagicMock(name="OpenSearch")
-    fake_opensearch_mod.AsyncOpenSearch = MagicMock(name="AsyncOpenSearch")
-    fake_opensearch_mod.AWSV4SignerAsyncAuth = MagicMock(name="AWSV4SignerAsyncAuth")
-    fake_opensearch_mod.AsyncHttpConnection = MagicMock(name="AsyncHttpConnection")
-    fake_opensearch_mod.Urllib3AWSV4SignerAuth = MagicMock(name="Urllib3AWSV4SignerAuth")
-    fake_opensearch_mod.Urllib3HttpConnection = MagicMock(name="Urllib3HttpConnection")
-    fake_opensearch_mod.exceptions = fake_exceptions_mod
-
-    fake_llama_vs_mod = types.ModuleType("llama_index.vector_stores")
-    fake_llama_os_mod = types.ModuleType("llama_index.vector_stores.opensearch")
-
-    class _FakeOpensearchVectorClient:
-        _get_opensearch_version = None
-        _bulk_ingest_embeddings = None
-
-    fake_llama_os_mod.OpensearchVectorClient = _FakeOpensearchVectorClient
-    fake_llama_vs_mod.opensearch = fake_llama_os_mod
-    llama_index.vector_stores = fake_llama_vs_mod
-
-    sys.modules["opensearchpy"] = fake_opensearch_mod
-    sys.modules["opensearchpy.exceptions"] = fake_exceptions_mod
-    sys.modules["llama_index.vector_stores"] = fake_llama_vs_mod
-    sys.modules["llama_index.vector_stores.opensearch"] = fake_llama_os_mod
-
-
-_install_opensearch_mocks()
+install_opensearch_mocks()
 
 import graphrag_toolkit.lexical_graph.storage.vector.opensearch_vector_indexes as ovi  # noqa: E402
 from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY  # noqa: E402

--- a/lexical-graph/tests/unit/storage/vector/test_repair_opensearch_vector_store.py
+++ b/lexical-graph/tests/unit/storage/vector/test_repair_opensearch_vector_store.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for repair_opensearch_vector_store()'s per-index error handling.
+
+Covers:
+  - A ValueError from index_exists() (e.g. a NextGen-misconfigured collection)
+    skips that index and continues the batch instead of aborting the whole run
+"""
+
+from unittest.mock import MagicMock, patch
+
+import graphrag_toolkit.lexical_graph.storage.vector.repair_opensearch_vector_store as rovs
+from graphrag_toolkit.lexical_graph.storage.constants import ALL_EMBEDDING_INDEXES
+
+
+def test_valueerror_from_one_index_does_not_abort_the_batch():
+    def fake_index_exists(tenant_id, index_name, vector_store):
+        if index_name == ALL_EMBEDDING_INDEXES[0]:
+            raise ValueError(f"misconfigured NextGen collection for {index_name}")
+        return False
+
+    with patch.object(rovs, "GraphStoreFactory") as mock_graph_factory, \
+         patch.object(rovs, "VectorStoreFactory") as mock_vector_factory, \
+         patch.object(rovs, "index_exists", side_effect=fake_index_exists) as mock_index_exists:
+        mock_graph_factory.for_graph_store.return_value = MagicMock()
+        mock_vector_factory.for_vector_store.return_value = MagicMock()
+
+        result = rovs.repair_opensearch_vector_store(
+            graph_store_info="fake-graph-store",
+            vector_store_info="fake-vector-store",
+            tenant_ids=["testtenant"],
+        )
+
+    # index_exists() was called for every index despite the first one raising
+    assert mock_index_exists.call_count == len(ALL_EMBEDDING_INDEXES)
+    assert result["results"] == []

--- a/lexical-graph/tests/unit/test_aoss_nextgen_cfn_template_parity.py
+++ b/lexical-graph/tests/unit/test_aoss_nextgen_cfn_template_parity.py
@@ -1,0 +1,101 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guards against silent drift between the Classic and NextGen Neptune DB + OpenSearch
+Serverless CloudFormation templates.
+
+The NextGen template started as a copy of the Classic one with a small, deliberate delta
+(a CollectionGroup resource, three fields on the Collection resource). CloudFormation has
+no composition primitive that would let them share the VPC/Neptune/SageMaker resources
+without a nested-stack rewrite, so the duplication is accepted; this test enforces that
+any future fix to the shared resources gets applied to both files.
+"""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATES_DIR = REPO_ROOT / "examples" / "lexical-graph" / "cloudformation-templates"
+CLASSIC_TEMPLATE = TEMPLATES_DIR / "graphrag-toolkit-neptune-db-opensearch-serverless.json"
+NEXTGEN_TEMPLATE = TEMPLATES_DIR / "graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json"
+
+# The only resource NextGen adds outright.
+INTENTIONAL_NEW_RESOURCES = {"OpenSearchServerlessCollectionGroup"}
+
+# The only shared resource allowed to differ, and the only fields it may differ on.
+INTENTIONAL_MODIFIED_RESOURCE = "OpenSearchServerless"
+INTENTIONAL_MODIFIED_FIELDS = {"DependsOn", "CollectionGroupName", "StandbyReplicas"}
+
+# Top-level sections that must be byte-identical between the two templates.
+SHARED_TOP_LEVEL_SECTIONS = ("Parameters", "Rules", "Metadata", "Conditions", "Outputs")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+# Loaded once at import time; both files are read-only fixtures for this whole module.
+CLASSIC = _load(CLASSIC_TEMPLATE)
+NEXTGEN = _load(NEXTGEN_TEMPLATE)
+
+
+def test_shared_top_level_sections_are_identical():
+    classic = CLASSIC
+    nextgen = NEXTGEN
+
+    for section in SHARED_TOP_LEVEL_SECTIONS:
+        assert classic.get(section) == nextgen.get(section), (
+            f"'{section}' has drifted between the Classic and NextGen templates. "
+            f"If this is an intentional NextGen-specific change, add it to "
+            f"SHARED_TOP_LEVEL_SECTIONS' exceptions in this test; otherwise the change "
+            f"needs to be applied to both templates."
+        )
+
+
+def test_only_the_collection_group_resource_is_new_in_nextgen():
+    classic = CLASSIC
+    nextgen = NEXTGEN
+
+    added = set(nextgen["Resources"]) - set(classic["Resources"])
+    removed = set(classic["Resources"]) - set(nextgen["Resources"])
+
+    assert added == INTENTIONAL_NEW_RESOURCES
+    assert not removed, f"NextGen template is missing resources present in Classic: {removed}"
+
+
+def test_shared_resources_are_identical_except_the_known_delta():
+    classic = CLASSIC
+    nextgen = NEXTGEN
+
+    shared_resource_names = set(classic["Resources"]) & set(nextgen["Resources"])
+
+    for name in shared_resource_names:
+        classic_resource = classic["Resources"][name]
+        nextgen_resource = nextgen["Resources"][name]
+
+        if name != INTENTIONAL_MODIFIED_RESOURCE:
+            assert classic_resource == nextgen_resource, (
+                f"Resource '{name}' has drifted between the Classic and NextGen "
+                f"templates. Apply the change to both, or if it's an intentional "
+                f"NextGen-only difference, update this test."
+            )
+            continue
+
+        classic_props = classic_resource.get("Properties", {})
+        nextgen_props = nextgen_resource.get("Properties", {})
+
+        changed_top_level_keys = {
+            k for k in set(classic_resource) | set(nextgen_resource)
+            if classic_resource.get(k) != nextgen_resource.get(k) and k != "Properties"
+        }
+        changed_property_keys = {
+            k for k in set(classic_props) | set(nextgen_props)
+            if classic_props.get(k) != nextgen_props.get(k)
+        }
+
+        unexpected = (changed_top_level_keys | changed_property_keys) - INTENTIONAL_MODIFIED_FIELDS
+        assert not unexpected, (
+            f"'{INTENTIONAL_MODIFIED_RESOURCE}' differs on unexpected field(s) {unexpected} "
+            f"between the Classic and NextGen templates. Only {INTENTIONAL_MODIFIED_FIELDS} "
+            f"are expected to differ."
+        )

--- a/lexical-graph/tests/unit/test_config.py
+++ b/lexical-graph/tests/unit/test_config.py
@@ -10,6 +10,7 @@ import os
 from unittest.mock import Mock, patch
 from graphrag_toolkit.lexical_graph.config import (
     GraphRAGConfig,
+    OpenSearchServerlessGeneration,
     _is_json_string,
     string_to_bool,
     DEFAULT_EXTRACTION_MODEL,
@@ -205,44 +206,63 @@ class TestGraphRAGConfigEnvironmentVariables:
         finally:
             GraphRAGConfig._build_batch_size = original
 
-    def test_opensearch_serverless_nextgen_defaults_none_for_auto_detect(self):
-        """Verify opensearch_serverless_nextgen defaults to None (auto-detect) when unset."""
-        original = GraphRAGConfig._opensearch_serverless_nextgen
+    def test_opensearch_serverless_generation_defaults_none_for_auto_detect(self):
+        """opensearch_serverless_generation defaults to None (auto-detect) when unset."""
+        original = GraphRAGConfig._opensearch_serverless_generation
         try:
             with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop('OPENSEARCH_SERVERLESS_NEXTGEN', None)
-                GraphRAGConfig._opensearch_serverless_nextgen = None
-                assert GraphRAGConfig.opensearch_serverless_nextgen is None
+                os.environ.pop('OPENSEARCH_SERVERLESS_GENERATION', None)
+                GraphRAGConfig._opensearch_serverless_generation = None
+                assert GraphRAGConfig.opensearch_serverless_generation is None
         finally:
-            GraphRAGConfig._opensearch_serverless_nextgen = original
+            GraphRAGConfig._opensearch_serverless_generation = original
 
-    def test_opensearch_serverless_nextgen_from_env(self):
-        """Verify opensearch_serverless_nextgen reads from OPENSEARCH_SERVERLESS_NEXTGEN env var."""
-        original = GraphRAGConfig._opensearch_serverless_nextgen
+    def test_opensearch_serverless_generation_from_env_nextgen(self):
+        """Reads NEXTGEN from OPENSEARCH_SERVERLESS_GENERATION (case-insensitive)."""
+        original = GraphRAGConfig._opensearch_serverless_generation
         try:
-            with patch.dict(os.environ, {'OPENSEARCH_SERVERLESS_NEXTGEN': 'true'}):
-                GraphRAGConfig._opensearch_serverless_nextgen = None
-                assert GraphRAGConfig.opensearch_serverless_nextgen is True
+            with patch.dict(os.environ, {'OPENSEARCH_SERVERLESS_GENERATION': 'nextgen'}):
+                GraphRAGConfig._opensearch_serverless_generation = None
+                assert GraphRAGConfig.opensearch_serverless_generation is OpenSearchServerlessGeneration.NEXTGEN
         finally:
-            GraphRAGConfig._opensearch_serverless_nextgen = original
+            GraphRAGConfig._opensearch_serverless_generation = original
 
-    def test_opensearch_serverless_nextgen_setter_true(self):
-        """Verify opensearch_serverless_nextgen can be forced to True (skip auto-detect, force NextGen)."""
-        original = GraphRAGConfig._opensearch_serverless_nextgen
+    def test_opensearch_serverless_generation_from_env_classic(self):
+        """Reads CLASSIC from OPENSEARCH_SERVERLESS_GENERATION."""
+        original = GraphRAGConfig._opensearch_serverless_generation
         try:
-            GraphRAGConfig.opensearch_serverless_nextgen = True
-            assert GraphRAGConfig.opensearch_serverless_nextgen is True
+            with patch.dict(os.environ, {'OPENSEARCH_SERVERLESS_GENERATION': 'CLASSIC'}):
+                GraphRAGConfig._opensearch_serverless_generation = None
+                assert GraphRAGConfig.opensearch_serverless_generation is OpenSearchServerlessGeneration.CLASSIC
         finally:
-            GraphRAGConfig._opensearch_serverless_nextgen = original
+            GraphRAGConfig._opensearch_serverless_generation = original
 
-    def test_opensearch_serverless_nextgen_setter_false(self):
-        """Verify opensearch_serverless_nextgen can be forced to False (skip auto-detect, force Classic)."""
-        original = GraphRAGConfig._opensearch_serverless_nextgen
+    def test_opensearch_serverless_generation_setter_nextgen(self):
+        """Setter forces NEXTGEN (skip auto-detect)."""
+        original = GraphRAGConfig._opensearch_serverless_generation
         try:
-            GraphRAGConfig.opensearch_serverless_nextgen = False
-            assert GraphRAGConfig.opensearch_serverless_nextgen is False
+            GraphRAGConfig.opensearch_serverless_generation = OpenSearchServerlessGeneration.NEXTGEN
+            assert GraphRAGConfig.opensearch_serverless_generation is OpenSearchServerlessGeneration.NEXTGEN
         finally:
-            GraphRAGConfig._opensearch_serverless_nextgen = original
+            GraphRAGConfig._opensearch_serverless_generation = original
+
+    def test_opensearch_serverless_generation_setter_accepts_string(self):
+        """Setter coerces a case-insensitive string to the enum."""
+        original = GraphRAGConfig._opensearch_serverless_generation
+        try:
+            GraphRAGConfig.opensearch_serverless_generation = 'classic'
+            assert GraphRAGConfig.opensearch_serverless_generation is OpenSearchServerlessGeneration.CLASSIC
+        finally:
+            GraphRAGConfig._opensearch_serverless_generation = original
+
+    def test_opensearch_serverless_generation_invalid_raises(self):
+        """An unrecognized generation value raises ValueError."""
+        original = GraphRAGConfig._opensearch_serverless_generation
+        try:
+            with pytest.raises(ValueError):
+                GraphRAGConfig.opensearch_serverless_generation = 'quantum'
+        finally:
+            GraphRAGConfig._opensearch_serverless_generation = original
 
     def test_opensearch_serverless_nextgen_compression_defaults_none(self):
         """Verify opensearch_serverless_nextgen_compression defaults to None when unset."""

--- a/lexical-graph/tests/unit/test_config.py
+++ b/lexical-graph/tests/unit/test_config.py
@@ -204,3 +204,54 @@ class TestGraphRAGConfigEnvironmentVariables:
                 assert GraphRAGConfig.build_batch_size == 7
         finally:
             GraphRAGConfig._build_batch_size = original
+
+    def test_opensearch_serverless_nextgen_defaults_false(self):
+        """Verify opensearch_serverless_nextgen defaults to False when unset."""
+        original = GraphRAGConfig._opensearch_serverless_nextgen
+        try:
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop('OPENSEARCH_SERVERLESS_NEXTGEN', None)
+                GraphRAGConfig._opensearch_serverless_nextgen = None
+                assert GraphRAGConfig.opensearch_serverless_nextgen is False
+        finally:
+            GraphRAGConfig._opensearch_serverless_nextgen = original
+
+    def test_opensearch_serverless_nextgen_from_env(self):
+        """Verify opensearch_serverless_nextgen reads from OPENSEARCH_SERVERLESS_NEXTGEN env var."""
+        original = GraphRAGConfig._opensearch_serverless_nextgen
+        try:
+            with patch.dict(os.environ, {'OPENSEARCH_SERVERLESS_NEXTGEN': 'true'}):
+                GraphRAGConfig._opensearch_serverless_nextgen = None
+                assert GraphRAGConfig.opensearch_serverless_nextgen is True
+        finally:
+            GraphRAGConfig._opensearch_serverless_nextgen = original
+
+    def test_opensearch_serverless_nextgen_setter(self):
+        """Verify opensearch_serverless_nextgen can be set directly."""
+        original = GraphRAGConfig._opensearch_serverless_nextgen
+        try:
+            GraphRAGConfig.opensearch_serverless_nextgen = True
+            assert GraphRAGConfig.opensearch_serverless_nextgen is True
+        finally:
+            GraphRAGConfig._opensearch_serverless_nextgen = original
+
+    def test_opensearch_serverless_nextgen_compression_defaults_none(self):
+        """Verify opensearch_serverless_nextgen_compression defaults to None when unset."""
+        original = GraphRAGConfig._opensearch_serverless_nextgen_compression
+        try:
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop('OPENSEARCH_SERVERLESS_NEXTGEN_COMPRESSION', None)
+                GraphRAGConfig._opensearch_serverless_nextgen_compression = None
+                assert GraphRAGConfig.opensearch_serverless_nextgen_compression is None
+        finally:
+            GraphRAGConfig._opensearch_serverless_nextgen_compression = original
+
+    def test_opensearch_serverless_nextgen_compression_from_env(self):
+        """Verify opensearch_serverless_nextgen_compression reads from its env var."""
+        original = GraphRAGConfig._opensearch_serverless_nextgen_compression
+        try:
+            with patch.dict(os.environ, {'OPENSEARCH_SERVERLESS_NEXTGEN_COMPRESSION': '8x'}):
+                GraphRAGConfig._opensearch_serverless_nextgen_compression = None
+                assert GraphRAGConfig.opensearch_serverless_nextgen_compression == '8x'
+        finally:
+            GraphRAGConfig._opensearch_serverless_nextgen_compression = original

--- a/lexical-graph/tests/unit/test_config.py
+++ b/lexical-graph/tests/unit/test_config.py
@@ -205,14 +205,14 @@ class TestGraphRAGConfigEnvironmentVariables:
         finally:
             GraphRAGConfig._build_batch_size = original
 
-    def test_opensearch_serverless_nextgen_defaults_false(self):
-        """Verify opensearch_serverless_nextgen defaults to False when unset."""
+    def test_opensearch_serverless_nextgen_defaults_none_for_auto_detect(self):
+        """Verify opensearch_serverless_nextgen defaults to None (auto-detect) when unset."""
         original = GraphRAGConfig._opensearch_serverless_nextgen
         try:
             with patch.dict(os.environ, {}, clear=False):
                 os.environ.pop('OPENSEARCH_SERVERLESS_NEXTGEN', None)
                 GraphRAGConfig._opensearch_serverless_nextgen = None
-                assert GraphRAGConfig.opensearch_serverless_nextgen is False
+                assert GraphRAGConfig.opensearch_serverless_nextgen is None
         finally:
             GraphRAGConfig._opensearch_serverless_nextgen = original
 
@@ -226,12 +226,21 @@ class TestGraphRAGConfigEnvironmentVariables:
         finally:
             GraphRAGConfig._opensearch_serverless_nextgen = original
 
-    def test_opensearch_serverless_nextgen_setter(self):
-        """Verify opensearch_serverless_nextgen can be set directly."""
+    def test_opensearch_serverless_nextgen_setter_true(self):
+        """Verify opensearch_serverless_nextgen can be forced to True (skip auto-detect, force NextGen)."""
         original = GraphRAGConfig._opensearch_serverless_nextgen
         try:
             GraphRAGConfig.opensearch_serverless_nextgen = True
             assert GraphRAGConfig.opensearch_serverless_nextgen is True
+        finally:
+            GraphRAGConfig._opensearch_serverless_nextgen = original
+
+    def test_opensearch_serverless_nextgen_setter_false(self):
+        """Verify opensearch_serverless_nextgen can be forced to False (skip auto-detect, force Classic)."""
+        original = GraphRAGConfig._opensearch_serverless_nextgen
+        try:
+            GraphRAGConfig.opensearch_serverless_nextgen = False
+            assert GraphRAGConfig.opensearch_serverless_nextgen is False
         finally:
             GraphRAGConfig._opensearch_serverless_nextgen = original
 


### PR DESCRIPTION
## Description

Adds support for AOSS NextGen vector search collections. Classic collections and NextGen collections need different `knn_vector` mappings (NextGen rejects the `engine`/`method` fields Classic requires), so `index_exists()` now auto-detects which one a collection needs: it tries the Classic mapping first, and only if the collection rejects it as NextGen-incompatible, retries once with the NextGen mapping. No new configuration is required. `GraphRAGConfig.opensearch_serverless_nextgen` still exists as an explicit `True`/`False` override for callers who want to skip detection, but it's unset by default.

## Changes

- `GraphRAGConfig.opensearch_serverless_nextgen` is now `Optional[bool]`: `None` (default) auto-detects, `True`/`False` forces one mapping.
- `index_exists()` builds the NextGen mapping (no `method` block, `space_type` at the field level, optional `compression_level`) or the unchanged Classic mapping, via `_build_index_mapping()`.
- Auto-detection retries once with NextGen on the specific rejection error. An explicit `False` override still raises an actionable `ValueError` on that same rejection instead of the previous silent fallback to a no-op client.
- New example CloudFormation template (`graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json`) provisioning a NextGen collection via an explicit `CollectionGroup` with `Generation: NEXTGEN`. `StandbyReplicas` must be `ENABLED` on both the group and the collection — found by deploying and reading the actual `CREATE_FAILED` errors. Wired into the integration-test `EnvTypeMap` as `neptune-db-aoss-nextgen`.
- `test_aoss_nextgen_cfn_template_parity.py` diffs the Classic and NextGen templates field by field, so a future fix to their shared resources can't silently miss one of them.
- `repair_opensearch_vector_store()`'s batch loop now catches the `ValueError` case per index instead of aborting the whole run on the first misconfigured one.

## Problem

Pointing `graphrag-toolkit` at an AOSS NextGen collection fails at index creation because the code unconditionally sends `engine`/`method` parameters NextGen doesn't support.

Related issue (if any): #359

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

35 new unit tests covering both mapping shapes, auto-detection (retry-on-rejection, no-retry on explicit overrides), the error-raising branch's false-positive guards, CFN template parity, and the repair script's per-index handling. Full suite in the touched packages: 175 passed.

Manually verified end-to-end against real AOSS NextGen collections (created and torn down during this work): reproduced the issue's exact error, confirmed auto-detection retries and succeeds against a real NextGen collection with no configuration set, confirmed the created index's mapping is actually NextGen-shaped, and confirmed the explicit-`False` override still raises instead of retrying.

Also ran the existing `lexical.short` integration playbook (24 tests: build, extract, 10+ query variants, checkpointing, FalkorDB, batch fallback, injection safety) against a real Neptune DB + Classic AOSS stack, since auto-detection now sits on the default path for every deployment, not just NextGen ones. Result: 22 passed, 2 skipped (no pgvector store or GPU instance in this env, both expected), 0 failed — no regression on the Classic path.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

## Still open

The integration test script (`aoss_nextgen.py`) and `lexical.nextgen` playbook from the issue are left out, pending a dedicated NextGen test endpoint for CI. The new template is already wired into the `EnvTypeMap` so that's a small follow-up.

Considered proactively detecting generation via `BatchGetCollection`/`BatchGetCollectionGroup` instead of the reactive retry. Went reactive — no new IAM permissions or CFN changes needed, since it only uses OpenSearch calls the client already has permission for.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

