### PR TITLE
[FIX] Integration test fail on boto3/botocore dependencies

### DIFF
--- a/.github/workflows/byokg-rag-tests.yml
+++ b/.github/workflows/byokg-rag-tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Create virtual environment
-        run: uv venv .venv
+        run: uv venv --seed .venv
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Create virtual environment
-        run: uv venv .venv
+        run: uv venv --seed .venv
 
       - name: Install dependencies
         run: |

--- a/byokg-rag/RELEASE.md
+++ b/byokg-rag/RELEASE.md
@@ -7,15 +7,19 @@ This document describes the release process for the graphrag-toolkit components.
 - Maintain separate tags and workflows for the `graphrag-lexical-graph` and `graphrag-byokg` projects, allowing each to be released independently.
 - Ensure each release is validated before it is published.
 
-## Lexical Graph Release Process
+## BYOKG RAG Release Process
 
-1. Create a release candidate tag for the pre-release (e.g., `graphrag-lexical-graph/vX.Y.Z.devN`).
+1. Create a release candidate tag for the pre-release (e.g., `graphrag-byokg/vX.Y.Z.devN`).
    NOTE: the project version is hardcoded in the [pyproject.toml](./pyproject.toml).  Ensure that the version matches.  
 2. Create a pre-release in GitHub using the release candidate tag, marking it as a pre-release.
 3. Test the pre-release artefacts via CI workflow and manual testing.
-4. Create the final release tag (e.g., `graphrag-lexical-graph/vX.Y.Z`).
+4. Create the final release tag (e.g., `graphrag-byokg/vX.Y.Z`).
 5. Update the GitHub release to remove the pre-release label, promoting it to a full release.
 6. Test the final release from PyPI.
+
+TODO: 
+- filter changelog to show differences between graphrag-byokg/vX.Y.Z releases
+- filter out any differences not related to byokg (ie, lexical-graph changes)
 
 ### Step 1: Create a Pre-release Tag
 
@@ -24,23 +28,22 @@ All tags are created from the `main` branch, which is the ongoing development br
 ```bash
 git checkout main
 git pull origin main
-git tag graphrag-lexical-graph/vX.Y.Z.devN
-git push origin graphrag-lexical-graph/vX.Y.Z.devN
+git tag graphrag-byokg/vX.Y.Z.devN
+git push origin graphrag-byokg/vX.Y.Z.devN
 ```
 
-For example, `graphrag-lexical-graph/v1.2.0.dev0` for the first dev pre-release for version `1.2.0`.
+For example, `graphrag-byokg/v1.2.0.dev0` for the first dev pre-release for version `1.2.0`.
 
-Note: `graphrag-lexical-graph` is used to create a lexical graph release.  
+Note: `graphrag-byokg` is used to create a BYOKG RAG release.  
 
 ### Step 2: Create a GitHub Pre-release
 
 Create a new release in GitHub using the pre-release tag. Mark it as a pre-release.
 
-This triggers the [Lexical Graph Pre-Release](/.github/workflows/lexical-graph-prerelease.yml) workflow, which builds the package and attaches the following artefacts to the release:
+This triggers the [BYOKG-RAG Pre-Release](/.github/workflows/byokg-rag-prerelease.yml) workflow, which builds the package and attaches the following artefacts to the release:
 
 - Python distribution files (wheel and sdist tarball)
-- `lexical-graph-examples` notebook zip (versioned and latest)
-- `lexical-graph-hybrid-dev-examples` notebook zip (versioned and latest) 
+- `byokg-notebooks` notebook zip (versioned and latest)
 
 ### Step 3: Test the Pre-release Artefacts
 
