### PR TITLE
[FEATURE] Wire ChunkGraphBuilder and read paths to ChunkStore

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/chunk_graph_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/chunk_graph_builder.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
 from graphrag_toolkit.lexical_graph.indexing.build.graph_builder import GraphBuilder
 
 from llama_index.core.schema import BaseNode
@@ -57,33 +58,35 @@ class ChunkGraphBuilder(GraphBuilder):
 
             logger.debug(f'Inserting chunk [chunk_id: {chunk_id}]')
 
-            statements_c = [
-                '// insert chunks',
-                'UNWIND $params AS params',
-                f'MERGE (chunk:`__Chunk__`{{{graph_client.node_id("chunkId")}: params.chunk_id}})'
-            ]
+            chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=graph_client)
+            chunk_store.put(chunk_id, node.text)
 
-            chunk_property_setters = [
-                'chunk.value = params.text'
-            ]
-            
-            properties_c = {
-                'chunk_id': chunk_id,
-                'text': node.text
-            }
+            chunk_property_setters = []
+            properties_c = {'chunk_id': chunk_id}
 
-            # Add external properties if present
+            # Add external properties if present. 'chunkId' and 'value' are
+            # skipped: chunkId is the merge key, and value is chunk text,
+            # already written via chunk_store.put() above - a metadata field
+            # named 'value' must not overwrite it.
             for key, value in chunk_metadata.items():
-                if key != 'chunkId':  # Skip the ID field
+                if key not in ('chunkId', 'value'):
                     chunk_property_setters.append(f'chunk.{key} = params.{key}')
                     properties_c[key] = value
 
-            setter_statement = f"ON CREATE SET {', '.join(chunk_property_setters)} ON MATCH SET {', '.join(chunk_property_setters)}" 
-            statements_c.append(setter_statement)
+            if chunk_property_setters:
 
-            query_c = '\n'.join(statements_c)
+                statements_c = [
+                    '// insert chunk metadata',
+                    'UNWIND $params AS params',
+                    f'MERGE (chunk:`__Chunk__`{{{graph_client.node_id("chunkId")}: params.chunk_id}})'
+                ]
 
-            graph_client.execute_query_with_retry(query_c, self._to_params(properties_c), max_attempts=5, max_wait=7)
+                setter_statement = f"ON CREATE SET {', '.join(chunk_property_setters)} ON MATCH SET {', '.join(chunk_property_setters)}"
+                statements_c.append(setter_statement)
+
+                query_c = '\n'.join(statements_c)
+
+                graph_client.execute_query_with_retry(query_c, self._to_params(properties_c), max_attempts=5, max_wait=7)
 
             source_info = node.relationships.get(NodeRelationship.SOURCE, None)
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/graph_batch_client.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/graph_batch_client.py
@@ -77,7 +77,21 @@ class GraphBatchClient():
             Any: The ID of the node as returned by the `graph_client`.
         """
         return self.graph_client.node_id(id_name)
-    
+
+    def execute_query(self, query, parameters={}, **kwargs):
+        """
+        Executes a read query via the underlying graph client. Reads aren't
+        batched, so this passes straight through rather than queuing.
+
+        Args:
+            query: The query to execute.
+            parameters: Query parameters.
+
+        Returns:
+            The graph client's query result.
+        """
+        return self.graph_client.execute_query(query, parameters, **kwargs)
+
     def property_assigment_fn(self, key:str, value:Any) -> Callable[[str], str]:
         """
         Assigns a property to a specified key and returns a function to retrieve the property.

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/graph_batch_client.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/graph_batch_client.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Dict, Any, List, Callable
+from typing import Dict, Any, List, Callable, Optional
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore, Query, QueryTree
 
 BATCH_MAX_ATTEMPTS = 10
@@ -78,7 +78,7 @@ class GraphBatchClient():
         """
         return self.graph_client.node_id(id_name)
 
-    def execute_query(self, query, parameters={}, **kwargs):
+    def execute_query(self, query, parameters={}, correlation_id:Optional[str]=None):
         """
         Executes a read query via the underlying graph client. Reads aren't
         batched, so this passes straight through rather than queuing.
@@ -86,11 +86,12 @@ class GraphBatchClient():
         Args:
             query: The query to execute.
             parameters: Query parameters.
+            correlation_id: Optional id used to correlate the query in logs.
 
         Returns:
             The graph client's query result.
         """
-        return self.graph_client.execute_query(query, parameters, **kwargs)
+        return self.graph_client.execute_query(query, parameters, correlation_id)
 
     def property_assigment_fn(self, key:str, value:Any) -> Callable[[str], str]:
         """

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/update_chunk_metadata.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/processors/update_chunk_metadata.py
@@ -15,6 +15,9 @@ class UpdateChunkMetadata(ProcessorBase):
     def _process_results(self, search_results:SearchResultCollection, query:QueryBundle) -> SearchResultCollection:
         def update_chunks(topic:Topic):
             for chunk in topic.chunks:
