### PR TITLE
[FIX] Handle empty metadata filters across query backends

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/graph/graph_utils.py
@@ -304,10 +304,15 @@ def parse_metadata_filters_recursive(metadata_filters:MetadataFilters) -> str:
                 raise ValueError(f'Expected MetadataFilters for FilterCondition.NOT, but found MetadataFilter')
             filter_strs.append(metadata_filter_to_opencypher_filter(metadata_filter))
         elif isinstance(metadata_filter, MetadataFilters):
-            filter_strs.append(parse_metadata_filters_recursive(metadata_filter))
+            nested_filter = parse_metadata_filters_recursive(metadata_filter)
+            if nested_filter:
+                filter_strs.append(nested_filter)
         else:
             raise ValueError(f'Invalid metadata filter type: {type(metadata_filter)}')
         
+    if not filter_strs:
+        return ''
+
     if metadata_filters.condition == FilterCondition.NOT:
         return f"(NOT {' '.join(filter_strs)})"
     elif metadata_filters.condition == FilterCondition.AND or metadata_filters.condition == FilterCondition.OR:
@@ -338,4 +343,3 @@ def filter_config_to_opencypher_filters(filter_config:FilterConfig) -> str:
     if filter_config is None or filter_config.source_filters is None:
         return ''
     return parse_metadata_filters_recursive(filter_config.source_filters)
