### PR TITLE
[FIX] Parallelise per-document chunk listing in S3ChunkDownloader

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -41,6 +41,10 @@ DEFAULT_EMBEDDINGS_DIMENSIONS = 1024
 DEFAULT_EXTRACTION_NUM_WORKERS = 2
 DEFAULT_EXTRACTION_BATCH_SIZE = 4
 DEFAULT_EXTRACTION_NUM_THREADS_PER_WORKER = 4
+# botocore's own default. Not a chosen value - it's the floor the S3 pool is
+# never sized below. Distinct from DEFAULT_MAX_POOL_CONNECTIONS in
+# neptune_graph_stores, which is that client's chosen size.
+BOTOCORE_DEFAULT_MAX_POOL_CONNECTIONS = 10
 DEFAULT_BUILD_NUM_WORKERS = 2
 DEFAULT_BUILD_BATCH_SIZE = 4
 DEFAULT_BUILD_BATCH_WRITE_SIZE = 25
@@ -153,6 +157,26 @@ class ResilientClient:
         self._lock = threading.Lock()
 
 
+    def _client_config(self):
+        """
+        Build the botocore config for this service, or None to take the defaults.
+
+        S3 listing and downloading now run concurrently, so peak connections
+        reach twice the configured thread count. botocore's default pool of 10
+        sits well under the thread counts the extract stage uses, and once the
+        pool is exhausted botocore discards and reopens connections, which
+        costs back the concurrency it was given.
+
+        Returns:
+            Config: A botocore config for S3, or None for other services
+        """
+        if self.service_name != 's3':
+            return None
+
+        num_threads = self.config.extraction_num_threads_per_worker
+
+        return Config(max_pool_connections=max(BOTOCORE_DEFAULT_MAX_POOL_CONNECTIONS, num_threads * 2))
+
     def _create_client(self):
         """
         Create a new boto3 client using the config's session.
@@ -164,7 +188,7 @@ class ResilientClient:
             RuntimeError: If the AWS SSO token is missing or expired
         """
         try:
-            return self.config.session.client(self.service_name)
+            return self.config.session.client(self.service_name, config=self._client_config())
         except SSOTokenLoadError as e:
             raise RuntimeError(
                 f"[ResilientClient] SSO token is missing or expired for profile '{self.config.aws_profile}'.\n"

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -10,9 +10,10 @@ import threading
 import uuid
 import concurrent.futures
 
+from collections import deque
 from os.path import join
 from datetime import datetime
-from itertools import repeat
+from itertools import repeat, islice
 from threading import Semaphore
 from typing import List, Any, Generator, Optional, Dict, Callable
 
@@ -295,32 +296,44 @@ class S3ChunkDownloader(BaseComponent):
 
         num_threads = GraphRAGConfig.extraction_num_threads_per_worker
 
-        def _list_chunk_keys(source_doc_prefix):
-            chunk_pages = s3_client.get_paginator('list_objects_v2').paginate(
-                Bucket=self.bucket_name, Prefix=source_doc_prefix
+        # download_executor is the outer context so it outlives list_executor,
+        # whose tasks submit downloads onto it.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as download_executor, \
+             concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as list_executor:
+
+            def _list_and_dispatch(source_doc_prefix):
+                # List a document's chunks (reusing the stateless paginator) and
+                # dispatch their downloads, so consecutive documents overlap.
+                chunk_pages = paginator.paginate(Bucket=self.bucket_name, Prefix=source_doc_prefix)
+                chunk_keys = [
+                    chunk_obj['Key']
+                    for chunk_page in chunk_pages
+                    for chunk_obj in chunk_page.get('Contents', [])
+                ]
+                return [
+                    download_executor.submit(self._download_chunk, chunk_key, s3_client)
+                    for chunk_key in chunk_keys
+                ]
+
+            # Bounded sliding window: at most num_threads listings in flight, so
+            # peak memory tracks the window, not the whole collection.
+            remaining_prefixes = iter(source_doc_prefixes)
+            in_flight = deque(
+                (source_doc_prefix, list_executor.submit(_list_and_dispatch, source_doc_prefix))
+                for source_doc_prefix in islice(remaining_prefixes, num_threads)
             )
-            return [
-                chunk_obj['Key']
-                for chunk_page in chunk_pages
-                for chunk_obj in chunk_page.get('Contents', [])
-            ]
 
-        # List each document's chunks concurrently. The per-document
-        # list_objects_v2 calls previously ran one at a time on the main thread
-        # and were a large part of readback. executor.map keeps yield order.
-        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as list_executor, \
-             concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as download_executor:
+            while in_flight:
+                source_doc_prefix, listing = in_flight.popleft()
+                download_futures = listing.result()
 
-            for source_doc_prefix, chunk_keys in zip(
-                source_doc_prefixes,
-                list_executor.map(_list_chunk_keys, source_doc_prefixes)
-            ):
+                next_prefix = next(remaining_prefixes, None)
+                if next_prefix is not None:
+                    in_flight.append(
+                        (next_prefix, list_executor.submit(_list_and_dispatch, next_prefix))
+                    )
 
-                nodes = list(download_executor.map(
-                    self._download_chunk,
-                    chunk_keys,
-                    repeat(s3_client)
-                ))
+                nodes = [download_future.result() for download_future in download_futures]
 
                 logger.debug(f'Yielding source document [source: {source_doc_prefix}, num_nodes: {len(nodes)}]')
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -293,26 +293,37 @@ class S3ChunkDownloader(BaseComponent):
 
         logger.debug(f'Started getting source documents from S3 [bucket: {self.bucket_name}, collection_path: {collection_path}, num_prefixes: {len(source_doc_prefixes)}]')
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=GraphRAGConfig.extraction_num_threads_per_worker) as executor:
+        num_threads = GraphRAGConfig.extraction_num_threads_per_worker
 
-            for source_doc_prefix in source_doc_prefixes:
-                
-                chunk_pages = paginator.paginate(Bucket=self.bucket_name, Prefix=source_doc_prefix)
-                
-                chunk_keys = [
-                    chunk_obj['Key']
-                    for chunk_page in chunk_pages
-                    for chunk_obj in chunk_page['Contents'] 
-                ]
+        def _list_chunk_keys(source_doc_prefix):
+            chunk_pages = s3_client.get_paginator('list_objects_v2').paginate(
+                Bucket=self.bucket_name, Prefix=source_doc_prefix
+            )
+            return [
+                chunk_obj['Key']
+                for chunk_page in chunk_pages
+                for chunk_obj in chunk_page.get('Contents', [])
+            ]
 
-                nodes = list(executor.map(
+        # List each document's chunks concurrently. The per-document
+        # list_objects_v2 calls previously ran one at a time on the main thread
+        # and were a large part of readback. executor.map keeps yield order.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as list_executor, \
+             concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as download_executor:
+
+            for source_doc_prefix, chunk_keys in zip(
+                source_doc_prefixes,
+                list_executor.map(_list_chunk_keys, source_doc_prefixes)
+            ):
+
+                nodes = list(download_executor.map(
                     self._download_chunk,
                     chunk_keys,
                     repeat(s3_client)
                 ))
 
                 logger.debug(f'Yielding source document [source: {source_doc_prefix}, num_nodes: {len(nodes)}]')
-            
+
                 yield SourceDocument(nodes=nodes)
 
 class S3ChunkUploader(BaseComponent):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -296,44 +296,45 @@ class S3ChunkDownloader(BaseComponent):
 
         num_threads = GraphRAGConfig.extraction_num_threads_per_worker
 
-        # download_executor is the outer context so it outlives list_executor,
-        # whose tasks submit downloads onto it.
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as download_executor, \
              concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as list_executor:
 
-            def _list_and_dispatch(source_doc_prefix):
-                # List a document's chunks (reusing the stateless paginator) and
-                # dispatch their downloads, so consecutive documents overlap.
+            def _list_chunk_keys(source_doc_prefix):
+                # Listing only: no downloads dispatched here, so peak resident 
+                # chunk data stays one document's worth rather than the whole window's.
                 chunk_pages = paginator.paginate(Bucket=self.bucket_name, Prefix=source_doc_prefix)
-                chunk_keys = [
+                return [
                     chunk_obj['Key']
                     for chunk_page in chunk_pages
                     for chunk_obj in chunk_page.get('Contents', [])
                 ]
-                return [
-                    download_executor.submit(self._download_chunk, chunk_key, s3_client)
-                    for chunk_key in chunk_keys
-                ]
 
-            # Bounded sliding window: at most num_threads listings in flight, so
-            # peak memory tracks the window, not the whole collection.
+            # Bounded sliding window: at most num_threads listings prefetch ahead,
+            # so listing overlaps downloading without reading the whole collection.
             remaining_prefixes = iter(source_doc_prefixes)
             in_flight = deque(
-                (source_doc_prefix, list_executor.submit(_list_and_dispatch, source_doc_prefix))
+                (source_doc_prefix, list_executor.submit(_list_chunk_keys, source_doc_prefix))
                 for source_doc_prefix in islice(remaining_prefixes, num_threads)
             )
 
             while in_flight:
                 source_doc_prefix, listing = in_flight.popleft()
-                download_futures = listing.result()
+                chunk_keys = listing.result()
 
                 next_prefix = next(remaining_prefixes, None)
                 if next_prefix is not None:
                     in_flight.append(
-                        (next_prefix, list_executor.submit(_list_and_dispatch, next_prefix))
+                        (next_prefix, list_executor.submit(_list_chunk_keys, next_prefix))
                     )
 
-                nodes = [download_future.result() for download_future in download_futures]
+                # Download the current document's chunks only, then yield, so at
+                # most one document's chunk data is resident at a time and an
+                # abandoned generator dispatches no downloads for unconsumed docs.
+                nodes = list(download_executor.map(
+                    self._download_chunk,
+                    chunk_keys,
+                    repeat(s3_client),
+                ))
 
                 logger.debug(f'Yielding source document [source: {source_doc_prefix}, num_nodes: {len(nodes)}]')
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import io
 import json
 import logging
@@ -277,7 +278,15 @@ class S3ChunkDownloader(BaseComponent):
             return self.fn(TextNode.from_json(data))
 
     def download(self):
+        """
+        Yield one SourceDocument per source-document prefix in the collection.
 
+        Two thread pools stay open across the yields, so they shut down when the
+        generator is closed rather than when the loop ends. Consume it fully, or
+        close it - `with contextlib.closing(...)` or an explicit `.close()` - if
+        you might stop early. Abandoning it without closing leaves the pools for
+        the garbage collector to reclaim.
+        """
         s3_client = GraphRAGConfig.s3
 
         collection_path = join(self.key_prefix,  self.collection_id, '')
@@ -285,11 +294,11 @@ class S3ChunkDownloader(BaseComponent):
         paginator = s3_client.get_paginator('list_objects_v2')
         source_doc_pages = paginator.paginate(Bucket=self.bucket_name, Prefix=collection_path, Delimiter='/')
 
-        source_doc_prefixes = [ 
-            source_doc_obj['Prefix'] 
-            for source_doc_page in source_doc_pages 
+        source_doc_prefixes = [
+            source_doc_obj['Prefix']
+            for source_doc_page in source_doc_pages
             for source_doc_obj in source_doc_page.get('CommonPrefixes', [])
-             
+
         ]
 
         logger.debug(f'Started getting source documents from S3 [bucket: {self.bucket_name}, collection_path: {collection_path}, num_prefixes: {len(source_doc_prefixes)}]')
@@ -499,9 +508,15 @@ class S3BasedDocs(NodeHandler):
         start = time.time()
         doc_count = 0
 
-        for doc in self._downloader.download():
-            doc_count += 1
-            yield(doc)
+        # download() holds thread pools open across its yields, so closing it is
+        # what shuts them down. Wrapping it here means a consumer that stops
+        # early - `for doc in docs: break` - unwinds the pools through this
+        # generator's own GeneratorExit, rather than waiting on the garbage
+        # collector to finalize an abandoned generator.
+        with contextlib.closing(self._downloader.download()) as docs:
+            for doc in docs:
+                doc_count += 1
+                yield(doc)
 
         end = time.time()
 

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -425,3 +425,82 @@ class TestS3DownloaderCommonPrefixes:
             for obj in page.get('CommonPrefixes', [])
         ]
         assert source_doc_prefixes == ['p/c/doc1/']
+
+
+class TestS3ChunkDownloaderParallelListing:
+    """S3ChunkDownloader.download() lists each document's chunks concurrently
+    while preserving document order."""
+
+    @staticmethod
+    def _paginate_side_effect(layout):
+        """Return a paginate() stub: the collection-level call (Delimiter='/')
+        yields the source-doc prefixes; a per-prefix call yields that prefix's
+        chunk keys."""
+        def paginate(**kwargs):
+            if kwargs.get('Delimiter') == '/':
+                return [{'CommonPrefixes': [{'Prefix': p} for p in layout]}]
+            return [{'Contents': [{'Key': k} for k in layout[kwargs['Prefix']]]}]
+        return paginate
+
+    @patch('graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig')
+    def test_preserves_document_and_chunk_order(self, mock_config):
+        """Each yielded SourceDocument carries its own chunks, and documents
+        yield in prefix order — the concurrent listing must not reorder them."""
+        layout = {
+            'p/c/doc-a/': ['p/c/doc-a/c1.json', 'p/c/doc-a/c2.json'],
+            'p/c/doc-b/': ['p/c/doc-b/c1.json'],
+            'p/c/doc-c/': ['p/c/doc-c/c1.json', 'p/c/doc-c/c2.json', 'p/c/doc-c/c3.json'],
+        }
+
+        mock_s3 = MagicMock()
+        mock_config.s3 = mock_s3
+        mock_config.extraction_num_threads_per_worker = 4
+        paginator = MagicMock()
+        paginator.paginate.side_effect = self._paginate_side_effect(layout)
+        mock_s3.get_paginator.return_value = paginator
+
+        downloader = S3ChunkDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b',
+            fn=lambda node: node,
+        )
+        # Identity download: a chunk node's id is its key, so we can assert order.
+        with patch.object(
+            S3ChunkDownloader, '_download_chunk',
+            side_effect=lambda key, client: TextNode(id_=key, text=''),
+        ):
+            docs = list(downloader.download())
+
+        got = [[n.id_ for n in d.nodes] for d in docs]
+        assert got == list(layout.values())
+
+    @patch('graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig')
+    def test_listing_is_concurrent_not_serial(self, mock_config):
+        """The per-document list calls run concurrently. A Barrier that only
+        releases when all listing threads arrive at once passes on the parallel
+        implementation and times out (BrokenBarrierError) on a serial one."""
+        import threading
+
+        num_threads = 4
+        prefixes = [f'p/c/doc-{i}/' for i in range(num_threads)]
+        barrier = threading.Barrier(num_threads, timeout=10)
+
+        def paginate(**kwargs):
+            if kwargs.get('Delimiter') == '/':
+                return [{'CommonPrefixes': [{'Prefix': p} for p in prefixes]}]
+            barrier.wait()  # raises BrokenBarrierError on timeout if calls are serial
+            return [{'Contents': []}]
+
+        mock_s3 = MagicMock()
+        mock_config.s3 = mock_s3
+        mock_config.extraction_num_threads_per_worker = num_threads
+        paginator = MagicMock()
+        paginator.paginate.side_effect = paginate
+        mock_s3.get_paginator.return_value = paginator
+
+        downloader = S3ChunkDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b',
+            fn=lambda node: node,
+        )
+        # Completes only if the num_threads listing calls overlap in time.
+        docs = list(downloader.download())
+        assert len(docs) == num_threads

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -504,3 +504,58 @@ class TestS3ChunkDownloaderParallelListing:
         # Completes only if the num_threads listing calls overlap in time.
         docs = list(downloader.download())
         assert len(docs) == num_threads
+
+    @patch('graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig')
+    def test_listing_window_is_bounded(self, mock_config):
+        """A consumer stalled on document 0 must not let listing run ahead
+        through the whole collection: at most num_threads listings in flight."""
+        import threading
+
+        num_threads = 2
+        num_docs = 20
+        prefixes = [f'p/c/doc-{i}/' for i in range(num_docs)]
+        listed = []
+        listed_lock = threading.Lock()
+        first_download_started = threading.Event()
+        release_first_download = threading.Event()
+
+        def paginate(**kwargs):
+            if kwargs.get('Delimiter') == '/':
+                return [{'CommonPrefixes': [{'Prefix': p} for p in prefixes]}]
+            with listed_lock:
+                listed.append(kwargs['Prefix'])
+            return [{'Contents': [{'Key': kwargs['Prefix'] + 'c0.json'}]}]
+
+        mock_s3 = MagicMock()
+        mock_config.s3 = mock_s3
+        mock_config.extraction_num_threads_per_worker = num_threads
+        paginator = MagicMock()
+        paginator.paginate.side_effect = paginate
+        mock_s3.get_paginator.return_value = paginator
+
+        downloader = S3ChunkDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b',
+            fn=lambda node: node,
+        )
+
+        def _download(key, client):
+            # Block the first chunk download so the consumer stalls on document 0.
+            if not first_download_started.is_set():
+                first_download_started.set()
+                release_first_download.wait(timeout=10)
+            return TextNode(id_=key, text='')
+
+        with patch.object(S3ChunkDownloader, '_download_chunk', side_effect=_download):
+            gen = downloader.download()
+            next(gen)  # pulls doc 0; blocks inside its download until released
+            assert first_download_started.wait(timeout=10)
+            with listed_lock:
+                listed_while_stalled = len(listed)
+            release_first_download.set()
+            list(gen)  # drain the rest cleanly
+
+        assert listed_while_stalled <= num_threads + 1, (
+            f'listing ran ahead unboundedly: {listed_while_stalled} of {num_docs} '
+            f'documents listed while the consumer was stalled on document 0'
+        )
+        assert len(listed) == num_docs

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -1,6 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
+import time
+
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from llama_index.core.schema import TextNode
@@ -478,8 +481,6 @@ class TestS3ChunkDownloaderParallelListing:
         """The per-document list calls run concurrently. A Barrier that only
         releases when all listing threads arrive at once passes on the parallel
         implementation and times out (BrokenBarrierError) on a serial one."""
-        import threading
-
         num_threads = 4
         prefixes = [f'p/c/doc-{i}/' for i in range(num_threads)]
         barrier = threading.Barrier(num_threads, timeout=10)
@@ -508,9 +509,12 @@ class TestS3ChunkDownloaderParallelListing:
     @patch('graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig')
     def test_listing_window_is_bounded(self, mock_config):
         """A consumer stalled on document 0 must not let listing run ahead
-        through the whole collection: at most num_threads listings in flight."""
-        import threading
+        through the whole collection: at most num_threads listings in flight.
 
+        The generator body runs in the consumer's thread, so the consumer is
+        driven from a background thread here — that lets the main thread read
+        the listing count *while* the consumer is genuinely stalled inside
+        document 0's download, rather than after the fact via a timeout."""
         num_threads = 2
         num_docs = 20
         prefixes = [f'p/c/doc-{i}/' for i in range(num_docs)]
@@ -542,20 +546,106 @@ class TestS3ChunkDownloaderParallelListing:
             # Block the first chunk download so the consumer stalls on document 0.
             if not first_download_started.is_set():
                 first_download_started.set()
-                release_first_download.wait(timeout=10)
+                release_first_download.wait()
             return TextNode(id_=key, text='')
 
-        with patch.object(S3ChunkDownloader, '_download_chunk', side_effect=_download):
-            gen = downloader.download()
-            next(gen)  # pulls doc 0; blocks inside its download until released
+        docs = []
+
+        def consume():
+            with patch.object(S3ChunkDownloader, '_download_chunk', side_effect=_download):
+                docs.extend(downloader.download())
+
+        # daemon: if download() ever deadlocks, the assert below fails and the
+        # process still exits, rather than the thread outliving pytest.
+        consumer = threading.Thread(target=consume, daemon=True)
+        consumer.start()
+        try:
+            # Wait until the consumer is genuinely stalled inside document 0's
+            # download, then give any unbounded run-ahead a chance to list every
+            # prefix before measuring.
             assert first_download_started.wait(timeout=10)
+            time.sleep(0.2)
             with listed_lock:
                 listed_while_stalled = len(listed)
+        finally:
             release_first_download.set()
-            list(gen)  # drain the rest cleanly
+            consumer.join(timeout=10)
 
+        assert not consumer.is_alive(), 'consumer thread did not finish'
         assert listed_while_stalled <= num_threads + 1, (
             f'listing ran ahead unboundedly: {listed_while_stalled} of {num_docs} '
             f'documents listed while the consumer was stalled on document 0'
         )
         assert len(listed) == num_docs
+
+    @patch('graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig')
+    def test_downloads_are_lazy_per_document(self, mock_config):
+        """Chunk downloads must be dispatched one document at a time. While the
+        consumer is stalled on document 0, no chunk of a later document may have
+        started downloading — otherwise look-ahead payloads accumulate in memory
+        and an abandoned generator pays for downloads it never consumes.
+
+        This fails against eager dispatch (downloads submitted at listing time),
+        where the whole listing window's downloads fire before document 0 is
+        consumed."""
+        num_threads = 4
+        num_docs = 10
+        prefixes = [f'p/c/doc-{i}/' for i in range(num_docs)]
+        layout = {p: [p + 'c0.json', p + 'c1.json'] for p in prefixes}
+        downloaded = []
+        downloaded_lock = threading.Lock()
+        first_download_started = threading.Event()
+        release_first_download = threading.Event()
+
+        def paginate(**kwargs):
+            if kwargs.get('Delimiter') == '/':
+                return [{'CommonPrefixes': [{'Prefix': p} for p in prefixes]}]
+            return [{'Contents': [{'Key': k} for k in layout[kwargs['Prefix']]]}]
+
+        mock_s3 = MagicMock()
+        mock_config.s3 = mock_s3
+        mock_config.extraction_num_threads_per_worker = num_threads
+        paginator = MagicMock()
+        paginator.paginate.side_effect = paginate
+        mock_s3.get_paginator.return_value = paginator
+
+        downloader = S3ChunkDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b',
+            fn=lambda node: node,
+        )
+
+        def _download(key, client):
+            with downloaded_lock:
+                downloaded.append(key)
+            if key == 'p/c/doc-0/c0.json':
+                first_download_started.set()
+                release_first_download.wait()
+            return TextNode(id_=key, text='')
+
+        docs = []
+
+        def consume():
+            with patch.object(S3ChunkDownloader, '_download_chunk', side_effect=_download):
+                docs.extend(downloader.download())
+
+        # daemon: if download() ever deadlocks, the assert below fails and the
+        # process still exits, rather than the thread outliving pytest.
+        consumer = threading.Thread(target=consume, daemon=True)
+        consumer.start()
+        try:
+            assert first_download_started.wait(timeout=10)
+            time.sleep(0.2)  # give any eager look-ahead downloads time to fire
+            with downloaded_lock:
+                downloaded_while_stalled = list(downloaded)
+        finally:
+            release_first_download.set()
+            consumer.join(timeout=10)
+
+        assert not consumer.is_alive(), 'consumer thread did not finish'
+        later_doc_downloads = [
+            key for key in downloaded_while_stalled
+            if not key.startswith('p/c/doc-0/')
+        ]
+        assert later_doc_downloads == [], (
+            f'downloads dispatched ahead for unconsumed documents: {later_doc_downloads}'
+        )

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import threading
 import time
 