+                # TraversalBasedBaseRetriever's get_statements_by_topic_and_source()
+                # already promotes 'value' out of metadata when it's available, so
+                # this is usually a no-op for that path.
                 value = chunk.metadata.pop('value', None)
                 chunk.metadata.pop('chunkId', None)
                 if value:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
@@ -11,7 +11,6 @@ from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
 from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
 from graphrag_toolkit.lexical_graph.storage.vector import VectorStore
 from graphrag_toolkit.lexical_graph.storage.vector import DummyVectorIndex
-from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import node_result
 from graphrag_toolkit.lexical_graph.retrieval.model import ScoredEntity
 from graphrag_toolkit.lexical_graph.retrieval.utils.vector_utils import get_diverse_vss_elements
 from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_provider_base import KeywordProviderBase
@@ -51,6 +50,7 @@ class KeywordVSSProvider(KeywordProviderBase):
         self.graph_store = graph_store
         self.vector_store = vector_store
         self.filter_config = filter_config
+        self.chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=graph_store)
 
         self.index_name = 'topic' if not isinstance(vector_store.get_index('topic'), DummyVectorIndex) else 'chunk'
 
@@ -75,9 +75,11 @@ class KeywordVSSProvider(KeywordProviderBase):
     
     def _get_chunk_content(self, node_ids:List[str]) -> List[str]:
 
-        chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=self.graph_store)
+        # Keyed lookup rather than .values(): node_ids arrives in VSS relevance
+        # order, and the store returns whatever order the backend does.
+        chunk_text_by_id = self.chunk_store.get_batch(node_ids)
 
-        return list(chunk_store.get_batch(node_ids).values())
+        return [chunk_text_by_id[node_id] for node_id in node_ids if node_id in chunk_text_by_id]
     
     def _get_topic_content(self, node_ids:List[str]) -> List[str]:
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/query_context/keyword_vss_provider.py
@@ -8,6 +8,7 @@ from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
 from graphrag_toolkit.lexical_graph.utils import LLMCache, LLMCacheType
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
 from graphrag_toolkit.lexical_graph.storage.vector import VectorStore
 from graphrag_toolkit.lexical_graph.storage.vector import DummyVectorIndex
 from graphrag_toolkit.lexical_graph.storage.graph.graph_utils import node_result
@@ -73,23 +74,10 @@ class KeywordVSSProvider(KeywordProviderBase):
         return node_ids
     
     def _get_chunk_content(self, node_ids:List[str]) -> List[str]:
-        
-        cypher = f"""
-        // get chunk content
-        MATCH (c:`__Chunk__`)
-        WHERE {self.graph_store.node_id("c.chunkId")} in $nodeIds
-        RETURN c.value AS content
-        """
 
-        parameters = {
-            'nodeIds': node_ids
-        }
+        chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=self.graph_store)
 
-        results = self.graph_store.execute_query(cypher, parameters)
-
-        content = [result['content'] for result in results]
-
-        return content
+        return list(chunk_store.get_batch(node_ids).values())
     
     def _get_topic_content(self, node_ids:List[str]) -> List[str]:
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/traversal_based_base_retriever.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/traversal_based_base_retriever.py
@@ -10,6 +10,7 @@ from importlib.metadata import version, PackageNotFoundError
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig
 from graphrag_toolkit.lexical_graph.versioning import VALID_FROM, VALID_TO, EXTRACT_TIMESTAMP, BUILD_TIMESTAMP, VERSION_INDEPENDENT_ID_FIELDS, TIMESTAMP_LOWER_BOUND, TIMESTAMP_UPPER_BOUND
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
 from graphrag_toolkit.lexical_graph.storage.vector.vector_store import VectorStore
 from graphrag_toolkit.lexical_graph.retrieval.query_context import KeywordProvider, KeywordVSSProvider, KeywordNLPProvider, KeywordProviderMode, PassThruKeywordProvider
 from graphrag_toolkit.lexical_graph.retrieval.query_context import EntityProvider, EntityVSSProvider, EntityContextProvider
@@ -213,6 +214,37 @@ class TraversalBasedBaseRetriever(BaseRetriever):
                     if facts:
                         statement['facts'] = facts
                         statement['score'] = len(facts)
