### PR TITLE
fix: return empty string for empty filter list in parse_metadata_filters_recursive

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
@@ -308,6 +308,9 @@ def parse_metadata_filters_recursive(metadata_filters:MetadataFilters) -> str:
         else:
             raise ValueError(f'Invalid metadata filter type: {type(metadata_filter)}')
         
+    if not filter_strs:
+        return ''
+
     if metadata_filters.condition == FilterCondition.NOT:
         return f"(NOT {' '.join(filter_strs)})"
     elif metadata_filters.condition == FilterCondition.AND or metadata_filters.condition == FilterCondition.OR:

--- a/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
+++ b/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
@@ -329,3 +329,30 @@ class TestFilterConfigToOpencypherFilters:
         )
         result = filter_config_to_opencypher_filters(config)
         assert "source.`category` = 'tech'" in result
+
+
+    def test_empty_filters_list_returns_empty_string(self):
+        """Regression test for issue #408.
+        
+        When MetadataFilters has an empty filters list, parse_metadata_filters_recursive
+        should return '' (empty string) instead of '()' (empty parentheses).
+        
+        Without this fix, the VersionManager generates invalid Cypher:
+          WHERE () AND coalesce(...)
+        which Neptune Database rejects with MalformedQueryException.
+        """
+        filters = MetadataFilters(
+            filters=[],
+            condition=FilterCondition.AND,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert result == ''
+
+    def test_empty_filters_list_or_condition_returns_empty_string(self):
+        """Same as above but with OR condition."""
+        filters = MetadataFilters(
+            filters=[],
+            condition=FilterCondition.OR,
+        )
+        result = parse_metadata_filters_recursive(filters)
+        assert result == ''


### PR DESCRIPTION
## Summary

When `MetadataFilters` has an empty `filters` list, `parse_metadata_filters_recursive` returns `"()"` (from joining an empty list within parentheses). This truthy string bypasses the guard in `VersionManager._get_existing_source_nodes()` at line 70:

```python
if not where_clauses:  # "()" is truthy — guard fails
    return []
```

This causes the VersionManager to generate invalid Cypher:

```cypher
WHERE () AND coalesce(source.__aws__versioning__id_fields__, ...) = $param
```

Neptune Database (1.4.7.0) rejects this with:
```
MalformedQueryException: Invalid input 'A': expected whitespace, comment or a relationship pattern
```

## Fix

Return `''` (empty string) when `filter_strs` is empty, before reaching the condition-based join logic.

```python
if not filter_strs:
    return ''
```

## Testing

- Added 2 unit tests covering empty filter lists with AND and OR conditions
- Verified on Neptune Database 1.4.7.0: the versioning query now works correctly
- Confirmed via direct Neptune query testing that Neptune supports all other Cypher features used by the VersionManager (map literals, coalesce, `__` property names)

## Evidence

Direct Neptune testing results (from issue #408):

| Test | Query Pattern | Result |
|------|--------------|--------|
| Map literal in RETURN | `RETURN {id: id(n)} AS result` | ✅ Works |
| `__aws__` property names | `t.__aws__versioning__id_fields__` | ✅ Works |
| coalesce on versioning properties | `coalesce(t.__aws__versioning__valid_from__, -1)` | ✅ Works |
| **WHERE () AND filter** | `WHERE () AND id(n) IS NOT NULL` | **❌ MalformedQueryException** |
| Full versioning query (properly formed) | Complete pattern with valid WHERE | ✅ Works |

Fixes #408