### PR TITLE
[FEATURE] Add pluggable ChunkStore interface for chunk text storage

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/graph_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/graph_builder.py
@@ -5,6 +5,7 @@ import abc
 from typing import Dict, Any
 
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import to_params
 
 from llama_index.core.schema import BaseComponent, BaseNode
 
@@ -36,7 +37,7 @@ class GraphBuilder(BaseComponent):
         Returns:
             Dict: A dictionary wrapping the input as a value under the key `'params'`.
         """
-        return { 'params': [p] if p else [] }
+        return to_params(p)
 
     @classmethod
     @abc.abstractmethod

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/__init__.py
@@ -3,4 +3,5 @@
 
 from .graph_store_factory import GraphStoreFactory, GraphStoreType
 from .vector_store_factory import VectorStoreFactory, VectorStoreType
+from .chunk_store_factory import ChunkStoreFactory, ChunkStoreType
 from .constants import INDEX_KEY, ALL_EMBEDDING_INDEXES, DEFAULT_EMBEDDING_INDEXES, LEXICAL_GRAPH_LABELS

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .chunk_store import ChunkStore
+from .chunk_store_factory_method import ChunkStoreFactoryMethod
+from .in_graph_chunk_store import InGraphChunkStore

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+from typing import Dict, List, Optional
+
+
+class ChunkStore(abc.ABC):
+    """
+    Backend-agnostic interface for reading and writing chunk text.
+
+    Chunk text is stored separately from the graph so that graph traversal
+    queries are not weighed down by large text properties on every
+    `__Chunk__` node. Implementations decide where the text actually lives
+    (the graph itself, S3, or any other object store).
+    """
+
+    @abc.abstractmethod
+    def get(self, chunk_id: str) -> Optional[str]:
+        """
+        Return the text for a single chunk, or None if it isn't found.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def put(self, chunk_id: str, text: str) -> None:
+        """
+        Store the text for a single chunk.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_batch(self, chunk_ids: List[str]) -> Dict[str, str]:
+        """
+        Return text for the given chunk ids, keyed by chunk id. Chunk ids
+        with no stored text are omitted from the result.
+        """
+        raise NotImplementedError

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store.py
@@ -15,12 +15,11 @@ class ChunkStore(abc.ABC):
     (the graph itself, S3, or any other object store).
     """
 
-    @abc.abstractmethod
     def get(self, chunk_id: str) -> Optional[str]:
         """
         Return the text for a single chunk, or None if it isn't found.
         """
-        raise NotImplementedError
+        return self.get_batch([chunk_id]).get(chunk_id)
 
     @abc.abstractmethod
     def put(self, chunk_id: str, text: str) -> None:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store.py
@@ -21,6 +21,9 @@ class ChunkStore(abc.ABC):
         """
         return self.get_batch([chunk_id]).get(chunk_id)
 
+    # TODO: add a put_batch to this interface. ChunkGraphBuilder calls put()
+    # once per chunk, so writes stay serial. Reads already batch and thread,
+    # so the write path is where the remaining ingestion cost sits.
     @abc.abstractmethod
     def put(self, chunk_id: str, text: str) -> None:
         """

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store_factory_method.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store_factory_method.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
+from typing import Optional
 
 from graphrag_toolkit.lexical_graph.storage.chunk.chunk_store import ChunkStore
 
@@ -16,7 +17,7 @@ class ChunkStoreFactoryMethod(abc.ABC):
     factory.
     """
     @abc.abstractmethod
-    def try_create(self, chunk_info: str, **kwargs) -> ChunkStore:
+    def try_create(self, chunk_info: str, **kwargs) -> Optional[ChunkStore]:
         """
         Attempt to create a ChunkStore from chunk_info. Return None if this
         factory doesn't recognize chunk_info.

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store_factory_method.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/chunk_store_factory_method.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+
+from graphrag_toolkit.lexical_graph.storage.chunk.chunk_store import ChunkStore
+
+
+class ChunkStoreFactoryMethod(abc.ABC):
+    """
+    Factory method pattern for creating ChunkStore instances.
+
+    Mirrors GraphStoreFactoryMethod: subclasses attempt to create a
+    ChunkStore from the given chunk_info, returning None if they don't
+    recognize it so ChunkStoreFactory can move on to the next registered
+    factory.
+    """
+    @abc.abstractmethod
+    def try_create(self, chunk_info: str, **kwargs) -> ChunkStore:
+        """
+        Attempt to create a ChunkStore from chunk_info. Return None if this
+        factory doesn't recognize chunk_info.
+        """
+        raise NotImplementedError

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/in_graph_chunk_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/in_graph_chunk_store.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from graphrag_toolkit.lexical_graph.storage.chunk.chunk_store import ChunkStore
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
@@ -30,9 +30,6 @@ class InGraphChunkStore(ChunkStore):
 
     def __init__(self, graph_client: GraphStore):
         self.graph_client = graph_client