+
+        if self.args.include_chunk_details:
+
+            all_chunks = [
+                chunk
+                for statements_result in statements_results
+                for topic in statements_result['result']['topics']
+                for chunk in topic['chunks']
+            ]
+
+            if all_chunks:
+                # properties(c) (queried above as chunk metadata) already
+                # includes chunk.value for the in-graph backend - use it
+                # directly rather than paying for a second round trip to
+                # fetch the same text via ChunkStore. Only backends that
+                # don't store text as a graph property (e.g. a future
+                # S3-backed ChunkStore) need the ChunkStore.get_batch() call.
+                chunks_needing_fetch = []
+                for chunk in all_chunks:
+                    value = chunk['metadata'].pop('value', None)
+                    if value is not None:
+                        chunk['value'] = value
+                    else:
+                        chunks_needing_fetch.append(chunk)
+
+                if chunks_needing_fetch:
+                    chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=self.graph_store)
+                    chunk_text_by_id = chunk_store.get_batch([chunk['chunkId'] for chunk in chunks_needing_fetch])
+
+                    for chunk in chunks_needing_fetch:
+                        chunk['value'] = chunk_text_by_id.get(chunk['chunkId'])
 
         return statements_results
     

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/traversal_based_base_retriever.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/traversal_based_base_retriever.py
@@ -121,6 +121,7 @@ class TraversalBasedBaseRetriever(BaseRetriever):
         
         self.graph_store = graph_store
         self.vector_store = vector_store
+        self.chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=graph_store)
         if processors is not None:
             self.processors = processors
         else:
@@ -240,8 +241,7 @@ class TraversalBasedBaseRetriever(BaseRetriever):
                         chunks_needing_fetch.append(chunk)
 
                 if chunks_needing_fetch:
-                    chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=self.graph_store)
-                    chunk_text_by_id = chunk_store.get_batch([chunk['chunkId'] for chunk in chunks_needing_fetch])
+                    chunk_text_by_id = self.chunk_store.get_batch([chunk['chunkId'] for chunk in chunks_needing_fetch])
 
                     for chunk in chunks_needing_fetch:
                         chunk['value'] = chunk_text_by_id.get(chunk['chunkId'])