-    

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/pg_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/pg_vector_indexes.py
@@ -138,8 +138,12 @@ def parse_metadata_filters_recursive(metadata_filters:MetadataFilters) -> tuple[
             (fragment, fragment_params) = parse_metadata_filters_recursive(metadata_filter)
         else:
             raise ValueError(f'Invalid metadata filter type: {type(metadata_filter)}')
-        filter_strs.append(fragment)
-        params.extend(fragment_params)
+        if fragment:
+            filter_strs.append(fragment)
+            params.extend(fragment_params)
+
+    if not filter_strs:
+        return ('', [])
 
     if metadata_filters.condition == FilterCondition.NOT:
         return (f"(NOT {' '.join(filter_strs)})", params)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/s3_vector_indexes.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/vector/s3_vector_indexes.py
@@ -102,9 +102,17 @@ def parse_metadata_filters_recursive(metadata_filters:MetadataFilters) -> Dict[s
                 raise ValueError(f'Expected MetadataFilters for FilterCondition.NOT, but found MetadataFilter')
             filter_strs.append(to_s3_filter(metadata_filter))
         elif isinstance(metadata_filter, MetadataFilters):
-            filter_strs.append(json.dumps(parse_metadata_filters_recursive(metadata_filter)))
+            nested_filters = parse_metadata_filters_recursive(metadata_filter)
+            if nested_filters:
+                filter_strs.append(json.dumps(nested_filters))
         else:
             raise ValueError(f'Invalid metadata filter type: {type(metadata_filter)}')
+
+    if not filter_strs and (
+        metadata_filters.condition == FilterCondition.AND
+        or metadata_filters.condition == FilterCondition.OR
+    ):
+        return {}
 
     if metadata_filters.condition == FilterCondition.AND:       
         return json.loads(f'{{"$and": [{",".join(filter_strs)}]}}')

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/visualisation/graph_notebook/graph_notebook_visualisation.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/visualisation/graph_notebook/graph_notebook_visualisation.py
@@ -178,7 +178,8 @@ def get_sources_query(tenant_id, source_ids:Optional[List[str]]=None, filter:Opt
         where_clauses.append(filter_config_to_opencypher_filters(to_metadata_filter(filter)))
     if source_ids:
         where_clauses.append(f'(id(source) in {str(source_ids)})')
-    
+
+    where_clauses = [clause for clause in where_clauses if clause]
     where_clause = '' if not where_clauses else f"WHERE {' OR '.join(where_clauses)}"
         
           
@@ -586,5 +587,3 @@ class GraphNotebookVisualisation():
         cypher = get_schema_query(to_tenant_id(tenant_id))
         
         g.oc(line, cell=cypher, local_ns={}) 
-        
-       

--- a/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
+++ b/lexical-graph/tests/unit/storage/graph/test_graph_utils.py
@@ -311,6 +311,40 @@ class TestParseMetadataFiltersRecursive:
         assert ' AND ' in result
         assert ' OR ' in result
 
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_nested_empty_filter_group_returns_empty_string(self, condition):
+        filters = MetadataFilters(
+            filters=[MetadataFilters(filters=[], condition=FilterCondition.AND)],
+            condition=condition,
+        )
+
+        assert parse_metadata_filters_recursive(filters) == ''
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_nested_empty_filter_group_is_ignored_next_to_valid_filter(self, condition):
+        valid_filter = _eq_filter('category', 'tech')
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilters(filters=[], condition=FilterCondition.AND),
+                valid_filter,
+            ],
+            condition=condition,
+        )
+        expected = MetadataFilters(filters=[valid_filter], condition=condition)
+
+        assert (
+            parse_metadata_filters_recursive(filters)
+            == parse_metadata_filters_recursive(expected)
+        )
+
+    def test_not_with_nested_empty_filter_group_returns_empty_string(self):
+        filters = MetadataFilters(
+            filters=[MetadataFilters(filters=[], condition=FilterCondition.AND)],
+            condition=FilterCondition.NOT,
+        )
+
+        assert parse_metadata_filters_recursive(filters) == ''
+
 
 class TestFilterConfigToOpencypherFilters:
     def test_none_config_returns_empty_string(self):

--- a/lexical-graph/tests/unit/storage/vector/test_pg_vector_injection.py
+++ b/lexical-graph/tests/unit/storage/vector/test_pg_vector_injection.py
@@ -130,6 +130,25 @@ def _eq_filter_config(key, value):
 class TestTopKFilterInjection:
     """top_k() builds its WHERE clause from filter_config."""
 
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_empty_filter_group_does_not_emit_where_clause(self, condition):
+        index = _make_pg_index()
+        mock_conn, mock_cur = _mock_conn_cursor()
+        bundle = QueryBundle(query_str='q', embedding=[0.1, 0.2, 0.3])
+        filter_config = FilterConfig(source_filters=MetadataFilters(
+            filters=[
+                MetadataFilters(filters=[], condition=FilterCondition.AND),
+            ],
+            condition=condition,
+        ))
+
+        with patch.object(pvi.PGIndex, '_get_connection', return_value=mock_conn):
+            with patch.object(pvi, 'to_embedded_query', return_value=bundle):
+                index.top_k(bundle, top_k=5, filter_config=filter_config)
+
+        sql_text, _ = _captured_execute(mock_cur)
+        assert 'WHERE' not in sql_text
+
     def test_filter_value_is_bound_not_interpolated(self):
         index = _make_pg_index()
         mock_conn, mock_cur = _mock_conn_cursor()
@@ -276,6 +295,40 @@ class TestClauseBuilderContract:
 
     def test_none_config_returns_empty_fragment_and_params(self):
         assert pvi.filter_config_to_sql_filters(None) == ('', [])
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_empty_filter_group_returns_empty_fragment_and_params(self, condition):
+        filters = MetadataFilters(filters=[], condition=condition)
+
+        assert pvi.parse_metadata_filters_recursive(filters) == ('', [])
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_nested_empty_filter_group_returns_empty_fragment_and_params(self, condition):
+        filters = MetadataFilters(
+            filters=[MetadataFilters(filters=[], condition=FilterCondition.AND)],
+            condition=condition,
+        )
+
+        assert pvi.parse_metadata_filters_recursive(filters) == ('', [])
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_nested_empty_filter_group_is_ignored_next_to_valid_filter(self, condition):
+        valid_filter = MetadataFilter(
+            key='category', value='tech', operator=FilterOperator.EQ,
+        )
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilters(filters=[], condition=FilterCondition.AND),
+                valid_filter,
+            ],
+            condition=condition,
+        )
+        expected = MetadataFilters(filters=[valid_filter], condition=condition)
+
+        assert (
+            pvi.parse_metadata_filters_recursive(filters)
+            == pvi.parse_metadata_filters_recursive(expected)
+        )
 
 
 class TestLegitimateFilterStillWorks:

--- a/lexical-graph/tests/unit/storage/vector/test_s3_vector_helpers.py
+++ b/lexical-graph/tests/unit/storage/vector/test_s3_vector_helpers.py
@@ -4,6 +4,7 @@
 """Tests for the pure helpers in storage/vector/s3_vector_indexes."""
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 from llama_index.core.schema import TextNode
@@ -21,6 +22,7 @@ from graphrag_toolkit.lexical_graph.storage.vector.s3_vector_indexes import (
     formatter_for_type,
     node_to_s3_vector,
     parse_metadata_filters_recursive,
+    search_vectors,
     s3_vector_to_dict,
     to_s3_operator,
     validate_metadata_limits,
@@ -87,6 +89,44 @@ class TestParseMetadataFiltersRecursive:
         ))
         assert '$or' in result
 
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_empty_filter_group_returns_empty_filter(self, condition):
+        filters = MetadataFilters(filters=[], condition=condition)
+
+        assert parse_metadata_filters_recursive(filters) == {}
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_nested_empty_filter_group_returns_empty_filter(self, condition):
+        filters = MetadataFilters(
+            filters=[MetadataFilters(filters=[], condition=FilterCondition.AND)],
+            condition=condition,
+        )
+
+        assert parse_metadata_filters_recursive(filters) == {}
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_nested_empty_filter_group_is_ignored_next_to_valid_filter(self, condition):
+        valid_filter = _eq('category', 'tech')
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilters(filters=[], condition=FilterCondition.AND),
+                valid_filter,
+            ],
+            condition=condition,
+        )
+        expected = MetadataFilters(filters=[valid_filter], condition=condition)
+
+        assert (
+            parse_metadata_filters_recursive(filters)
+            == parse_metadata_filters_recursive(expected)
+        )
+
+    def test_empty_not_filter_group_remains_unsupported(self):
+        filters = MetadataFilters(filters=[], condition=FilterCondition.NOT)
+
+        with pytest.raises(ValueError, match='Unsupported filters condition'):
+            parse_metadata_filters_recursive(filters)
+
     def test_not_condition_with_bare_filter_raises(self):
         filters = MetadataFilters(filters=[_eq('a', 'x')], condition=FilterCondition.NOT)
         with pytest.raises(ValueError, match='Expected MetadataFilters'):