-
-    def get(self, chunk_id: str) -> Optional[str]:
-        return self.get_batch([chunk_id]).get(chunk_id)
 
     def get_batch(self, chunk_ids: List[str]) -> Dict[str, str]:
         if not chunk_ids:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/in_graph_chunk_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/in_graph_chunk_store.py
@@ -18,14 +18,18 @@ class InGraphChunkStore(ChunkStore):
     ChunkStore interface so other backends (e.g. S3) can be swapped in
     without changing callers.
 
-    Scope: this store only reads and writes chunk text (`chunk.value`).
-    get_batch() matches the existence semantics of
-    retrieval.utils.chunk_utils.get_chunks_query() (a chunk without a
-    valid `__EXTRACTED_FROM__` link to a `__Source__` is excluded), but it
-    does not return other chunk properties or source metadata, and put()
-    does not set the arbitrary per-chunk metadata properties
+    Scope: this store only reads and writes chunk text (`chunk.value`). A
+    chunk with no stored value is omitted from get_batch(). Chunks are
+    matched on chunk id alone, deliberately: put() writes only the text
+    and never creates the `__EXTRACTED_FROM__` link to a `__Source__`, so
+    requiring that link on read would make text written through this
+    store invisible to a read from it. Callers that need source-linked
+    chunks specifically should filter on their own query.
+
+    This store does not return other chunk properties or source metadata,
+    and put() does not set the arbitrary per-chunk metadata properties
     ChunkGraphBuilder.build() writes. Those remain the concern of
-    ChunkGraphBuilder and get_chunks_query, not of ChunkStore.
+    ChunkGraphBuilder and callers that need them, not of ChunkStore.
     """
 
     def __init__(self, graph_client: GraphStore):
@@ -36,7 +40,7 @@ class InGraphChunkStore(ChunkStore):
             return {}
 
         query = f'''
-        MATCH (chunk:`__Chunk__`)-[:`__EXTRACTED_FROM__`]->(:`__Source__`) WHERE {self.graph_client.node_id("chunk.chunkId")} in $chunk_ids
+        MATCH (chunk:`__Chunk__`) WHERE {self.graph_client.node_id("chunk.chunkId")} in $chunk_ids
         RETURN {{
             {node_result('chunk', self.graph_client.node_id("chunk.chunkId"), properties=['value'])}
         }} AS result

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/in_graph_chunk_store.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk/in_graph_chunk_store.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Dict, List, Optional
+
+from graphrag_toolkit.lexical_graph.storage.chunk.chunk_store import ChunkStore
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import node_result, to_params
+
+logger = logging.getLogger(__name__)
+
+
+class InGraphChunkStore(ChunkStore):
+    """
+    ChunkStore backed by the `chunk.value` property on `__Chunk__` graph
+    nodes, preserving today's chunk-text read/write behavior behind the
+    ChunkStore interface so other backends (e.g. S3) can be swapped in
+    without changing callers.
+
+    Scope: this store only reads and writes chunk text (`chunk.value`).
+    get_batch() matches the existence semantics of
+    retrieval.utils.chunk_utils.get_chunks_query() (a chunk without a
+    valid `__EXTRACTED_FROM__` link to a `__Source__` is excluded), but it
+    does not return other chunk properties or source metadata, and put()
+    does not set the arbitrary per-chunk metadata properties
+    ChunkGraphBuilder.build() writes. Those remain the concern of
+    ChunkGraphBuilder and get_chunks_query, not of ChunkStore.
+    """
+
+    def __init__(self, graph_client: GraphStore):
+        self.graph_client = graph_client
+
+    def get(self, chunk_id: str) -> Optional[str]:
+        return self.get_batch([chunk_id]).get(chunk_id)
+
+    def get_batch(self, chunk_ids: List[str]) -> Dict[str, str]:
+        if not chunk_ids:
+            return {}
+
+        query = f'''
+        MATCH (chunk:`__Chunk__`)-[:`__EXTRACTED_FROM__`]->(:`__Source__`) WHERE {self.graph_client.node_id("chunk.chunkId")} in $chunk_ids
+        RETURN {{
+            {node_result('chunk', self.graph_client.node_id("chunk.chunkId"), properties=['value'])}
+        }} AS result
+        '''
+        params = {'chunk_ids': chunk_ids}
+
+        rows = self.graph_client.execute_query(query, params)
+
+        return {
+            row['result']['chunk']['chunkId']: row['result']['chunk']['value']
+            for row in rows
+            if row['result']['chunk'].get('value') is not None
+        }
+
+    def put(self, chunk_id: str, text: str) -> None:
+        logger.debug(f'Writing chunk text to graph [chunk_id: {chunk_id}]')
+
+        query = f'''
+        // write chunk value
+        UNWIND $params AS params
+        MERGE (chunk:`__Chunk__`{{{self.graph_client.node_id("chunkId")}: params.chunk_id}})
+        ON CREATE SET chunk.value = params.text
+        ON MATCH SET chunk.value = params.text
+        '''
+        params = to_params({'chunk_id': chunk_id, 'text': text})
+
+        self.graph_client.execute_query_with_retry(query, params, max_attempts=5, max_wait=7)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
@@ -15,10 +15,10 @@ ChunkStoreFactoryMethodType = Union[ChunkStoreFactoryMethod, Type[ChunkStoreFact
 
 class InGraphChunkStoreFactory(ChunkStoreFactoryMethod):
     """