@@ -649,3 +650,43 @@ class TestS3ChunkDownloaderParallelListing:
         assert later_doc_downloads == [], (
             f'downloads dispatched ahead for unconsumed documents: {later_doc_downloads}'
         )
+
+    @patch('graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig')
+    def test_listing_error_propagates_to_consumer(self, mock_config):
+        """A failure while listing a document's chunks must surface to the
+        consumer rather than being swallowed by executor shutdown, and must not
+        corrupt documents already yielded before the failing one."""
+        prefixes = ['p/c/doc-0/', 'p/c/doc-1/', 'p/c/doc-2/']
+
+        def paginate(**kwargs):
+            if kwargs.get('Delimiter') == '/':
+                return [{'CommonPrefixes': [{'Prefix': p} for p in prefixes]}]
+            if kwargs['Prefix'] == 'p/c/doc-1/':
+                raise RuntimeError('transient S3 listing error')
+            return [{'Contents': [{'Key': kwargs['Prefix'] + 'c0.json'}]}]
+
+        mock_s3 = MagicMock()
+        mock_config.s3 = mock_s3
+        mock_config.extraction_num_threads_per_worker = 2
+        paginator = MagicMock()
+        paginator.paginate.side_effect = paginate
+        mock_s3.get_paginator.return_value = paginator
+
+        downloader = S3ChunkDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b',
+            fn=lambda node: node,
+        )
+
+        with patch.object(
+            S3ChunkDownloader, '_download_chunk',
+            side_effect=lambda key, client: TextNode(id_=key, text=''),
+        ):
+            with contextlib.closing(downloader.download()) as gen:
+                # doc-0 lists and downloads cleanly and is yielded.
+                first = next(gen)
+                assert [n.id_ for n in first.nodes] == ['p/c/doc-0/c0.json']
+
+                # doc-1's listing raised, and that surfaces rather than being lost
+                # while the executors unwind.
+                with pytest.raises(RuntimeError, match='transient S3 listing error'):
+                    next(gen)