@@ -114,6 +154,34 @@ class TestFilterConfigToS3Filters:
         ))
         result = filter_config_to_s3_filters(config)
         assert '$and' in result
+
+    def test_empty_source_filter_group_returns_empty_filter(self):
+        config = FilterConfig(source_filters=MetadataFilters(
+            filters=[], condition=FilterCondition.AND,
+        ))
+
+        assert filter_config_to_s3_filters(config) == {}
+
+    @pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+    def test_empty_filter_group_is_omitted_from_query_request(self, condition):
+        client = MagicMock()
+        client.query_vectors.return_value = {'vectors': []}
+        config = FilterConfig(source_filters=MetadataFilters(
+            filters=[
+                MetadataFilters(filters=[], condition=FilterCondition.AND),
+            ],
+            condition=condition,
+        ))
+
+        search_vectors(
+            client,
+            bucket_name='bucket',
+            index_name='index',
+            query_vector=[0.1, 0.2],
+            metadata_filters=filter_config_to_s3_filters(config),
+        )
+
+        assert 'filter' not in client.query_vectors.call_args.kwargs
 
 
 class TestNodeToS3Vector:

--- a/lexical-graph/tests/unit/visualisation/graph_notebook/test_graph_notebook_visualisation.py
+++ b/lexical-graph/tests/unit/visualisation/graph_notebook/test_graph_notebook_visualisation.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from llama_index.core.vector_stores.types import FilterCondition, MetadataFilters
+
+from graphrag_toolkit.lexical_graph.metadata import FilterConfig
+from graphrag_toolkit.lexical_graph.tenant_id import TenantId
+import graphrag_toolkit.lexical_graph.visualisation.graph_notebook.graph_notebook_visualisation as visualisation
+
+
+@pytest.fixture(params=[FilterCondition.AND, FilterCondition.OR])
+def empty_filter_config(request):
+    return FilterConfig(source_filters=MetadataFilters(
+        filters=[], condition=request.param,
+    ))
+
+
+def test_empty_filter_does_not_add_where_clause(monkeypatch, empty_filter_config):
+    # PR #415 changes the graph helper to return an empty string for this input.
+    # Stub that result here so this test isolates the notebook query consumer.
+    monkeypatch.setattr(
+        visualisation,
+        'filter_config_to_opencypher_filters',
+        lambda _: '',
+    )
+
+    query = visualisation.get_sources_query(
+        TenantId(), filter=empty_filter_config,
+    )
+
+    assert 'WHERE' not in query
+
+
+def test_empty_filter_does_not_add_leading_or_before_source_ids(
+    monkeypatch,
+    empty_filter_config,
+):
+    # PR #415 changes the graph helper to return an empty string for this input.
+    # Stub that result here so this test isolates the notebook query consumer.
+    monkeypatch.setattr(
+        visualisation,
+        'filter_config_to_opencypher_filters',
+        lambda _: '',
+    )
+
+    query = visualisation.get_sources_query(
+        TenantId(), source_ids=['source-1'], filter=empty_filter_config,
+    )
+
+    assert "WHERE (id(source) in ['source-1'])" in query
+    assert 'WHERE  OR' not in query

--- a/lexical-graph/tests/unit/visualisation/graph_notebook/test_graph_notebook_visualisation.py
+++ b/lexical-graph/tests/unit/visualisation/graph_notebook/test_graph_notebook_visualisation.py
@@ -2,29 +2,36 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from llama_index.core.vector_stores.types import FilterCondition, MetadataFilters
+from llama_index.core.vector_stores.types import (
+    FilterCondition,
+    MetadataFilter,
+    MetadataFilters,
+)
 
 from graphrag_toolkit.lexical_graph.metadata import FilterConfig
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
 import graphrag_toolkit.lexical_graph.visualisation.graph_notebook.graph_notebook_visualisation as visualisation
 
 