-    Fallback factory: creates an InGraphChunkStore when no other chunk
-    store backend recognizes chunk_info, preserving today's behavior.
-    Always tried last by ChunkStoreFactory, the same way
-    DummyGraphStoreFactory is the last-resort fallback for GraphStoreFactory.
+    Default factory: creates an InGraphChunkStore when no chunk_info is
+    given, preserving today's behavior for callers that don't configure a
+    chunk store. Returns None for any non-empty chunk_info, so it never
+    swallows a backend URI that a registered factory was meant to handle.
     """
     def try_create(self, chunk_info: str, **kwargs) -> ChunkStore:
         if chunk_info:
@@ -39,10 +39,14 @@ class ChunkStoreFactory():
     """
     Factory class for registering and creating ChunkStore objects.
 
-    Mirrors GraphStoreFactory: registered factory methods are tried in
-    order until one recognizes the given chunk_info and returns a
-    ChunkStore. InGraphChunkStoreFactory is always tried last, as the
-    fallback of last resort, regardless of registration order.
+    Registered factory methods are tried in registration order until one
+    recognizes the given chunk_info and returns a ChunkStore. If none do
+    and chunk_info is empty, InGraphChunkStoreFactory supplies the
+    default in-graph store; if none do and chunk_info is non-empty, that
+    is an error and ValueError is raised.
+
+    Note this differs from GraphStoreFactory, which has no default at all
+    and raises for empty graph_info as well as unrecognized graph_info.
     """
     @staticmethod
     def register(factory_type: ChunkStoreFactoryMethodType):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
@@ -6,7 +6,6 @@ from typing import Union, Type, Dict
 
 from graphrag_toolkit.lexical_graph.storage.chunk import ChunkStore, ChunkStoreFactoryMethod
 from graphrag_toolkit.lexical_graph.storage.chunk.in_graph_chunk_store import InGraphChunkStore
-from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class InGraphChunkStoreFactory(ChunkStoreFactoryMethod):
             return None
 
         graph_store = kwargs.get('graph_store')
-        if not isinstance(graph_store, GraphStore):
+        if graph_store is None:
             raise ValueError('InGraphChunkStoreFactory requires a graph_store keyword argument.')
 
         return InGraphChunkStore(graph_store)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Union, Type, Dict
+
+from graphrag_toolkit.lexical_graph.storage.chunk import ChunkStore, ChunkStoreFactoryMethod
+from graphrag_toolkit.lexical_graph.storage.chunk.in_graph_chunk_store import InGraphChunkStore
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+
+logger = logging.getLogger(__name__)
+
+ChunkStoreType = Union[str, ChunkStore]
+ChunkStoreFactoryMethodType = Union[ChunkStoreFactoryMethod, Type[ChunkStoreFactoryMethod]]
+
+
+class InGraphChunkStoreFactory(ChunkStoreFactoryMethod):
+    """
+    Fallback factory: creates an InGraphChunkStore when no other chunk
+    store backend recognizes chunk_info, preserving today's behavior.
+    Always tried last by ChunkStoreFactory, the same way
+    DummyGraphStoreFactory is the last-resort fallback for GraphStoreFactory.
+    """
+    def try_create(self, chunk_info: str, **kwargs) -> ChunkStore:
+        if chunk_info:
+            return None
+
+        graph_store = kwargs.get('graph_store')
+        if not isinstance(graph_store, GraphStore):
+            raise ValueError('InGraphChunkStoreFactory requires a graph_store keyword argument.')
+
+        return InGraphChunkStore(graph_store)
+
+
+_chunk_store_factories: Dict[str, ChunkStoreFactoryMethod] = {}
+_default_chunk_store_factory = InGraphChunkStoreFactory()
+
+
+class ChunkStoreFactory():
+    """
+    Factory class for registering and creating ChunkStore objects.
+
+    Mirrors GraphStoreFactory: registered factory methods are tried in
+    order until one recognizes the given chunk_info and returns a
+    ChunkStore. InGraphChunkStoreFactory is always tried last, as the
+    fallback of last resort, regardless of registration order.
+    """
+    @staticmethod
+    def register(factory_type: ChunkStoreFactoryMethodType):
+        """
+        Register a ChunkStoreFactoryMethod subclass or instance.
+        """
+        if isinstance(factory_type, type):
+            if not issubclass(factory_type, ChunkStoreFactoryMethod):
+                raise ValueError(f'Invalid factory_type argument: {factory_type.__name__} must inherit from ChunkStoreFactoryMethod.')
+            _chunk_store_factories[factory_type.__name__] = factory_type()
+        else:
+            factory_type_name = type(factory_type).__name__
+            if not isinstance(factory_type, ChunkStoreFactoryMethod):
+                raise ValueError(f'Invalid factory_type argument: {factory_type_name} must inherit from ChunkStoreFactoryMethod.')
+            _chunk_store_factories[factory_type_name] = factory_type
+
+    @staticmethod
+    def for_chunk_store(chunk_info: ChunkStoreType = None, **kwargs) -> ChunkStore:
+        """
+        Create a ChunkStore from chunk_info, or return chunk_info directly
+        if it's already a ChunkStore instance.
+        """
+        if chunk_info and isinstance(chunk_info, ChunkStore):
+            return chunk_info
+
+        for factory in _chunk_store_factories.values():
+            chunk_store = factory.try_create(chunk_info, **kwargs)
+            if chunk_store:
+                return chunk_store
+
+        if not chunk_info:
+            return _default_chunk_store_factory.try_create(chunk_info, **kwargs)
+
+        raise ValueError(f'Unrecognized chunk store info: {chunk_info}. Check that an appropriate chunk store factory method is registered with ChunkStoreFactory.')

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/chunk_store_factory.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Union, Type, Dict
+from typing import Union, Type, Dict, Optional
 
 from graphrag_toolkit.lexical_graph.storage.chunk import ChunkStore, ChunkStoreFactoryMethod
 from graphrag_toolkit.lexical_graph.storage.chunk.in_graph_chunk_store import InGraphChunkStore
@@ -20,7 +20,7 @@ class InGraphChunkStoreFactory(ChunkStoreFactoryMethod):
     chunk store. Returns None for any non-empty chunk_info, so it never
     swallows a backend URI that a registered factory was meant to handle.
     """