--- a/lexical-graph/tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
+++ b/lexical-graph/tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
@@ -1,0 +1,121 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live end-to-end check of the ChunkStore write/read wiring against a real
+Neo4j instance. Mocked unit tests can't catch a malformed Cypher query or a
+graph client that doesn't duck-type the way a factory expects - both bugs
+this test's ancestor scratch runs actually caught during development.
+
+Skipped unless NEO4J_TEST_URI is set. To run locally:
+
+    finch run -d --name chunk-store-test -p 7687:7687 \\
+        -e NEO4J_AUTH=neo4j/testpassword123 neo4j:5
+    NEO4J_TEST_URI=bolt://neo4j:testpassword123@localhost:7687 \\
+        pytest tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
+    finch stop chunk-store-test && finch rm chunk-store-test
+"""
+
+import os
+
+import pytest
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
+
+from graphrag_toolkit.lexical_graph.indexing.build.chunk_graph_builder import ChunkGraphBuilder
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.retrieval.processors import ProcessorArgs
+from graphrag_toolkit.lexical_graph.retrieval.query_context.keyword_vss_provider import KeywordVSSProvider
+from graphrag_toolkit.lexical_graph.retrieval.retrievers.traversal_based_base_retriever import (
+    TraversalBasedBaseRetriever,
+)
+from graphrag_toolkit.lexical_graph.retrieval.model import SearchResultCollection
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
+from graphrag_toolkit.lexical_graph.storage.graph_store_factory import GraphStoreFactory
+
+NEO4J_TEST_URI = os.environ.get('NEO4J_TEST_URI')
+
+pytestmark = pytest.mark.skipif(
+    not NEO4J_TEST_URI,
+    reason='set NEO4J_TEST_URI to a running Neo4j instance to run this live test',
+)
+
+
+class _ConcreteRetriever(TraversalBasedBaseRetriever):
+    def get_start_node_ids(self, query_bundle):
+        return []
+
+    def do_graph_search(self, query_bundle, start_node_ids):
+        return SearchResultCollection()
+
+
+@pytest.fixture
+def graph_client():
+    client = GraphStoreFactory.for_graph_store(NEO4J_TEST_URI)
+    client.execute_query('MATCH (n) DETACH DELETE n', {})
+    yield client
+    client.execute_query('MATCH (n) DETACH DELETE n', {})
+
+
+class TestChunkStoreLiveWiring:
+
+    def _write_chunk(self, graph_client, chunk_id, text, source_id, chunk_metadata=None):
+        node = TextNode(text=text)
+        node.metadata = {'chunk': {'chunkId': chunk_id, 'metadata': chunk_metadata or {}}}
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=source_id)
+        ChunkGraphBuilder().build(node, graph_client)
+
+    def test_write_then_read_via_chunk_store(self, graph_client):
+        self._write_chunk(graph_client, 'chunk-live-1', 'hello from a live neo4j chunk', 'source-live-1')
+
+        chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=graph_client)
+
+        assert chunk_store.get('chunk-live-1') == 'hello from a live neo4j chunk'
+        assert chunk_store.get_batch(['chunk-live-1']) == {'chunk-live-1': 'hello from a live neo4j chunk'}
+
+    def test_write_then_read_via_keyword_vss_provider(self, graph_client):
+        self._write_chunk(graph_client, 'chunk-live-2', 'the quick brown fox', 'source-live-2')
+
+        provider = KeywordVSSProvider.__new__(KeywordVSSProvider)
+        provider.graph_store = graph_client
+
+        content = provider._get_chunk_content(['chunk-live-2'])
+
+        assert content == ['the quick brown fox']
+
+    def test_write_then_read_via_traversal_retriever_with_chunk_details(self, graph_client):
+        self._write_chunk(
+            graph_client, 'chunk-live-3', 'second chunk text', 'source-live-3',
+            chunk_metadata={'page_number': 3},
+        )
+
+        graph_client.execute_query(
+            '''
+            MATCH (chunk:`__Chunk__` {chunkId: $chunk_id})
+            MERGE (topic:`__Topic__` {topicId: $topic_id})
+            ON CREATE SET topic.value = $topic_value
+            MERGE (statement:`__Statement__` {statementId: $statement_id})
+            ON CREATE SET statement.value = $statement_value, statement.details = ''
+            MERGE (statement)-[:`__BELONGS_TO__`]->(topic)
+            MERGE (statement)-[:`__MENTIONED_IN__`]->(chunk)
+            ''',
+            {
+                'chunk_id': 'chunk-live-3',
+                'topic_id': 'topic-live-3',
+                'topic_value': 'Topic',
+                'statement_id': 'statement-live-3',
+                'statement_value': 'A statement about the chunk.',
+            },
+        )
+
+        retriever = _ConcreteRetriever(
+            graph_store=graph_client,
+            vector_store=None,
+            processor_args=ProcessorArgs(include_chunk_details=True),
+            filter_config=FilterConfig(),
+        )
+
+        results = retriever.get_statements_by_topic_and_source(['statement-live-3'])
+        chunk = results[0]['result']['topics'][0]['chunks'][0]
+
+        assert chunk['value'] == 'second chunk text'
+        assert 'value' not in chunk['metadata']
+        assert chunk['metadata']['page_number'] == 3

--- a/lexical-graph/tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
+++ b/lexical-graph/tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
@@ -6,7 +6,8 @@ Neo4j instance. Mocked unit tests can't catch a malformed Cypher query or a
 graph client that doesn't duck-type the way a factory expects - both bugs
 this test's ancestor scratch runs actually caught during development.
 
-Skipped unless NEO4J_TEST_URI is set. To run locally:
+Skipped unless NEO4J_TEST_URI is set, and fails rather than runs if that URI
+points at a database that already holds data. To run locally:
 
     finch run -d --name chunk-store-test -p 7687:7687 \\
         -e NEO4J_AUTH=neo4j/testpassword123 neo4j:5
@@ -50,8 +51,23 @@ class _ConcreteRetriever(TraversalBasedBaseRetriever):
 @pytest.fixture
 def graph_client():
     client = GraphStoreFactory.for_graph_store(NEO4J_TEST_URI)
-    client.execute_query('MATCH (n) DETACH DELETE n', {})
+
+    rows = client.execute_query('MATCH (n) RETURN count(n) AS node_count', {})
+    node_count = rows[0]['node_count'] if rows else 0
+    if node_count:
+        pytest.fail(
+            f'NEO4J_TEST_URI points at a database that is not empty (node count: '
+            f'{node_count}). This test writes and deletes chunk and source nodes, so it '
+            f'only runs against an empty database. Point NEO4J_TEST_URI at a throwaway '
+            f'instance.'
+        )
+
     yield client
+
+    # Safe to delete unconditionally: the check above proved the database was empty, so
+    # everything here now was written by this test. These tests seed topic and statement
+    # nodes as well as the chunks and sources ChunkGraphBuilder writes, so deleting by
+    # label would leave residue behind every time that set grows.
     client.execute_query('MATCH (n) DETACH DELETE n', {})
 
 

--- a/lexical-graph/tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
+++ b/lexical-graph/tests/integration/storage/chunk/test_chunk_store_wiring_live_neo4j.py
@@ -74,8 +74,10 @@ class TestChunkStoreLiveWiring:
     def test_write_then_read_via_keyword_vss_provider(self, graph_client):
         self._write_chunk(graph_client, 'chunk-live-2', 'the quick brown fox', 'source-live-2')
 
+        # Bypasses __init__, which needs a vector store this test has no use for.
         provider = KeywordVSSProvider.__new__(KeywordVSSProvider)
         provider.graph_store = graph_client
+        provider.chunk_store = ChunkStoreFactory.for_chunk_store(graph_store=graph_client)
 
         content = provider._get_chunk_content(['chunk-live-2'])
 

--- a/lexical-graph/tests/unit/indexing/build/test_chunk_graph_builder.py
+++ b/lexical-graph/tests/unit/indexing/build/test_chunk_graph_builder.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from graphrag_toolkit.lexical_graph.indexing.build.chunk_graph_builder import ChunkGraphBuilder
 from llama_index.core.schema import NodeRelationship
 
@@ -109,6 +109,68 @@ class TestChunkGraphBuilding:
         client = self._make_graph_client()
         builder.build(node, client)
 
-        # Verify the chunk insert query includes the custom property
-        first_call_params = client.execute_query_with_retry.call_args_list[0][0][1]
-        assert first_call_params['params'][0].get('custom_prop') == 'custom_value'
+        # The custom property is set in its own query, separate from the
+        # chunk-text write (which routes through ChunkStore.put()).
+        calls_with_custom_prop = [
+            call for call in client.execute_query_with_retry.call_args_list
+            if call[0][1]['params'] and call[0][1]['params'][0].get('custom_prop') == 'custom_value'
+        ]
+        assert len(calls_with_custom_prop) == 1
+
+    def test_build_with_metadata_value_key_does_not_overwrite_chunk_text(self):
+        """A chunk_metadata key literally named 'value' must not clobber the chunk text ChunkStore.put() writes."""
+        builder = ChunkGraphBuilder()
+        node = self._make_chunk_node(chunk_id='chunk_001', text='Sample text')
+        node.metadata['chunk']['metadata'] = {'value': 'attacker-controlled', 'other_prop': 'kept'}
+
+        client = self._make_graph_client()
+        mock_chunk_store = Mock()
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.build.chunk_graph_builder.ChunkStoreFactory.for_chunk_store',
+            return_value=mock_chunk_store,
+        ):
+            builder.build(node, client)
+
+        mock_chunk_store.put.assert_called_once_with('chunk_001', 'Sample text')
+
+        # the metadata-only query must never touch chunk.value
+        for call in client.execute_query_with_retry.call_args_list:
+            query = call[0][0]
+            assert 'chunk.value' not in query
+
+        # other_prop still gets set as usual
+        calls_with_other_prop = [
+            call for call in client.execute_query_with_retry.call_args_list
+            if call[0][1]['params'] and call[0][1]['params'][0].get('other_prop') == 'kept'
+        ]
+        assert len(calls_with_other_prop) == 1
+
+    def test_build_writes_chunk_text_via_chunk_store(self):
+        """Verify build routes chunk text through ChunkStoreFactory/ChunkStore.put()."""
+        builder = ChunkGraphBuilder()
+        node = self._make_chunk_node(chunk_id='chunk_001', text='Sample text')
+
+        client = self._make_graph_client()
+        mock_chunk_store = Mock()
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.build.chunk_graph_builder.ChunkStoreFactory.for_chunk_store',
+            return_value=mock_chunk_store,
+        ) as mock_for_chunk_store:
+            builder.build(node, client)
+
+        mock_for_chunk_store.assert_called_once_with(graph_store=client)
+        mock_chunk_store.put.assert_called_once_with('chunk_001', 'Sample text')
+
+    def test_build_skips_metadata_query_when_no_extra_properties(self):
+        """Verify build doesn't issue an empty SET query when there's no extra chunk metadata."""
+        builder = ChunkGraphBuilder()
+        node = self._make_chunk_node()
+
+        client = self._make_graph_client()
+        builder.build(node, client)
+
+        # chunk-text write (via ChunkStore) + source relationship = 2, no
+        # separate (and otherwise-empty) metadata SET query.
+        assert client.execute_query_with_retry.call_count == 2

--- a/lexical-graph/tests/unit/indexing/build/test_graph_batch_client.py
+++ b/lexical-graph/tests/unit/indexing/build/test_graph_batch_client.py
@@ -80,3 +80,19 @@ class TestGraphBatchClientNodeId:
         result = client.node_id('entityId')
         assert result == 'params.entityId'
         mock_neptune_store.node_id.assert_called_once_with('entityId')
+
+
+class TestGraphBatchClientExecuteQuery:
+    """Tests for execute_query delegation (reads aren't batched)."""
+
+    def test_execute_query_delegates_to_graph_client(self, mock_neptune_store):
+        """Verify execute_query passes straight through to the underlying graph client."""
+        mock_neptune_store.execute_query = Mock(return_value=[{'result': 'row'}])
+        client = GraphBatchClient(
+            graph_client=mock_neptune_store,
+            batch_writes_enabled=True,
+            batch_write_size=10,
+        )
+        result = client.execute_query('MATCH (n) RETURN n', {'a': 1})
+        assert result == [{'result': 'row'}]
+        mock_neptune_store.execute_query.assert_called_once_with('MATCH (n) RETURN n', {'a': 1})

--- a/lexical-graph/tests/unit/indexing/build/test_graph_batch_client.py
+++ b/lexical-graph/tests/unit/indexing/build/test_graph_batch_client.py
@@ -95,4 +95,25 @@ class TestGraphBatchClientExecuteQuery:
         )
         result = client.execute_query('MATCH (n) RETURN n', {'a': 1})
         assert result == [{'result': 'row'}]