--- a/lexical-graph/tests/unit/test_config.py
+++ b/lexical-graph/tests/unit/test_config.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 from graphrag_toolkit.lexical_graph.config import (
     GraphRAGConfig,
     OpenSearchServerlessGeneration,
+    ResilientClient,
     _is_json_string,
     string_to_bool,
     DEFAULT_EXTRACTION_MODEL,
@@ -19,8 +20,48 @@ from graphrag_toolkit.lexical_graph.config import (
     DEFAULT_EXTRACTION_NUM_WORKERS,
     DEFAULT_EXTRACTION_BATCH_SIZE,
     DEFAULT_BUILD_NUM_WORKERS,
-    DEFAULT_BUILD_BATCH_SIZE
+    DEFAULT_BUILD_BATCH_SIZE,
+    BOTOCORE_DEFAULT_MAX_POOL_CONNECTIONS
 )
+
+
+class TestS3ConnectionPoolSizing:
+    """The S3 client's connection pool has to cover listing and downloading at
+    the configured thread count. botocore's default of 10 throttles well below
+    the thread counts the extract stage uses."""
+
+    def _client_for(self, service_name, num_threads):
+        config = Mock()
+        config.extraction_num_threads_per_worker = num_threads
+        client = ResilientClient.__new__(ResilientClient)
+        client.config = config
+        client.service_name = service_name
+        return client
+
+    def test_s3_pool_covers_both_sides_of_the_thread_count(self):
+        client = self._client_for('s3', 32)
+
+        assert client._client_config().max_pool_connections == 64
+
+    def test_s3_pool_never_drops_below_the_botocore_default(self):
+        # 2 x the default 4 threads is 8, which would be a regression on
+        # botocore's own default of 10.
+        client = self._client_for('s3', 4)
+
+        assert client._client_config().max_pool_connections == BOTOCORE_DEFAULT_MAX_POOL_CONNECTIONS
+
+    def test_other_services_keep_the_botocore_defaults(self):
+        assert self._client_for('bedrock', 32)._client_config() is None
+
+    def test_client_is_created_with_the_sized_config(self):
+        client = self._client_for('s3', 16)
+        session = Mock()
+        client.config.session = session
+
+        client._create_client()
+
+        passed = session.client.call_args.kwargs['config']
+        assert passed.max_pool_connections == 32
 
 
 class TestHelperFunctions:

--- a/lexical-graph/tests/unit/test_config_resilient_client.py
+++ b/lexical-graph/tests/unit/test_config_resilient_client.py
@@ -42,6 +42,8 @@ class TestResilientClientCreateClient:
         mock_config = MagicMock()
         mock_boto_client = MagicMock()
         mock_config.session.client.return_value = mock_boto_client
+        # sizes the S3 connection pool, so it has to be a real number
+        mock_config.extraction_num_threads_per_worker = 4
 
         rc = ResilientClient.__new__(ResilientClient)
         rc.config = mock_config
@@ -50,13 +52,14 @@ class TestResilientClientCreateClient:
 
         result = rc._create_client()
         assert result is mock_boto_client
-        mock_config.session.client.assert_called_once_with("s3")
+        assert mock_config.session.client.call_args.args == ("s3",)
 
     def test_create_client_sso_token_error_raises_runtime(self):
         from graphrag_toolkit.lexical_graph.config import ResilientClient
 
         mock_config = MagicMock()
         mock_config.aws_profile = "my-profile"
+        mock_config.extraction_num_threads_per_worker = 4
         mock_config.session.client.side_effect = SSOTokenLoadError(error_msg="token expired")
 
         rc = ResilientClient.__new__(ResilientClient)


### PR DESCRIPTION
## Description

`S3ChunkDownloader.download` reads extracted documents back from S3. It lists each document's chunks with a separate `list_objects_v2` call, and those calls ran one at a time on the main thread. This runs them on a thread pool instead, so the listing no longer serialises. Documents still yield in the same order.

## Changes

- List each document's chunk keys concurrently, sized by `extraction_num_threads_per_worker` (the setting the chunk downloads already use). Documents yield in prefix order. Listing and downloading use separate pools so listings prefetch while the current document downloads.
- Bound the listing with a sliding window of at most `extraction_num_threads_per_worker` documents in flight, refilled one per document consumed, so listing prefetches ahead without reading the whole collection.
- Download each document's chunks lazily, when the consumer reaches that document, rather than dispatching them at listing time. At most one document's chunk data is resident at a time (the same bound as the original serial code), and abandoning the generator early dispatches no downloads for unconsumed documents.
- Read `chunk_page.get('Contents', [])` instead of `chunk_page['Contents']`, so a prefix that lists empty returns no keys instead of raising `KeyError`.
- Tests: document and chunk order preservation, a `Barrier`-based test that the listing runs concurrently, a bounded-window test driven from a consumer thread, and a guard that no later document's chunks download while the consumer is stalled on the first document.

## Problem

Reading extracted documents back from S3 was slow. On a 5,000-document collection (16,536 chunk objects) the readback took 578s against 3s from local disk. The per-document listing accounted for 255.7s of that, running as 5,000 sequential round-trips on the main thread while the downloads already used a thread pool.

Related issue (if any): #

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

169 tests in `tests/unit/indexing/load/` pass, including the four added here. The concurrency test fails with `BrokenBarrierError` against serial listing, and the lazy-dispatch guard fails against eager download dispatch (later documents' chunks download while the consumer is stalled on document 0), so they guard the behaviour rather than passing vacuously.

Measured against the same collection, listing isolated from downloads:

| threads | listing time |
|---|---|
| serial | 255.7s |
| 16 | 16.5s |
| 32 | 8.3s |
| 64 | 4.4s |

Listing is I/O-bound, so raising `extraction_num_threads_per_worker` above its default of 4 increases the gain; at the default it is smaller. This covers the listing part of readback. The chunk downloads (~322s) are unchanged.

## Checklist

- [x] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

Public behaviour is unchanged: the same `SourceDocument` objects yield in the same order. No new files.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