-    def try_create(self, chunk_info: str, **kwargs) -> ChunkStore:
+    def try_create(self, chunk_info: str, **kwargs) -> Optional[ChunkStore]:
         if chunk_info:
             return None
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
@@ -3,7 +3,7 @@
 
 import re
 import string
-from typing import Any, List, Optional, Callable
+from typing import Any, Dict, List, Optional, Callable
 import uuid
 
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig, type_name_for_key_value, format_datetime
@@ -15,6 +15,13 @@ SEARCH_STRING_PATTERN = re.compile(r'([^\s\w]|_)+')
 
 def new_query_var():
     return f'n{uuid.uuid4().hex}'
+
+def to_params(p: Dict) -> Dict:
+    """
+    Wraps a parameter dict as the `params` list expected by
+    `UNWIND $params AS params`-style Cypher queries.
+    """
+    return {'params': [p] if p else []}
 
 def search_string_from(value:str):
     """

--- a/lexical-graph/tests/integration/storage/chunk/test_chunk_store_live_neo4j.py
+++ b/lexical-graph/tests/integration/storage/chunk/test_chunk_store_live_neo4j.py
@@ -8,7 +8,8 @@ catch a query that is well-formed but matches the wrong thing. A store
 whose put() output its own get_batch() can't see is exactly that failure,
 and it only shows up against a real graph.
 
-Skipped unless NEO4J_TEST_URI is set. To run locally:
+Skipped unless NEO4J_TEST_URI is set, and fails rather than runs if that URI
+points at a database that already holds data. To run locally:
 
     finch run -d --name chunk-store-test -p 7687:7687 \\
         -e NEO4J_AUTH=neo4j/testpassword123 neo4j:5
@@ -35,9 +36,21 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture
 def graph_client():
     client = GraphStoreFactory.for_graph_store(NEO4J_TEST_URI)
-    client.execute_query('MATCH (n) DETACH DELETE n', {})
+
+    rows = client.execute_query('MATCH (n) RETURN count(n) AS node_count', {})
+    node_count = rows[0]['node_count'] if rows else 0
+    if node_count:
+        pytest.fail(
+            f'NEO4J_TEST_URI points at a database that is not empty (node count: '
+            f'{node_count}). This test writes and deletes chunk nodes, so it only runs '
+            f'against an empty database. Point NEO4J_TEST_URI at a throwaway instance.'
+        )
+
     yield client
-    client.execute_query('MATCH (n) DETACH DELETE n', {})
+
+    # Safe to delete unconditionally: the database was empty above, and this test
+    # only ever creates __Chunk__ nodes.
+    client.execute_query('MATCH (chunk:`__Chunk__`) DETACH DELETE chunk', {})
 
 
 @pytest.fixture

--- a/lexical-graph/tests/integration/storage/chunk/test_chunk_store_live_neo4j.py
+++ b/lexical-graph/tests/integration/storage/chunk/test_chunk_store_live_neo4j.py
@@ -1,0 +1,78 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live check of ChunkStore write/read against a real Neo4j instance.
+
+Mocked unit tests assert on the shape of the query string, which can't
+catch a query that is well-formed but matches the wrong thing. A store
+whose put() output its own get_batch() can't see is exactly that failure,
+and it only shows up against a real graph.
+
+Skipped unless NEO4J_TEST_URI is set. To run locally:
+
+    finch run -d --name chunk-store-test -p 7687:7687 \\
+        -e NEO4J_AUTH=neo4j/testpassword123 neo4j:5
+    NEO4J_TEST_URI=bolt://neo4j:testpassword123@localhost:7687 \\
+        pytest tests/integration/storage/chunk/test_chunk_store_live_neo4j.py
+    finch stop chunk-store-test && finch rm chunk-store-test
+"""
+
+import os
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
+from graphrag_toolkit.lexical_graph.storage.graph_store_factory import GraphStoreFactory
+
+NEO4J_TEST_URI = os.environ.get('NEO4J_TEST_URI')
+
+pytestmark = pytest.mark.skipif(
+    not NEO4J_TEST_URI,
+    reason='set NEO4J_TEST_URI to a running Neo4j instance to run this live test',
+)
+
+
+@pytest.fixture
+def graph_client():
+    client = GraphStoreFactory.for_graph_store(NEO4J_TEST_URI)
+    client.execute_query('MATCH (n) DETACH DELETE n', {})
+    yield client
+    client.execute_query('MATCH (n) DETACH DELETE n', {})
+
+
+@pytest.fixture
+def chunk_store(graph_client):
+    return ChunkStoreFactory.for_chunk_store(graph_store=graph_client)
+
+
+class TestChunkStoreLiveRoundTrip:
+
+    def test_put_then_get_returns_the_text(self, chunk_store):
+        chunk_store.put('chunk-live-1', 'hello from a live neo4j chunk')
+
+        assert chunk_store.get('chunk-live-1') == 'hello from a live neo4j chunk'
+
+    def test_put_then_get_batch_returns_the_text(self, chunk_store):
+        chunk_store.put('chunk-live-1', 'text one')
+        chunk_store.put('chunk-live-2', 'text two')
+
+        assert chunk_store.get_batch(['chunk-live-1', 'chunk-live-2']) == {
+            'chunk-live-1': 'text one',
+            'chunk-live-2': 'text two',
+        }
+
+    def test_put_overwrites_existing_text(self, chunk_store):
+        chunk_store.put('chunk-live-1', 'first text')
+        chunk_store.put('chunk-live-1', 'second text')
+
+        assert chunk_store.get('chunk-live-1') == 'second text'
+
+    def test_get_returns_none_for_unwritten_chunk(self, chunk_store):
+        assert chunk_store.get('chunk-never-written') is None
+
+    def test_get_batch_omits_unwritten_chunks(self, chunk_store):
+        chunk_store.put('chunk-live-1', 'text one')
+
+        assert chunk_store.get_batch(['chunk-live-1', 'chunk-never-written']) == {
+            'chunk-live-1': 'text one',
+        }