@@ -49,29 +52,29 @@ This triggers the [Lexical Graph Pre-Release](/.github/workflows/lexical-graph-p
 To install the pre-release wheel from the GitHub release:
 
 ```bash
-pip install https://github.com/awslabs/graphrag-toolkit/releases/download/graphrag-lexical-graph%2FvX.Y.Z.devN/graphrag_lexical_graph-X.Y.Z.devN-py3-none-any.whl
+pip install https://github.com/awslabs/graphrag-toolkit/releases/download/graphrag-byokg%2FvX.Y.Z.devN/graphrag_toolkit_byokg_rag-X.Y.Z.devN-py3-none-any.whl
 ```
 
 For example, to install `v1.2.0.dev1`:
 
 ```bash
-pip install https://github.com/awslabs/graphrag-toolkit/releases/download/graphrag-lexical-graph%2Fv1.2.0.dev1/graphrag_lexical_graph-1.2.0.dev0-py3-none-any.whl
+pip install https://github.com/awslabs/graphrag-toolkit/releases/download/graphrag-byokg%2Fv1.2.0.dev1/graphrag_toolkit_byokg_rag-1.2.0.dev0-py3-none-any.whl
 ```
 
 #### To run the unit tests locally:
 
 ```bash
-cd lexical-graph
+cd byokg-rag
 PYTHONPATH=src python -m pytest -v tests/
 ```
 
 #### To run integration tests manually:
 
-The wheel artefacts should be tested against a well known release test suite to look for regressions.  Release managers should run the test suite against the "Short" and "Versioning" test suites. To run: 
+The wheel artefacts should be tested against a well known release test suite to look for regressions.  Release managers should run the test suite against the "Short" test suite. To run: 
 
 ```bash
 cd integration-tests
-sh build-tests.sh --test-file lexical.short,lexical.versioning --lexical-graph-wheel /path/to/graphrag_lexical_graph-X.Y.Z-py3-none-any.whl --toolkit-dir /path/to/graphrag-toolkit
+sh build-tests.sh --test-file byokg.short --byokg-rag-wheel /path/to/graphrag_toolkit_byokg_rag-X.Y.Z-py3-none-any.whl --toolkit-dir /path/to/graphrag-toolkit
 ```
 
 #### Attach integration test results to the github-release
@@ -92,8 +95,8 @@ Once the pre-release has been validated, create the full release tag (without th
 ```bash
 git checkout main
 git pull origin main
-git tag graphrag-lexical-graph/vX.Y.Z
-git push origin graphrag-lexical-graph/vX.Y.Z
+git tag graphrag-byokg/vX.Y.Z
+git push origin graphrag-byokg/vX.Y.Z
 ```
 
 ### Step 5: Promote to Full Release
@@ -105,7 +108,7 @@ Update the GitHub release to remove the pre-release label, promoting it to a ful
 Install the published package from PyPI:
 
 ```bash
-pip install graphrag-lexical-graph==X.Y.Z
+pip install graphrag-toolkit-byokg-rag==X.Y.Z
 ```
 
 Sanity checks should be completed against the PyPI release artefacts to verify the package installs and functions correctly.

--- a/byokg-rag/tests/unit/test_integ_dependency_compatibility.py
+++ b/byokg-rag/tests/unit/test_integ_dependency_compatibility.py
@@ -18,30 +18,66 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 INTEG_REQUIREMENTS = PROJECT_ROOT / "integration-tests" / "requirements-integ-test.txt"
 
-LIBRARY_REQUIREMENTS = (
+BYOKG_RAG_REQUIREMENTS = (
     PROJECT_ROOT / "byokg-rag" / "src" / "graphrag_toolkit"
     / "byokg_rag" / "requirements.txt"
 )
 
+LEXICAL_GRAPH_REQUIREMENTS = (
+    PROJECT_ROOT / "lexical-graph" / "src" / "graphrag_toolkit"
+    / "lexical_graph" / "requirements.txt"
+)
+
+
+def _filter_requirements(path):
+    """Read a requirements file, stripping pip options like --only-binary."""
+    lines = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("--") or not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    return lines
+
 
 @pytest.fixture(scope="module")
 def resolved_versions():
-    """Dry-run pip install to resolve final versions for all dependencies."""
+    """Dry-run pip install to resolve final versions for all dependencies.
+
+    Mirrors the single-pass install in run_test_suite.sh which resolves
+    all three requirements files together.
+    """
     if not INTEG_REQUIREMENTS.exists():
         pytest.skip(f"Integration requirements not found: {INTEG_REQUIREMENTS}")
 
-    req_files = ["-r", str(INTEG_REQUIREMENTS)]
-    if LIBRARY_REQUIREMENTS.exists():
-        req_files += ["-r", str(LIBRARY_REQUIREMENTS)]
+    packages = _filter_requirements(INTEG_REQUIREMENTS)
+    if BYOKG_RAG_REQUIREMENTS.exists():
+        packages += _filter_requirements(BYOKG_RAG_REQUIREMENTS)
+    if LEXICAL_GRAPH_REQUIREMENTS.exists():
+        packages += _filter_requirements(LEXICAL_GRAPH_REQUIREMENTS)
 
-    result = subprocess.run(
-        [
-            sys.executable, "-m", "pip", "install",
-            "--dry-run", "--report", "-",
-        ] + req_files,
-        capture_output=True,
-        text=True,
-    )
+    import tempfile
+    import json
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("\n".join(packages))
+        tmp_req = f.name
+
+    tmp_report = tmp_req + ".json"
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "pip", "install",
+                "--dry-run", "--quiet", "--ignore-installed",
+                "--report", tmp_report,
+                "-r", tmp_req,
+            ],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(tmp_req).unlink(missing_ok=True)
 
     if result.returncode != 0:
         pytest.fail(
@@ -49,8 +85,8 @@ def resolved_versions():
             f"{result.stderr}"
         )
 
-    import json
-    report = json.loads(result.stdout)
+    report = json.loads(Path(tmp_report).read_text())
+    Path(tmp_report).unlink(missing_ok=True)
 
     versions = {}
     for item in report.get("install", []):

--- a/byokg-rag/tests/unit/test_integ_dependency_compatibility.py
+++ b/byokg-rag/tests/unit/test_integ_dependency_compatibility.py
@@ -1,0 +1,81 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify that installed dependencies are compatible.
+
+These tests catch version mismatches (e.g. boto3/botocore) that arise when
+transitive dependencies (like aiobotocore via s3fs) constrain one package
+without updating its paired counterpart.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+INTEG_REQUIREMENTS = PROJECT_ROOT / "integration-tests" / "requirements-integ-test.txt"
+
+LIBRARY_REQUIREMENTS = (
+    PROJECT_ROOT / "byokg-rag" / "src" / "graphrag_toolkit"
+    / "byokg_rag" / "requirements.txt"
+)
+
+
+@pytest.fixture(scope="module")
+def resolved_versions():
+    """Dry-run pip install to resolve final versions for all dependencies."""
+    if not INTEG_REQUIREMENTS.exists():
+        pytest.skip(f"Integration requirements not found: {INTEG_REQUIREMENTS}")
+
+    req_files = ["-r", str(INTEG_REQUIREMENTS)]
+    if LIBRARY_REQUIREMENTS.exists():
+        req_files += ["-r", str(LIBRARY_REQUIREMENTS)]
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pip", "install",
+            "--dry-run", "--report", "-",
+        ] + req_files,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        pytest.fail(
+            f"pip dependency resolution failed — dependencies are incompatible:\n"
+            f"{result.stderr}"
+        )
+
+    import json
+    report = json.loads(result.stdout)
+
+    versions = {}
+    for item in report.get("install", []):
+        metadata = item.get("metadata", {})
+        name = metadata.get("name", "").lower()
+        version = metadata.get("version", "")
+        if name and version:
+            versions[name] = version
+
+    return versions
+
+
+class TestIntegDependencyCompatibility:
+    """Verify integration test dependencies resolve without conflicts."""
+
+    def test_boto3_botocore_version_alignment(self, resolved_versions):
+        """boto3 and botocore must be from the same release."""
+        boto3_ver = resolved_versions.get("boto3")
+        botocore_ver = resolved_versions.get("botocore")
+
+        if boto3_ver is None or botocore_ver is None:
+            pytest.skip("boto3/botocore not found in environment")
+
+        assert boto3_ver == botocore_ver, (
+            f"boto3=={boto3_ver} and botocore=={botocore_ver} are mismatched. "
+            f"These must be from the same release to avoid ImportError on "
+            f"cross-package symbol references."
+        )

--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -273,6 +273,7 @@ fi
 
 cp -r $GRAPHRAG_TOOLKIT_DIR/lexical-graph-contrib/* graphrag-toolkit
 cp -r $GRAPHRAG_TOOLKIT_DIR/byokg-rag/src/* graphrag-toolkit
+cp $GRAPHRAG_TOOLKIT_DIR/integration-tests/requirements-integ-test.txt graphrag-toolkit/
 cp -r $GRAPHRAG_TOOLKIT_DIR/examples/lexical-graph/notebooks/* lexical-graph-examples
 cp -r $GRAPHRAG_TOOLKIT_DIR/examples/byokg-rag/* lexical-graph-examples
 cp -r ./../test-scripts/* lexical-graph-examples

--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -82,6 +82,7 @@ if [[ "$#" -gt 0 ]]; then
     echo "  --embeddings-model <Embeddings model id>"
     echo "  --embeddings-dimensions <Embeddings dimensions>"
     echo "  --lexical-graph-wheel <path to local .whl file to upload to S3 and install>"
+    echo "  --byokg-rag-wheel <path to local .whl file to upload to S3 and install>"
     echo "  --ssh-cidr <SSH CIDR block (default: auto-detected IP/32, use 0.0.0.0/0 for open access)>"
     echo "  --benchmark-data-dir <local directory containing benchmark data to upload>"
     echo "  --benchmark-data-s3-uri <S3 URI for benchmark data (synced at runtime instead of uploading)>"
@@ -155,6 +156,7 @@ while [[ "$#" -gt 0 ]]; do
 				--lexical-graph-install) LEXICAL_GRAPH_INSTALL_URI="$2"; shift ;;
 				--lexical-graph-wheel) LEXICAL_GRAPH_WHEEL="$2"; shift ;;
 				--byokg-rag-install) BYOKG_RAG_INSTALL_URI="$2"; shift ;;
+				--byokg-rag-wheel) BYOKG_RAG_WHEEL="$2"; shift ;;
         --bucket) BUCKET_NAME="$2"; shift ;;
         --region) REGION_NAME="$2"; shift ;;
 				--env-type) ENV_TYPE="$2"; shift ;;
@@ -264,6 +266,25 @@ if [[ "$LEXICAL_GRAPH_WHEEL" ]]; then
     echo "Copying wheel $WHEEL_FILENAME into packages for S3 upload..."
     cp "$LEXICAL_GRAPH_WHEEL" graphrag/assets/packages/"$WHEEL_FILENAME"
     LEXICAL_GRAPH_INSTALL_URI="$S3_ROOT/packages/$WHEEL_FILENAME"
+fi
+
+if [[ "$BYOKG_RAG_WHEEL" ]]; then
+    if [[ "$BYOKG_RAG_INSTALL_URI" ]]; then
+        echo "ERROR: --byokg-rag-wheel and --byokg-rag-install are mutually exclusive."
+        exit 1
+    fi
+    if [[ ! -f "$BYOKG_RAG_WHEEL" ]]; then
+        echo "ERROR: Wheel file not found: $BYOKG_RAG_WHEEL"
+        exit 1
+    fi
+    if [[ "$BYOKG_RAG_WHEEL" != *.whl ]]; then
+        echo "ERROR: --byokg-rag-wheel expects a .whl file, got: $BYOKG_RAG_WHEEL"
+        exit 1
+    fi
+    WHEEL_FILENAME=$(basename "$BYOKG_RAG_WHEEL")
+    echo "Copying wheel $WHEEL_FILENAME into packages for S3 upload..."
+    cp "$BYOKG_RAG_WHEEL" graphrag/assets/packages/"$WHEEL_FILENAME"
+    BYOKG_RAG_INSTALL_URI="$S3_ROOT/packages/$WHEEL_FILENAME"
 fi
 
 if [[ -z "$LEXICAL_GRAPH_INSTALL_URI" ]]; then
@@ -388,6 +409,7 @@ echo ""
 echo "----------------------------------------------------"
 echo "GRAPHRAG_TOOLKIT_DIR     : $GRAPHRAG_TOOLKIT_DIR"
 echo "LEXICAL_GRAPH_WHEEL      : $LEXICAL_GRAPH_WHEEL"
+echo "BYOKG_RAG_WHEEL          : $BYOKG_RAG_WHEEL"
 echo "LEXICAL_GRAPH_INSTALL_URI: $LEXICAL_GRAPH_INSTALL_URI"
 echo "BYOKG_RAG_INSTALL_URI    : $BYOKG_RAG_INSTALL_URI"
 echo "ENV_TYPE                 : $ENV_TYPE"

--- a/integration-tests/requirements-integ-test.txt
+++ b/integration-tests/requirements-integ-test.txt
@@ -8,3 +8,4 @@ psycopg2-binary>=2.9.0
 pgvector>=0.2.0
 sentence-transformers>=2.2.0
 torch>=2.0.0
+aiobotocore>=2.5.0

--- a/integration-tests/requirements-integ-test.txt
+++ b/integration-tests/requirements-integ-test.txt
@@ -1,0 +1,10 @@
+neo4j>=5.0.0
+opensearch-py>=2.4.0
+llama-index-vector-stores-opensearch>=0.1.0
+llama-index-readers-web>=0.1.0
+llama-index-readers-file>=0.1.0
+llama-index-readers-s3>=0.1.0
+psycopg2-binary>=2.9.0
+pgvector>=0.2.0
+sentence-transformers>=2.2.0
+torch>=2.0.0

--- a/integration-tests/requirements-integ-test.txt
+++ b/integration-tests/requirements-integ-test.txt
@@ -1,9 +1,9 @@
 neo4j>=5.0.0
-opensearch-py>=2.4.0
-llama-index-vector-stores-opensearch>=0.1.0
-llama-index-readers-web>=0.1.0
-llama-index-readers-file>=0.1.0
-llama-index-readers-s3>=0.1.0
+opensearch-py>=3.0.0
+llama-index-vector-stores-opensearch>=1.0.0
+llama-index-readers-web>=0.3.0
+llama-index-readers-file>=0.4.0
+llama-index-readers-s3>=0.4.0
 psycopg2-binary>=2.9.0
 pgvector>=0.2.0
 sentence-transformers>=2.2.0

--- a/integration-tests/test-scripts/on-start.sh
+++ b/integration-tests/test-scripts/on-start.sh
@@ -14,25 +14,16 @@ rm -rf graphrag_toolkit
 
 pip install https://github.com/awslabs/graphrag-toolkit/archive/refs/tags/v3.12.0.zip#subdirectory=lexical-graph
 
-pip install opensearch-py llama-index-vector-stores-opensearch
-
-pip install llama-index-readers-web
-pip install llama-index-readers-file
-
-pip install torch sentence_transformers
-#pip install numpy==1.26.1
+echo "Installing all dependencies in a single pass for consistent resolution"
+pip install \
+    opensearch-py \
+    llama-index-vector-stores-opensearch \
+    llama-index-readers-web \
+    llama-index-readers-file \
+    torch \
+    sentence_transformers
 
 python -m spacy download en_core_web_sm
-
-# Ensure boto3 and botocore are from the same release. Other packages
-# (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
-# leaving an incompatible pair that crashes on import.
-BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
-BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
-if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
-    echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Reinstalling compatible pair."
-    pip install --force-reinstall "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
-fi
 
 source /home/ec2-user/anaconda3/bin/deactivate
 

--- a/integration-tests/test-scripts/on-start.sh
+++ b/integration-tests/test-scripts/on-start.sh
@@ -27,14 +27,11 @@ python -m spacy download en_core_web_sm
 # Ensure boto3 and botocore are from the same release. Other packages
 # (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
 # leaving an incompatible pair that crashes on import.
-# boto3 declares botocore as a dependency with an exact pin (e.g. boto3==1.35.0
-# requires botocore==1.35.0), so pinning botocore and using >= for boto3 lets
-# pip resolve the matching boto3 release automatically.
 BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
 BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
 if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
     echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Reinstalling compatible pair."
-    pip install --force-reinstall --no-deps "boto3>=$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
+    pip install --force-reinstall "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
 fi
 
 source /home/ec2-user/anaconda3/bin/deactivate

--- a/integration-tests/test-scripts/on-start.sh
+++ b/integration-tests/test-scripts/on-start.sh
@@ -14,16 +14,20 @@ rm -rf graphrag_toolkit
 
 pip install https://github.com/awslabs/graphrag-toolkit/archive/refs/tags/v3.12.0.zip#subdirectory=lexical-graph
 
-echo "Installing all dependencies in a single pass for consistent resolution"
-pip install \
-    opensearch-py \
-    llama-index-vector-stores-opensearch \
-    llama-index-readers-web \
-    llama-index-readers-file \
-    torch \
-    sentence_transformers
+pip install opensearch-py llama-index-vector-stores-opensearch
+
+pip install llama-index-readers-web
+pip install llama-index-readers-file
+
+pip install torch sentence_transformers
+#pip install numpy==1.26.1
 
 python -m spacy download en_core_web_sm
+
+# Pin boto3/botocore/aiobotocore to compatible versions. aiobotocore constrains
+# botocore to a narrow range; without pinning, other installs can pull a boto3
+# that imports symbols missing from the allowed botocore (e.g. DocumentModifiedShape).
+pip install boto3==1.43.0 botocore==1.43.0 aiobotocore==3.7.0
 
 source /home/ec2-user/anaconda3/bin/deactivate
 

--- a/integration-tests/test-scripts/on-start.sh
+++ b/integration-tests/test-scripts/on-start.sh
@@ -27,11 +27,14 @@ python -m spacy download en_core_web_sm
 # Ensure boto3 and botocore are from the same release. Other packages
 # (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
 # leaving an incompatible pair that crashes on import.
+# boto3 declares botocore as a dependency with an exact pin (e.g. boto3==1.35.0
+# requires botocore==1.35.0), so pinning botocore and using >= for boto3 lets
+# pip resolve the matching boto3 release automatically.
 BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
 BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
 if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
-    echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Aligning boto3 to botocore version."
-    pip install "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
+    echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Reinstalling compatible pair."
+    pip install --force-reinstall --no-deps "boto3>=$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
 fi
 
 source /home/ec2-user/anaconda3/bin/deactivate

--- a/integration-tests/test-scripts/on-start.sh
+++ b/integration-tests/test-scripts/on-start.sh
@@ -24,10 +24,15 @@ pip install torch sentence_transformers
 
 python -m spacy download en_core_web_sm
 
-# Pin boto3/botocore/aiobotocore to compatible versions. aiobotocore constrains
-# botocore to a narrow range; without pinning, other installs can pull a boto3
-# that imports symbols missing from the allowed botocore (e.g. DocumentModifiedShape).
-pip install boto3==1.43.0 botocore==1.43.0 aiobotocore==3.7.0
+# Ensure boto3 and botocore are from the same release. Other packages
+# (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
+# leaving an incompatible pair that crashes on import.
+BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
+BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
+if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
+    echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Aligning boto3 to botocore version."
+    pip install "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
+fi
 
 source /home/ec2-user/anaconda3/bin/deactivate
 

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -51,7 +51,18 @@ if [[ "$DO_SETUP" = true ]]; then
 
     if [[ "$BYOKG_RAG_INSTALL_URI" ]]; then
         echo "Installing byokg_rag from $BYOKG_RAG_INSTALL_URI"
-        pip install $BYOKG_RAG_INSTALL_URI
+        if [[ "$BYOKG_RAG_INSTALL_URI" == s3://* && "$BYOKG_RAG_INSTALL_URI" == *.whl ]]; then
+            WHEEL_FILENAME=$(basename "$BYOKG_RAG_INSTALL_URI")
+            echo "Downloading wheel from S3: $BYOKG_RAG_INSTALL_URI"
+            if ! aws s3 cp "$BYOKG_RAG_INSTALL_URI" "./$WHEEL_FILENAME"; then
+                echo "ERROR: Failed to download wheel from S3: $BYOKG_RAG_INSTALL_URI"
+                exit 1
+            fi
+            pip install "./$WHEEL_FILENAME"
+            rm -f "./$WHEEL_FILENAME"
+        else
+            pip install $BYOKG_RAG_INSTALL_URI
+        fi
     fi
 
     if [[ "$LEXICAL_GRAPH_INSTALL_URI" ]]; then
@@ -74,7 +85,7 @@ if [[ "$DO_SETUP" = true ]]; then
     pip install \
         -r graphrag_toolkit/byokg_rag/requirements.txt \
         -r graphrag_toolkit/lexical_graph/requirements.txt \
-        -r graphrag_toolkit/requirements-integ-test.txt
+        -r requirements-integ-test.txt
 
     #if [[ "$USE_GPU" == "True" ]]; then
     #    pip install --upgrade cmake

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -99,6 +99,16 @@ if [[ "$DO_SETUP" = true ]]; then
     
     python -m spacy download en_core_web_sm
     
+    # Ensure boto3 and botocore are from the same release. Other packages
+    # (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
+    # leaving an incompatible pair that crashes on import.
+    BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
+    BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
+    if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
+        echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Aligning boto3 to botocore version."
+        pip install "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
+    fi
+
     python --version
     pip list
 fi

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -82,9 +82,11 @@ if [[ "$DO_SETUP" = true ]]; then
     fi
 
     echo "Installing all dependencies in a single pass for consistent resolution"
+    grep -v '^--' graphrag_toolkit/byokg_rag/requirements.txt > /tmp/byokg_rag_deps.txt
+    grep -v '^--' graphrag_toolkit/lexical_graph/requirements.txt > /tmp/lexical_graph_deps.txt
     pip install \
-        -r graphrag_toolkit/byokg_rag/requirements.txt \
-        -r graphrag_toolkit/lexical_graph/requirements.txt \
+        -r /tmp/byokg_rag_deps.txt \
+        -r /tmp/lexical_graph_deps.txt \
         -r requirements-integ-test.txt
 
     #if [[ "$USE_GPU" == "True" ]]; then

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -54,9 +54,6 @@ if [[ "$DO_SETUP" = true ]]; then
         pip install $BYOKG_RAG_INSTALL_URI
     fi
 
-    echo "Installing byokg_rag dependencies"
-    pip install -r graphrag_toolkit/byokg_rag/requirements.txt
-
     if [[ "$LEXICAL_GRAPH_INSTALL_URI" ]]; then
         echo "Installing lexical graph from $LEXICAL_GRAPH_INSTALL_URI"
         if [[ "$LEXICAL_GRAPH_INSTALL_URI" == s3://* && "$LEXICAL_GRAPH_INSTALL_URI" == *.whl ]]; then
@@ -71,38 +68,28 @@ if [[ "$DO_SETUP" = true ]]; then
         else
             pip install $LEXICAL_GRAPH_INSTALL_URI
         fi
-    else
-        echo "Installing lexical graph from local install"
-        pip install -r graphrag_toolkit/lexical_graph/requirements.txt
     fi
-    
-    echo "Installing integration test dependencies"
-    pip install -r graphrag_toolkit/requirements-integ-test.txt
-    
+
+    echo "Installing all dependencies in a single pass for consistent resolution"
+    pip install \
+        -r graphrag_toolkit/byokg_rag/requirements.txt \
+        -r graphrag_toolkit/lexical_graph/requirements.txt \
+        -r graphrag_toolkit/requirements-integ-test.txt
+
     #if [[ "$USE_GPU" == "True" ]]; then
-    #    pip install --upgrade cmake 
+    #    pip install --upgrade cmake
     #    pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre pyarrow
     #    pip install torch FlagEmbedding
     #fi
-    
+
     pushd falkordb
         pip install .
     popd
 
     mkdir test-results
     mkdir test-logs
-    
+
     python -m spacy download en_core_web_sm
-    
-    # Ensure boto3 and botocore are from the same release. Other packages
-    # (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
-    # leaving an incompatible pair that crashes on import.
-    BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
-    BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
-    if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
-        echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Reinstalling compatible pair."
-        pip install --force-reinstall "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
-    fi
 
     python --version
     pip list

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -97,14 +97,11 @@ if [[ "$DO_SETUP" = true ]]; then
     # Ensure boto3 and botocore are from the same release. Other packages
     # (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
     # leaving an incompatible pair that crashes on import.
-    # boto3 declares botocore as a dependency with an exact pin (e.g. boto3==1.35.0
-    # requires botocore==1.35.0), so pinning botocore and using >= for boto3 lets
-    # pip resolve the matching boto3 release automatically.
     BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
     BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
     if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
         echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Reinstalling compatible pair."
-        pip install --force-reinstall --no-deps "boto3>=$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
+        pip install --force-reinstall "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
     fi
 
     python --version

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -76,13 +76,8 @@ if [[ "$DO_SETUP" = true ]]; then
         pip install -r graphrag_toolkit/lexical_graph/requirements.txt
     fi
     
-    pip install opensearch-py llama-index-vector-stores-opensearch
-    pip install psycopg2-binary pgvector
-    pip install neo4j
-    pip install llama-index-readers-web
-    pip install llama-index-readers-file
-    pip install llama-index-readers-s3
-    pip install torch sentence_transformers
+    echo "Installing integration test dependencies"
+    pip install -r graphrag_toolkit/requirements-integ-test.txt
     
     #if [[ "$USE_GPU" == "True" ]]; then
     #    pip install --upgrade cmake 
@@ -102,11 +97,14 @@ if [[ "$DO_SETUP" = true ]]; then
     # Ensure boto3 and botocore are from the same release. Other packages
     # (e.g. aiobotocore via s3fs) can downgrade botocore without touching boto3,
     # leaving an incompatible pair that crashes on import.
+    # boto3 declares botocore as a dependency with an exact pin (e.g. boto3==1.35.0
+    # requires botocore==1.35.0), so pinning botocore and using >= for boto3 lets
+    # pip resolve the matching boto3 release automatically.
     BOTO3_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('boto3'))")
     BOTOCORE_VER=$(python -c "import importlib.metadata; print(importlib.metadata.version('botocore'))")
     if [[ "$BOTO3_VER" != "$BOTOCORE_VER" ]]; then
-        echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Aligning boto3 to botocore version."
-        pip install "boto3==$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
+        echo "WARNING: boto3==$BOTO3_VER and botocore==$BOTOCORE_VER are mismatched. Reinstalling compatible pair."
+        pip install --force-reinstall --no-deps "boto3>=$BOTOCORE_VER" "botocore==$BOTOCORE_VER"
     fi
 
     python --version

--- a/lexical-graph/tests/unit/test_integ_dependency_compatibility.py
+++ b/lexical-graph/tests/unit/test_integ_dependency_compatibility.py
@@ -18,30 +18,66 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 INTEG_REQUIREMENTS = PROJECT_ROOT / "integration-tests" / "requirements-integ-test.txt"
 
-LIBRARY_REQUIREMENTS = (
+BYOKG_RAG_REQUIREMENTS = (
+    PROJECT_ROOT / "byokg-rag" / "src" / "graphrag_toolkit"
+    / "byokg_rag" / "requirements.txt"
+)
+
+LEXICAL_GRAPH_REQUIREMENTS = (
     PROJECT_ROOT / "lexical-graph" / "src" / "graphrag_toolkit"
     / "lexical_graph" / "requirements.txt"
 )
 
 
+def _filter_requirements(path):
+    """Read a requirements file, stripping pip options like --only-binary."""
+    lines = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("--") or not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    return lines
+
+
 @pytest.fixture(scope="module")
 def resolved_versions():
-    """Dry-run pip install to resolve final versions for all dependencies."""
+    """Dry-run pip install to resolve final versions for all dependencies.
+
+    Mirrors the single-pass install in run_test_suite.sh which resolves
+    all three requirements files together.
+    """
     if not INTEG_REQUIREMENTS.exists():
         pytest.skip(f"Integration requirements not found: {INTEG_REQUIREMENTS}")
 
-    req_files = ["-r", str(INTEG_REQUIREMENTS)]
-    if LIBRARY_REQUIREMENTS.exists():
-        req_files += ["-r", str(LIBRARY_REQUIREMENTS)]
+    packages = _filter_requirements(INTEG_REQUIREMENTS)
+    if BYOKG_RAG_REQUIREMENTS.exists():
+        packages += _filter_requirements(BYOKG_RAG_REQUIREMENTS)
+    if LEXICAL_GRAPH_REQUIREMENTS.exists():
+        packages += _filter_requirements(LEXICAL_GRAPH_REQUIREMENTS)
 
-    result = subprocess.run(
-        [
-            sys.executable, "-m", "pip", "install",
-            "--dry-run", "--report", "-",
-        ] + req_files,
-        capture_output=True,
-        text=True,
-    )
+    import tempfile
+    import json
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("\n".join(packages))
+        tmp_req = f.name
+
+    tmp_report = tmp_req + ".json"
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "pip", "install",
+                "--dry-run", "--quiet", "--ignore-installed",
+                "--report", tmp_report,
+                "-r", tmp_req,
+            ],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(tmp_req).unlink(missing_ok=True)
 
     if result.returncode != 0:
         pytest.fail(
@@ -49,8 +85,8 @@ def resolved_versions():
             f"{result.stderr}"
         )
 
-    import json
-    report = json.loads(result.stdout)
+    report = json.loads(Path(tmp_report).read_text())
+    Path(tmp_report).unlink(missing_ok=True)
 
     versions = {}
     for item in report.get("install", []):

--- a/lexical-graph/tests/unit/test_integ_dependency_compatibility.py
+++ b/lexical-graph/tests/unit/test_integ_dependency_compatibility.py
@@ -1,0 +1,81 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify that installed dependencies are compatible.
+
+These tests catch version mismatches (e.g. boto3/botocore) that arise when
+transitive dependencies (like aiobotocore via s3fs) constrain one package
+without updating its paired counterpart.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+INTEG_REQUIREMENTS = PROJECT_ROOT / "integration-tests" / "requirements-integ-test.txt"
+
+LIBRARY_REQUIREMENTS = (
+    PROJECT_ROOT / "lexical-graph" / "src" / "graphrag_toolkit"
+    / "lexical_graph" / "requirements.txt"
+)
+
+
+@pytest.fixture(scope="module")
+def resolved_versions():
+    """Dry-run pip install to resolve final versions for all dependencies."""
+    if not INTEG_REQUIREMENTS.exists():
+        pytest.skip(f"Integration requirements not found: {INTEG_REQUIREMENTS}")
+
+    req_files = ["-r", str(INTEG_REQUIREMENTS)]
+    if LIBRARY_REQUIREMENTS.exists():
+        req_files += ["-r", str(LIBRARY_REQUIREMENTS)]
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pip", "install",
+            "--dry-run", "--report", "-",
+        ] + req_files,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        pytest.fail(
+            f"pip dependency resolution failed — dependencies are incompatible:\n"
+            f"{result.stderr}"
+        )
+
+    import json
+    report = json.loads(result.stdout)
+
+    versions = {}
+    for item in report.get("install", []):
+        metadata = item.get("metadata", {})
+        name = metadata.get("name", "").lower()
+        version = metadata.get("version", "")
+        if name and version:
+            versions[name] = version
+
+    return versions
+
+
+class TestIntegDependencyCompatibility:
+    """Verify integration test dependencies resolve without conflicts."""
+
+    def test_boto3_botocore_version_alignment(self, resolved_versions):
+        """boto3 and botocore must be from the same release."""
+        boto3_ver = resolved_versions.get("boto3")
+        botocore_ver = resolved_versions.get("botocore")
+
+        if boto3_ver is None or botocore_ver is None:
+            pytest.skip("boto3/botocore not found in environment")
+
+        assert boto3_ver == botocore_ver, (
+            f"boto3=={boto3_ver} and botocore=={botocore_ver} are mismatched. "
+            f"These must be from the same release to avoid ImportError on "
+            f"cross-package symbol references."
+        )


### PR DESCRIPTION
## Description

[FIX] Integration tests are brittle and will fail if there is a version dependency mismatch between boto3 and botocore.  Unfortunately, we are bringing in a lot of dependencies for integration tests that potentially cause this mismatch. 

## Changes

<!-- List the key changes made -->

- Use a requirement.txt file to install test dependencies. 
- Add unit tests to check version mismatches to find errors early. 

## Problem

Related issue (if any): N/A

## Testing

<!-- How was this tested? -->

- [X] Unit tests added/updated
- [X] Integration tests added (as appropriate)
- [X] Existing tests pass (`pytest`)
- [X] Tested manually (describe below)

## Checklist

- [X] Code follows existing style and conventions
- [X] License headers present on new files
- [X] Documentation updated (if applicable)
- [X] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