-        mock_neptune_store.execute_query.assert_called_once_with('MATCH (n) RETURN n', {'a': 1})
+        mock_neptune_store.execute_query.assert_called_once_with('MATCH (n) RETURN n', {'a': 1}, None)
+
+    def test_execute_query_forwards_correlation_id(self, mock_neptune_store):
+        """Verify the correlation id GraphStore.execute_query accepts reaches it."""
+        mock_neptune_store.execute_query = Mock(return_value=[])
+        client = GraphBatchClient(
+            graph_client=mock_neptune_store,
+            batch_writes_enabled=True,
+            batch_write_size=10,
+        )
+        client.execute_query('MATCH (n) RETURN n', {}, correlation_id='abc123')
+        mock_neptune_store.execute_query.assert_called_once_with('MATCH (n) RETURN n', {}, 'abc123')
+
+    def test_execute_query_rejects_unsupported_kwargs(self, mock_neptune_store):
+        """GraphStore.execute_query takes no **kwargs, so neither does this passthrough."""
+        client = GraphBatchClient(
+            graph_client=mock_neptune_store,
+            batch_writes_enabled=True,
+            batch_write_size=10,
+        )
+        with pytest.raises(TypeError):
+            client.execute_query('MATCH (n) RETURN n', {}, max_attempts=3)

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
@@ -58,14 +58,18 @@ class TestKeywordVSSProvider:
 
     def test_get_chunk_content_returns_content_strings(self):
         provider, store, _ = _provider(use_chunk_index=True)