--- a/lexical-graph/tests/unit/storage/chunk/test_chunk_store.py
+++ b/lexical-graph/tests/unit/storage/chunk/test_chunk_store.py
@@ -15,16 +15,19 @@ class TestChunkStoreContract:
         with pytest.raises(TypeError):
             ChunkStore()
 
-    def test_subclass_missing_get_cannot_instantiate(self):
-        class IncompleteChunkStore(ChunkStore):
+    def test_subclass_omitting_get_can_instantiate_and_uses_default(self):
+        class ChunkStoreWithoutGet(ChunkStore):
             def put(self, chunk_id, text):
                 pass
 
             def get_batch(self, chunk_ids):
-                return {}
+                known = {'chunk-1': 'text-chunk-1'}
+                return {chunk_id: known[chunk_id] for chunk_id in chunk_ids if chunk_id in known}
 
-        with pytest.raises(TypeError):
-            IncompleteChunkStore()
+        store = ChunkStoreWithoutGet()
+
+        assert store.get('chunk-1') == 'text-chunk-1'
+        assert store.get('missing-chunk') is None
 
     def test_subclass_missing_put_cannot_instantiate(self):
         class IncompleteChunkStore(ChunkStore):

--- a/lexical-graph/tests/unit/storage/chunk/test_chunk_store.py
+++ b/lexical-graph/tests/unit/storage/chunk/test_chunk_store.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ChunkStore abstract base class."""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.storage.chunk import ChunkStore
+
+
+class TestChunkStoreContract:
+    """Verify ChunkStore enforces its abstract contract."""
+
+    def test_cannot_instantiate_chunk_store_directly(self):
+        with pytest.raises(TypeError):
+            ChunkStore()
+
+    def test_subclass_missing_get_cannot_instantiate(self):
+        class IncompleteChunkStore(ChunkStore):
+            def put(self, chunk_id, text):
+                pass
+
+            def get_batch(self, chunk_ids):
+                return {}
+
+        with pytest.raises(TypeError):
+            IncompleteChunkStore()
+
+    def test_subclass_missing_put_cannot_instantiate(self):
+        class IncompleteChunkStore(ChunkStore):
+            def get(self, chunk_id):
+                return None
+
+            def get_batch(self, chunk_ids):
+                return {}
+
+        with pytest.raises(TypeError):
+            IncompleteChunkStore()
+
+    def test_subclass_missing_get_batch_cannot_instantiate(self):
+        class IncompleteChunkStore(ChunkStore):
+            def get(self, chunk_id):
+                return None
+
+            def put(self, chunk_id, text):
+                pass
+
+        with pytest.raises(TypeError):
+            IncompleteChunkStore()
+
+    def test_subclass_implementing_all_methods_can_instantiate(self):
+        class CompleteChunkStore(ChunkStore):
+            def get(self, chunk_id):
+                return 'text'
+
+            def put(self, chunk_id, text):
+                pass
+
+            def get_batch(self, chunk_ids):
+                return {chunk_id: 'text' for chunk_id in chunk_ids}
+
+        store = CompleteChunkStore()
+
+        assert store.get('chunk-1') == 'text'
+        assert store.get_batch(['chunk-1']) == {'chunk-1': 'text'}

--- a/lexical-graph/tests/unit/storage/chunk/test_in_graph_chunk_store.py
+++ b/lexical-graph/tests/unit/storage/chunk/test_in_graph_chunk_store.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for InGraphChunkStore, which preserves the current chunk.value behavior."""
+
+from unittest.mock import Mock
+
+from graphrag_toolkit.lexical_graph.storage.chunk import ChunkStore, InGraphChunkStore
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.graph.graph_store import format_id
+
+
+class TestInGraphChunkStoreGet:
+
+    def test_get_returns_value_for_known_chunk(self):
+        graph_client = Mock(spec=GraphStore)
+        graph_client.node_id.side_effect = format_id
+        graph_client.execute_query.return_value = [
+            {'result': {'chunk': {'chunkId': 'chunk-1', 'value': 'hello world'}}}
+        ]
+
+        store = InGraphChunkStore(graph_client)
+
+        assert store.get('chunk-1') == 'hello world'
+
+    def test_get_returns_none_for_unknown_chunk(self):
+        graph_client = Mock(spec=GraphStore)
+        graph_client.node_id.side_effect = format_id
+        graph_client.execute_query.return_value = []
+
+        store = InGraphChunkStore(graph_client)
+
+        assert store.get('missing-chunk') is None
+
+
+class TestInGraphChunkStoreGetBatch:
+
+    def test_get_batch_returns_values_keyed_by_chunk_id(self):
+        graph_client = Mock(spec=GraphStore)
+        graph_client.node_id.side_effect = format_id
+        graph_client.execute_query.return_value = [
+            {'result': {'chunk': {'chunkId': 'chunk-1', 'value': 'text one'}}},
+            {'result': {'chunk': {'chunkId': 'chunk-2', 'value': 'text two'}}},
+        ]
+
+        store = InGraphChunkStore(graph_client)
+
+        assert store.get_batch(['chunk-1', 'chunk-2']) == {
+            'chunk-1': 'text one',
+            'chunk-2': 'text two',
+        }
+
+    def test_get_batch_omits_chunks_with_no_match(self):
+        graph_client = Mock(spec=GraphStore)
+        graph_client.node_id.side_effect = format_id
+        graph_client.execute_query.return_value = [
+            {'result': {'chunk': {'chunkId': 'chunk-1', 'value': 'text one'}}},
+        ]
+
+        store = InGraphChunkStore(graph_client)
+
+        assert store.get_batch(['chunk-1', 'chunk-2']) == {'chunk-1': 'text one'}
+
+    def test_get_batch_empty_input_returns_empty_dict(self):
+        graph_client = Mock(spec=GraphStore)
+
+        store = InGraphChunkStore(graph_client)
+
+        assert store.get_batch([]) == {}
+        graph_client.execute_query.assert_not_called()
+
+
+class TestInGraphChunkStorePut:
+
+    def test_put_writes_chunk_value_with_retry(self):
+        graph_client = Mock(spec=GraphStore)
+        graph_client.node_id.side_effect = format_id
+
+        store = InGraphChunkStore(graph_client)
+        store.put('chunk-1', 'new text')
+
+        graph_client.execute_query_with_retry.assert_called_once()
+        query, params = graph_client.execute_query_with_retry.call_args.args[:2]
+        assert 'chunk.value' in query
+        assert params['params'] == [{'chunk_id': 'chunk-1', 'text': 'new text'}]
+
+
+class TestInGraphChunkStoreIsChunkStore:
+
+    def test_in_graph_chunk_store_is_a_chunk_store(self):
+        graph_client = Mock(spec=GraphStore)
+        store = InGraphChunkStore(graph_client)
+
+        assert isinstance(store, ChunkStore)