-@pytest.fixture(params=[FilterCondition.AND, FilterCondition.OR])
+@pytest.fixture(params=[
+    (FilterCondition.AND, False),
+    (FilterCondition.OR, False),
+    (FilterCondition.AND, True),
+    (FilterCondition.OR, True),
+], ids=['and', 'or', 'nested-and', 'nested-or'])
 def empty_filter_config(request):
+    condition, nested = request.param
+    filters = (
+        [MetadataFilters(filters=[], condition=FilterCondition.AND)]
+        if nested
+        else []
+    )
     return FilterConfig(source_filters=MetadataFilters(
-        filters=[], condition=request.param,
+        filters=filters, condition=condition,
     ))
 
 
-def test_empty_filter_does_not_add_where_clause(monkeypatch, empty_filter_config):
-    # PR #415 changes the graph helper to return an empty string for this input.
-    # Stub that result here so this test isolates the notebook query consumer.
-    monkeypatch.setattr(
-        visualisation,
-        'filter_config_to_opencypher_filters',
-        lambda _: '',
-    )
-
+def test_empty_filter_does_not_add_where_clause(empty_filter_config):
     query = visualisation.get_sources_query(
         TenantId(), filter=empty_filter_config,
     )
@@ -33,20 +40,28 @@ def test_empty_filter_does_not_add_where_clause(monkeypatch, empty_filter_config
 
 
 def test_empty_filter_does_not_add_leading_or_before_source_ids(
-    monkeypatch,
     empty_filter_config,
 ):
-    # PR #415 changes the graph helper to return an empty string for this input.
-    # Stub that result here so this test isolates the notebook query consumer.
-    monkeypatch.setattr(
-        visualisation,
-        'filter_config_to_opencypher_filters',
-        lambda _: '',
-    )
-
     query = visualisation.get_sources_query(
         TenantId(), source_ids=['source-1'], filter=empty_filter_config,
     )
 
     assert "WHERE (id(source) in ['source-1'])" in query
     assert 'WHERE  OR' not in query
+
+
+@pytest.mark.parametrize('condition', [FilterCondition.AND, FilterCondition.OR])
+def test_nested_empty_filter_is_ignored_next_to_valid_filter(condition):
+    filter_config = FilterConfig(source_filters=MetadataFilters(
+        filters=[
+            MetadataFilters(filters=[], condition=FilterCondition.AND),
+            MetadataFilter(key='category', value='tech'),
+        ],
+        condition=condition,
+    ))
+
+    query = visualisation.get_sources_query(TenantId(), filter=filter_config)
+
+    assert "source.`category` = 'tech'" in query
+    assert 'WHERE ( AND ' not in query
+    assert 'WHERE ( OR ' not in query


### PR DESCRIPTION
## Description

Handle empty and recursively empty `MetadataFilters` without generating
malformed queries in the PGVector, S3 Vectors, and Graph Notebook paths.

## Changes

- return an empty PG filter fragment when no effective clauses remain, including
  after recursively empty groups are removed
- omit empty nested groups from S3 filter composition while preserving the
  existing unsupported behavior for `FilterCondition.NOT`
- remove empty openCypher clauses before Graph Notebook builds its `WHERE`
  expression
- add regression coverage for top-level and nested AND/OR groups, mixed valid
  filters, the S3 request payload, the final PG SQL, and Graph Notebook queries

The Graph Notebook consumer change relies on the empty-string helper contract
introduced by #415. Its tests stub that contract so this PR does not duplicate
or modify the `graph_utils.py` changes in #415.

## Problem

An empty PG filter currently becomes `()` and is emitted as `WHERE ()`. S3
serializes the same input as `$and: []` or `$or: []` and sends it as a filter.
After the graph helper returns an empty string, Graph Notebook still includes
that string in its clause list, producing either an empty `WHERE` or
`WHERE  OR (...)`.

Recursively empty groups need the same treatment; otherwise a parent group can
still produce a leading boolean operator or contain an empty S3 object.

Fixes #423

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (not needed; the affected request/SQL boundaries
      are exercised with unit-level client and cursor fakes)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (directly inspected the final PG SQL and S3
      `query_vectors` arguments)

Validation performed:

- focused regression suite: 69 passed
- full non-network suite: 1,810 passed, 1 skipped
- dependency-resolution compatibility test: 1 passed
- sdist and wheel builds
- repository license-header check
- `pre-commit run git-secrets --all-files`
- `git diff --check`

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (not applicable; no public API change)
- [x] No breaking changes

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