-        store.execute_query.return_value = [{'content': 'foo'}, {'content': 'bar'}]
-        result = provider._get_chunk_content(['c1', 'c2'])
-        assert result == ['foo', 'bar']
+        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
+            mock_factory.for_chunk_store.return_value.get_batch.return_value = {'c1': 'foo', 'c2': 'bar'}
+            result = provider._get_chunk_content(['c1', 'c2'])
+        mock_factory.for_chunk_store.assert_called_once_with(graph_store=store)
+        mock_factory.for_chunk_store.return_value.get_batch.assert_called_once_with(['c1', 'c2'])
+        assert sorted(result) == ['bar', 'foo']
 
     def test_get_content_dispatches_by_index_name(self):
         provider, store, _ = _provider(use_chunk_index=True)
-        store.execute_query.return_value = [{'content': 'hello'}]
-        assert provider._get_content(['c1']) == ['hello']
+        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
+            mock_factory.for_chunk_store.return_value.get_batch.return_value = {'c1': 'hello'}
+            assert provider._get_content(['c1']) == ['hello']
 
     def test_get_keywords_from_content_splits_response(self):
         provider, _, llm = _provider(llm_response='apple\norange\n')

--- a/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
+++ b/lexical-graph/tests/unit/retrieval/query_context/test_keyword_vss_provider.py
@@ -56,20 +56,35 @@ class TestKeywordVSSProvider:
             result = provider._get_node_ids(QueryBundle('q'))
         assert result == ['t1', 't2']
 
-    def test_get_chunk_content_returns_content_strings(self):
-        provider, store, _ = _provider(use_chunk_index=True)
+    def test_chunk_store_is_resolved_once_at_construction(self):
         with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
-            mock_factory.for_chunk_store.return_value.get_batch.return_value = {'c1': 'foo', 'c2': 'bar'}
-            result = provider._get_chunk_content(['c1', 'c2'])
+            provider, store, _ = _provider(use_chunk_index=True)
         mock_factory.for_chunk_store.assert_called_once_with(graph_store=store)
-        mock_factory.for_chunk_store.return_value.get_batch.assert_called_once_with(['c1', 'c2'])
-        assert sorted(result) == ['bar', 'foo']
+        assert provider.chunk_store is mock_factory.for_chunk_store.return_value
+
+    def test_get_chunk_content_returns_content_strings(self):
+        provider, _, _ = _provider(use_chunk_index=True)
+        provider.chunk_store = MagicMock()
+        provider.chunk_store.get_batch.return_value = {'c1': 'foo', 'c2': 'bar'}
+
+        result = provider._get_chunk_content(['c1', 'c2'])
+
+        provider.chunk_store.get_batch.assert_called_once_with(['c1', 'c2'])
+        assert result == ['foo', 'bar']
+
+    def test_get_chunk_content_keeps_node_id_order_and_skips_misses(self):
+        provider, _, _ = _provider(use_chunk_index=True)
+        provider.chunk_store = MagicMock()
+        # Backend returns its own order and has nothing for 'missing'.
+        provider.chunk_store.get_batch.return_value = {'c2': 'bar', 'c1': 'foo'}
+
+        assert provider._get_chunk_content(['c1', 'missing', 'c2']) == ['foo', 'bar']
 
     def test_get_content_dispatches_by_index_name(self):