--- a/lexical-graph/tests/unit/storage/chunk/test_in_graph_chunk_store.py
+++ b/lexical-graph/tests/unit/storage/chunk/test_in_graph_chunk_store.py
@@ -69,6 +69,20 @@ class TestInGraphChunkStoreGetBatch:
         assert store.get_batch([]) == {}
         graph_client.execute_query.assert_not_called()
 
+    def test_get_batch_does_not_require_a_source_relationship(self):
+        graph_client = Mock(spec=GraphStore)
+        graph_client.node_id.side_effect = format_id
+        graph_client.execute_query.return_value = [
+            {'result': {'chunk': {'chunkId': 'chunk-1', 'value': 'text one'}}},
+        ]
+
+        store = InGraphChunkStore(graph_client)
+
+        assert store.get_batch(['chunk-1']) == {'chunk-1': 'text one'}
+
+        query = graph_client.execute_query.call_args.args[0]
+        assert 'EXTRACTED_FROM' not in query
+
 
 class TestInGraphChunkStorePut:
 

--- a/lexical-graph/tests/unit/storage/test_chunk_store_factory.py
+++ b/lexical-graph/tests/unit/storage/test_chunk_store_factory.py
@@ -74,6 +74,21 @@ class TestChunkStoreFactoryForChunkStore:
         with pytest.raises(ValueError, match="InGraphChunkStoreFactory requires a graph_store"):
             ChunkStoreFactory.for_chunk_store(None)
 
