### PR TITLE
fix(lexical-graph): avoid duplicate Neptune Config arguments

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/neptune_graph_stores.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/neptune_graph_stores.py
@@ -146,15 +146,11 @@ def create_config(config:Optional[str]=None):
 
     config_args.setdefault('max_pool_connections', DEFAULT_MAX_POOL_CONNECTIONS)
 
-    return Config(
-        retries={
-            'total_max_attempts': 1,
-            'mode': 'standard'
-        },
-        read_timeout=600,
-        user_agent_appid=f'graphrag-lexical-graph-{toolkit_version}',
-        **config_args
-    )
+    config_args.setdefault('read_timeout', 600)
+    config_args.setdefault('retries', {'total_max_attempts': 1, 'mode': 'standard'})
+    config_args.setdefault('user_agent_appid', f'graphrag-lexical-graph-{toolkit_version}')
+
+    return Config(**config_args)
 
 def create_property_assigment_fn_for_neptune(key:str, value:Any) -> Callable[[str], str]:
     """

--- a/lexical-graph/tests/unit/storage/graph/test_neptune_graph_stores.py
+++ b/lexical-graph/tests/unit/storage/graph/test_neptune_graph_stores.py
@@ -387,6 +387,27 @@ class TestCreateConfig:
         cfg = create_config()
         assert 'graphrag-lexical-graph' in cfg.user_agent_appid
 
+    @pytest.mark.parametrize(
+        "config_key, config_value, cfg_attr",
+        [
+            ('read_timeout', 30, 'read_timeout'),
+            (
+                'retries',
+                {'total_max_attempts': 3, 'mode': 'adaptive'},
+                'retries',
+            ),
+            ('user_agent_appid', 'custom-app', 'user_agent_appid'),
+        ],
+    )
+    def test_user_args_override_default_config_kwargs_without_type_error(
+        self,
+        config_key,
+        config_value,
+        cfg_attr,
+    ):
+        cfg = create_config(_json.dumps({config_key: config_value}))
+        assert getattr(cfg, cfg_attr) == config_value
+
 
 class TestCreatePropertyAssignmentFn:
     def test_non_datetime_key_returns_identity(self):


### PR DESCRIPTION
## Description

Continues #368 by @evanerwee. Their original commit was cherry-picked to preserve authorship, and this PR adds the regression coverage requested in review.

This fixes `create_config()` so user-provided botocore config values override the defaults.

Fixes #361.


## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [x] Existing tests pass (`pytest`)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