-        provider, store, _ = _provider(use_chunk_index=True)
-        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
-            mock_factory.for_chunk_store.return_value.get_batch.return_value = {'c1': 'hello'}
-            assert provider._get_content(['c1']) == ['hello']
+        provider, _, _ = _provider(use_chunk_index=True)
+        provider.chunk_store = MagicMock()
+        provider.chunk_store.get_batch.return_value = {'c1': 'hello'}
+        assert provider._get_content(['c1']) == ['hello']
 
     def test_get_keywords_from_content_splits_response(self):
         provider, _, llm = _provider(llm_response='apple\norange\n')

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_traversal_based_base_retriever.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_traversal_based_base_retriever.py
@@ -206,10 +206,11 @@ class TestGetStatementsByTopicAndSource:
             [],
         ]
 
-        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
-            result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+        retriever.chunk_store = MagicMock()
 
-        mock_factory.for_chunk_store.assert_not_called()
+        result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+
+        retriever.chunk_store.get_batch.assert_not_called()
 
         chunk = result[0]['result']['topics'][0]['chunks'][0]
         assert chunk['value'] == 'real chunk text'
@@ -237,12 +238,12 @@ class TestGetStatementsByTopicAndSource:
             [],
         ]
 
-        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
-            mock_factory.for_chunk_store.return_value.get_batch.return_value = {'c1': 'fetched chunk text'}
-            result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+        retriever.chunk_store = MagicMock()
+        retriever.chunk_store.get_batch.return_value = {'c1': 'fetched chunk text'}
 
-        mock_factory.for_chunk_store.assert_called_once_with(graph_store=store)
-        mock_factory.for_chunk_store.return_value.get_batch.assert_called_once_with(['c1'])
+        result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+
+        retriever.chunk_store.get_batch.assert_called_once_with(['c1'])
 
         chunk = result[0]['result']['topics'][0]['chunks'][0]
         assert chunk['value'] == 'fetched chunk text'
@@ -264,7 +265,14 @@ class TestGetStatementsByTopicAndSource:
             [],
         ]
 
-        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
-            retriever.get_statements_by_topic_and_source(['stmt-1'])
+        retriever.chunk_store = MagicMock()
 
-        mock_factory.for_chunk_store.assert_not_called()
+        retriever.get_statements_by_topic_and_source(['stmt-1'])
+
+        retriever.chunk_store.get_batch.assert_not_called()
+
+    def test_chunk_store_is_resolved_once_at_construction(self):
+        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
+            retriever, store = _retriever()
+        mock_factory.for_chunk_store.assert_called_once_with(graph_store=store)
+        assert retriever.chunk_store is mock_factory.for_chunk_store.return_value

--- a/lexical-graph/tests/unit/retrieval/retrievers/test_traversal_based_base_retriever.py
+++ b/lexical-graph/tests/unit/retrieval/retrievers/test_traversal_based_base_retriever.py
@@ -184,3 +184,87 @@ class TestGetStatementsByTopicAndSource:
         statement = topic['statements'][0]
         assert statement['facts'] == ['f1', 'f2']
         assert statement['score'] == 2