+    def test_factory_accepts_a_duck_typed_graph_client(self):
+        # GraphBatchClient (the object real builders pass as graph_client) does
+        # not subclass GraphStore, only duck-types it - the factory must not
+        # reject it via isinstance.
+        class DuckTypedGraphClient:
+            def node_id(self, name):
+                return name
+
+            def execute_query_with_retry(self, query, params, **kwargs):
+                pass
+
+        result = ChunkStoreFactory.for_chunk_store(None, graph_store=DuckTypedGraphClient())
+
+        assert isinstance(result, InGraphChunkStore)
+
 
 class TestChunkStoreFactoryCustomFactory:
 

--- a/lexical-graph/tests/unit/storage/test_chunk_store_factory.py
+++ b/lexical-graph/tests/unit/storage/test_chunk_store_factory.py
@@ -1,0 +1,105 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ChunkStoreFactory.
+
+Mirrors test_graph_store_factory.py: registration, dispatch to the default
+in-graph factory, and custom factory registration.
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
+from graphrag_toolkit.lexical_graph.storage.chunk import (
+    ChunkStore,
+    ChunkStoreFactoryMethod,
+    InGraphChunkStore,
+)
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+
+
+class TestChunkStoreFactoryRegister:
+
+    def test_register_factory_class(self):
+        class MockChunkStoreFactory(ChunkStoreFactoryMethod):
+            def try_create(self, chunk_info, **kwargs):
+                return None
+
+        ChunkStoreFactory.register(MockChunkStoreFactory)
+
+    def test_register_factory_instance(self):
+        class MockChunkStoreFactory(ChunkStoreFactoryMethod):
+            def try_create(self, chunk_info, **kwargs):
+                return None
+
+        ChunkStoreFactory.register(MockChunkStoreFactory())
+
+    def test_register_invalid_class_raises_error(self):
+        class InvalidFactory:
+            pass
+
+        with pytest.raises(ValueError, match="must inherit from ChunkStoreFactoryMethod"):
+            ChunkStoreFactory.register(InvalidFactory)
+
+    def test_register_invalid_instance_raises_error(self):
+        class InvalidFactory:
+            pass
+
+        with pytest.raises(ValueError, match="must inherit from ChunkStoreFactoryMethod"):
+            ChunkStoreFactory.register(InvalidFactory())
+
+
+class TestChunkStoreFactoryForChunkStore:
+
+    def test_factory_returns_existing_chunk_store_instance(self):
+        mock_store = Mock(spec=ChunkStore)
+
+        result = ChunkStoreFactory.for_chunk_store(mock_store)
+
+        assert result is mock_store
+
+    def test_factory_creates_in_graph_store_by_default(self):
+        graph_client = Mock(spec=GraphStore)
+
+        result = ChunkStoreFactory.for_chunk_store(None, graph_store=graph_client)
+
+        assert isinstance(result, InGraphChunkStore)
+
+    def test_factory_invalid_type_raises_error(self):
+        with pytest.raises(ValueError, match="Unrecognized chunk store info"):
+            ChunkStoreFactory.for_chunk_store("invalid://unknown")
+
+    def test_factory_missing_graph_store_kwarg_raises_specific_error(self):
+        with pytest.raises(ValueError, match="InGraphChunkStoreFactory requires a graph_store"):
+            ChunkStoreFactory.for_chunk_store(None)
+
+
+class TestChunkStoreFactoryCustomFactory:
+
+    def test_custom_factory_can_create_store(self):
+        class CustomChunkStoreFactory(ChunkStoreFactoryMethod):
+            def try_create(self, chunk_info, **kwargs):
+                if chunk_info == 'custom://':
+                    return Mock(spec=ChunkStore)
+                return None
+
+        ChunkStoreFactory.register(CustomChunkStoreFactory)
+
+        result = ChunkStoreFactory.for_chunk_store('custom://')
+
+        assert isinstance(result, ChunkStore)
+
+    def test_registered_factory_is_tried_before_in_graph_default(self):
+        class FalsyChunkInfoFactory(ChunkStoreFactoryMethod):
+            def try_create(self, chunk_info, **kwargs):
+                if not chunk_info:
+                    return Mock(spec=ChunkStore)
+                return None
+
+        ChunkStoreFactory.register(FalsyChunkInfoFactory)
+
+        graph_client = Mock(spec=GraphStore)
+        result = ChunkStoreFactory.for_chunk_store(None, graph_store=graph_client)
+
+        assert not isinstance(result, InGraphChunkStore)

