### PR TITLE
[FIX] Use spawn start method for pipeline ProcessPoolExecutor

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pipe import Pipe
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from typing import List, Optional, Sequence, Any, cast, Callable, Generator, Union
@@ -36,7 +37,16 @@ def run_pipeline(
         **kwargs
     )
 
-    with ProcessPoolExecutor(max_workers=num_workers) as p:
+    # Use the "spawn" start method rather than the platform default ("fork" on
+    # Linux). A forked worker inherits any lock held by a non-forking parent
+    # thread in a permanently-locked state; when a per-document logging thread
+    # (e.g. S3BasedDocs(for_jsonl=True)) holds the log file's BufferedWriter
+    # lock at fork time, the worker deadlocks on its first log call. "spawn"
+    # starts workers from a clean interpreter, eliminating inherited-lock hazards.
+    with ProcessPoolExecutor(
+        max_workers=num_workers,
+        mp_context=multiprocessing.get_context('spawn'),
+    ) as p:
         processed_node_batches = p.map(transform, node_batches)
         
     for processed_node_batch in processed_node_batches:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
@@ -37,12 +37,8 @@ def run_pipeline(
         **kwargs
     )
 
-    # Use the "spawn" start method rather than the platform default ("fork" on
-    # Linux). A forked worker inherits any lock held by a non-forking parent
-    # thread in a permanently-locked state; when a per-document logging thread
-    # (e.g. S3BasedDocs(for_jsonl=True)) holds the log file's BufferedWriter
-    # lock at fork time, the worker deadlocks on its first log call. "spawn"
-    # starts workers from a clean interpreter, eliminating inherited-lock hazards.
+    # Use "spawn": a forked worker can inherit a held lock (e.g. a logging
+    # thread's) and deadlock. Spawn starts workers from a clean interpreter.
     with ProcessPoolExecutor(
         max_workers=num_workers,
         mp_context=multiprocessing.get_context('spawn'),

--- a/lexical-graph/tests/unit/indexing/utils/test_pipeline_utils.py
+++ b/lexical-graph/tests/unit/indexing/utils/test_pipeline_utils.py
@@ -93,9 +93,12 @@ class TestRunPipeline:
                 mock_executor.return_value = mock_pool
                 
                 results = list(run_pipeline(mock_pipeline, node_batches, num_workers=1))
-                
+
                 assert len(results) == 1
-                mock_executor.assert_called_once_with(max_workers=1)
+                mock_executor.assert_called_once()
+                _, call_kwargs = mock_executor.call_args
+                assert call_kwargs['max_workers'] == 1
+                assert call_kwargs['mp_context'].get_start_method() == 'spawn'
     
     def test_run_pipeline_with_cache(self):
         """Verify run_pipeline uses cache when not disabled."""


### PR DESCRIPTION
## Description

`run_pipeline` forks its `ProcessPoolExecutor` workers using the platform default start method (`fork` on Linux). A forked worker inherits any lock a non-forking parent thread held, in a locked state. When a per-document logging thread holds the log file's `BufferedWriter` lock at fork time, the worker deadlocks on its first log call and the extraction hangs with no error. This switches the pool to the `spawn` start method, which starts workers from a clean interpreter and removes the inherited-lock hazard.

## Changes

- `pipeline_utils.py`: create the `ProcessPoolExecutor` with `mp_context=multiprocessing.get_context('spawn')` instead of the default fork context, and add the `import multiprocessing`.
- Add a comment explaining why fork is unsafe here.

## Problem

Extraction using `S3BasedDocs(for_jsonl=True)` hangs partway through the write phase with no exception and no traceback. `py-spy` shows a forked worker blocked in `logging`'s `StreamHandler.flush()` at `self.stream.flush()`. It already acquired the handler lock, so the block is the underlying log-file `BufferedWriter` lock. The parent then blocks in `ProcessPoolExecutor.shutdown()` joining a worker that can never finish.

The child inherits the buffer lock in a held state because a parent thread was mid-write to the log at fork time. `logging` reinitialises its own module and handler locks across fork via `os.register_at_fork` but cannot reach the lock inside the stream, so the child blocks on its first `flush()`.

The `for_jsonl=True` path triggers this because its uploader keeps a long-lived thread that logs once per document, so a thread is almost always inside a logging call when the pool forks. The default `for_jsonl=False` path keeps no such thread and rarely forks while the lock is held.

Related issue (if any): #418

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Reproduced the hang twice on a SageMaker notebook (Python 3.10.20) running a 5,000-document extraction with `S3BasedDocs(for_jsonl=True)`. Both runs froze at 1,000 uploaded objects with the forked worker at 0% CPU, and the `py-spy` dumps identify the `BufferedWriter` flush. With this change on the same notebook, the run passed 1,000 objects and completed all 5,000 documents. This is one clean run, and the failure is a fork-timing race, so a single pass does not rule out recurrence; it does remove the mechanism the dumps show.

## Checklist

- [x] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

No new files. `spawn` re-imports the module tree per worker, a small per-worker startup cost, and requires the `transform` closure to be picklable, which it is in the current pipeline.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