+
+    def test_include_chunk_details_uses_value_already_in_metadata(self):
+        # properties(c) already brought back chunk.value in metadata for the
+        # in-graph backend - use it directly instead of a redundant second
+        # ChunkStore round trip for the same text.
+        retriever, store = _retriever(include_chunk_details=True)
+        store.execute_query.side_effect = [
+            [{'result': {
+                'source': {'sourceId': 's1'},
+                'topics': [{
+                    'topic': 'T',
+                    'topicId': 't1',
+                    'chunks': [
+                        {'chunkId': 'c1', 'value': None, 'metadata': {'value': 'real chunk text', 'page': 3}},
+                    ],
+                    'statements': [],
+                }],
+                'score': 1,
+            }}],
+            [],
+        ]
+
+        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
+            result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+
+        mock_factory.for_chunk_store.assert_not_called()
+
+        chunk = result[0]['result']['topics'][0]['chunks'][0]
+        assert chunk['value'] == 'real chunk text'
+        assert 'value' not in chunk['metadata']
+        assert chunk['metadata']['page'] == 3
+
+    def test_include_chunk_details_falls_back_to_chunk_store_when_metadata_has_no_value(self):
+        # Backend where chunk text isn't stored as a graph property at all
+        # (e.g. a future S3-backed ChunkStore) - properties(c) has no
+        # 'value' key, so fetch it via ChunkStore instead.
+        retriever, store = _retriever(include_chunk_details=True)
+        store.execute_query.side_effect = [
+            [{'result': {
+                'source': {'sourceId': 's1'},
+                'topics': [{
+                    'topic': 'T',
+                    'topicId': 't1',
+                    'chunks': [
+                        {'chunkId': 'c1', 'value': None, 'metadata': {'page': 3}},
+                    ],
+                    'statements': [],
+                }],
+                'score': 1,
+            }}],
+            [],
+        ]
+
+        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
+            mock_factory.for_chunk_store.return_value.get_batch.return_value = {'c1': 'fetched chunk text'}
+            result = retriever.get_statements_by_topic_and_source(['stmt-1'])
+
+        mock_factory.for_chunk_store.assert_called_once_with(graph_store=store)
+        mock_factory.for_chunk_store.return_value.get_batch.assert_called_once_with(['c1'])
+
+        chunk = result[0]['result']['topics'][0]['chunks'][0]
+        assert chunk['value'] == 'fetched chunk text'
+        assert chunk['metadata']['page'] == 3
+
+    def test_no_chunk_store_lookup_when_chunk_details_not_requested(self):
+        retriever, store = _retriever()
+        store.execute_query.side_effect = [
+            [{'result': {
+                'source': {'sourceId': 's1'},
+                'topics': [{
+                    'topic': 'T',
+                    'topicId': 't1',
+                    'chunks': [{'chunkId': 'c1', 'value': None, 'metadata': {}}],
+                    'statements': [],
+                }],
+                'score': 1,
+            }}],
+            [],
+        ]
+
+        with patch.object(mod, 'ChunkStoreFactory') as mock_factory:
+            retriever.get_statements_by_topic_and_source(['stmt-1'])
+
+        mock_factory.for_chunk_store.assert_not_called()


### PR DESCRIPTION
## Description

The `ChunkStore` interface (`InGraphChunkStore`, `ChunkStoreFactory`) landed as an interface-only addition with nothing calling it. This PR wires it into the write path and the two read paths that actually need chunk text today: `ChunkGraphBuilder` (write), `KeywordVSSProvider` (query-time keyword extraction), and `TraversalBasedBaseRetriever`'s `include_chunk_details` branch (synthesis context). `InGraphChunkStore` stays the default, so there's no behavior change for the in-graph backend today, this just gets these callers off direct `chunk.value` graph reads/writes so a future external backend (e.g. S3) can be swapped in without touching them. `chunk_utils.get_chunks_query()` is left as-is; its only caller lives in the deprecated retrievers package.

Stacked on #436 (the `ChunkStore` interface PR, not yet merged) - this diff will include those changes until it merges, then shrink to just this PR's commits.

## Changes

- `ChunkGraphBuilder.build()` writes chunk text via `ChunkStore.put()` instead of an inline `chunk.value` SET, split from the (now separate, conditional) metadata-properties query.
- `KeywordVSSProvider._get_chunk_content()` reads via `ChunkStore.get_batch()` instead of a hand-rolled Cypher query.
- `TraversalBasedBaseRetriever.get_statements_by_topic_and_source()`'s `include_chunk_details` branch reuses the chunk text the main query already returns when present, and falls back to `ChunkStore.get_batch()` only for chunks where it isn't, avoiding a redundant round trip to re-fetch text the query already has.
- `GraphBatchClient` (what graph builders actually receive as their graph client) gains an `execute_query` passthrough, closing a gap where it duck-typed the write side of `GraphStore` but not the read side.
- `ChunkGraphBuilder` no longer lets a `chunk_external_properties` field named `value` overwrite the chunk text `ChunkStore.put()` just wrote.

## Problem

Related issue (if any): #324

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Unit tests cover the write/read wiring, the `get_batch()` existence-semantics change, the `include_chunk_details` fetch/fallback split, the `GraphBatchClient.execute_query` passthrough, and the metadata `value`-key collision fix. Also added a skip-gated live test (`NEO4J_TEST_URI`) exercising the write path and both read paths against a real Neo4j instance, since mocked tests can't catch a malformed query or a client that doesn't duck-type the way a factory expects, both real bugs this work caught during development before they reached review.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable) - not applicable yet, no user-facing config surface until an external backend exists
- [x] No breaking changes (or clearly documented)

`InGraphChunkStore` remains the default backend and its behavior is unchanged for existing users; the `get_batch()` existence-semantics change only affects code paths introduced by this PR and #436, nothing that shipped before them.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