--- a/lexical-graph/tests/unit/storage/test_chunk_store_factory.py
+++ b/lexical-graph/tests/unit/storage/test_chunk_store_factory.py
@@ -10,6 +10,7 @@ in-graph factory, and custom factory registration.
 import pytest
 from unittest.mock import Mock
 
+from graphrag_toolkit.lexical_graph.storage import chunk_store_factory
 from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
 from graphrag_toolkit.lexical_graph.storage.chunk import (
     ChunkStore,
@@ -17,6 +18,17 @@ from graphrag_toolkit.lexical_graph.storage.chunk import (
     InGraphChunkStore,
 )
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+
+
+@pytest.fixture(autouse=True)
+def isolate_chunk_store_registry():
+    """Registrations live in a module-level dict, so without this a test
+    that registers a broadly-matching factory changes what every later
+    test sees."""
+    saved = dict(chunk_store_factory._chunk_store_factories)
+    yield
+    chunk_store_factory._chunk_store_factories.clear()
+    chunk_store_factory._chunk_store_factories.update(saved)
 
 
 class TestChunkStoreFactoryRegister:
@@ -69,6 +81,13 @@ class TestChunkStoreFactoryForChunkStore:
     def test_factory_invalid_type_raises_error(self):
         with pytest.raises(ValueError, match="Unrecognized chunk store info"):
             ChunkStoreFactory.for_chunk_store("invalid://unknown")
+
+    def test_in_graph_default_not_used_for_unrecognized_chunk_info(self):
+        # The in-graph store is the default for empty chunk_info only. An
+        # unrecognized backend URI is an error, not something to silently
+        # fall back on - a typo'd URI should fail loudly.
+        with pytest.raises(ValueError, match="Unrecognized chunk store info"):
+            ChunkStoreFactory.for_chunk_store('unknown://somewhere', graph_store=Mock(spec=GraphStore))
 
     def test_factory_missing_graph_store_kwarg_raises_specific_error(self):
         with pytest.raises(ValueError, match="InGraphChunkStoreFactory requires a graph_store"):


### PR DESCRIPTION
## Description

Chunk text is stored inline as a `chunk.value` property on every `__Chunk__` node. Neptune keeps all node properties in memory whether or not a query reads them, so at scale this costs memory for text that is only needed at answer synthesis. This PR adds a `ChunkStore` interface for chunk text and an `InGraphChunkStore` that keeps today's behavior as the default. Nothing is wired to it yet, so there is no behavior change. Wiring the write and read paths (#437) and adding an S3 backend are follow-ups that merge after this.

## Changes

- `ChunkStore`, an abstract interface for chunk text. `put` and `get_batch` are abstract; `get` defaults to `get_batch([chunk_id]).get(chunk_id)`, so a backend only implements `get_batch`. `put()` has a TODO noting there is no batched write yet: `ChunkGraphBuilder` calls `put()` once per chunk while reads already batch, so writes are where the remaining ingestion cost sits.
- `InGraphChunkStore`, which reads and writes `chunk.value` on `__Chunk__` nodes. `get_batch()` matches on chunk id alone. It does not require the `__EXTRACTED_FROM__` link to a `__Source__` that `get_chunks_query` requires, because `put()` never creates that link: requiring it on read would make text written through the store unreadable from the same store.
- `ChunkStoreFactory`, a registration pattern for backends. Registered factories are tried in registration order. If none match and no `chunk_info` was given, the in-graph store is the default; a non-empty `chunk_info` nothing recognizes raises, so a typo'd URI fails loudly. This differs from `GraphStoreFactory`, which has no default and raises for empty `graph_info` too.
- `try_create` is annotated `Optional[ChunkStore]`, since it returns `None` when a factory doesn't recognize `chunk_info`. `GraphStoreFactoryMethod` and `VectorIndexFactoryMethod` document returning `None` while annotated otherwise; left alone to keep this PR to one concern.
- A shared `graph_utils.to_params()` helper for the `UNWIND $params` wrapping already used by `GraphBuilder._to_params`, so `InGraphChunkStore.put()` doesn't duplicate it.

## Problem

Related issue (if any): #324

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Unit tests cover the abstract contract, `InGraphChunkStore` against a mocked graph client, and factory registration and dispatch.

`tests/integration/storage/chunk/test_chunk_store_live_neo4j.py` runs the store against a real Neo4j instance, skipped unless `NEO4J_TEST_URI` is set (the container command is in the file header). Mocked tests assert on the shape of the query string, so they can't catch a query that is well-formed but matches nothing. That is the bug this caught: `put()` wrote a chunk `get_batch()` could not read back. Four of its five cases fail against the pre-fix query.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable) — internal interface, no user-facing config surface until an external backend lands
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
