### PR TITLE
feat: Generic LlamaIndex Reader Plugin (clean, 4 files only)

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/__init__.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/__init__.py
@@ -33,6 +33,8 @@ _PROVIDER_MODULES = {
     "S3DirectoryReaderProvider": ".s3_directory_reader_provider",
     # Database readers
     "DatabaseReaderProvider": ".database_reader_provider",
+    # Generic LlamaIndex plugin reader
+    "LlamaIndexPluginReaderProvider": ".llama_index_plugin_reader_provider",
 }
 
 def __getattr__(name):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/llama_index_plugin_reader_provider.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/providers/llama_index_plugin_reader_provider.py
@@ -1,0 +1,559 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic LlamaIndex reader plugin — wraps any reader from the LlamaIndex ecosystem.
+
+Usage:
+    from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import (
+        LlamaIndexPluginReaderConfig,
+    )
+    from graphrag_toolkit.lexical_graph.indexing.load.readers.providers import (
+        LlamaIndexPluginReaderProvider,
+    )
+
+    config = LlamaIndexPluginReaderConfig(
+        package="llama-index-readers-confluence",
+        module_path="llama_index.readers.confluence",
+        reader_class="ConfluenceReader",
+        init_args={"base_url": "https://mycompany.atlassian.net/wiki", "token": "..."},
+        load_args={"space_key": "ENG"},
+        timeout_seconds=60,
+        max_retries=2,
+    )
+    provider = LlamaIndexPluginReaderProvider(config)
+    docs = provider.read(None)
+"""
+
+import importlib
+import os
+import re
+import signal
+import time
+from typing import Any, List, Optional
+from functools import wraps
+
+from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import (
+    LlamaIndexPluginReaderConfig,
+)
+from graphrag_toolkit.lexical_graph.logging import logging
+from llama_index.core.schema import Document
+
+logger = logging.getLogger(__name__)
+
+# Item #4: Pattern for environment variable references in config values
+_ENV_VAR_PATTERN = re.compile(r'^\$([A-Z_][A-Z0-9_]*)$')
+
+# Item #7: Pattern for valid LlamaIndex package names (prevents typosquat suggestions)
+_VALID_PACKAGE_PATTERN = re.compile(r'^llama-index-readers?-[a-z0-9-]+$')
+
+
+class ReaderImportError(ImportError):
+    """Raised when the required LlamaIndex reader package is not installed."""
+    pass
+
+
+class ReaderAuthError(RuntimeError):
+    """Raised when authentication fails (expired token, invalid credentials)."""
+    pass
+
+
+class ReaderTimeoutError(TimeoutError):
+    """Raised when the reader exceeds the configured timeout."""
+    pass
+
+
+class LlamaIndexPluginReaderProvider:
+    """Generic reader provider that wraps any LlamaIndex reader via configuration.
+
+    Features:
+        - Dynamic import of any LlamaIndex reader package
+        - Namespace allowlist (prevents arbitrary module loading)
+        - Interface validation before instantiation
+        - Environment variable resolution in credentials ($VAR_NAME)
+        - Configurable timeout (prevents hangs)
+        - Retry with exponential backoff on transient failures
+        - Graceful degradation (fail_on_error=False returns [] instead of raising)
+        - Structured logging at every decision point (never logs credential values)
+        - Auth failure detection (recognizes 401/403 patterns)
+        - Empty result warnings
+        - Metadata enrichment support
+    """
+
+    # Item #1: Namespace allowlist — only these module prefixes can be loaded.
+    # Subclass and override to allow custom reader namespaces.
+    ALLOWED_MODULE_PREFIXES = ("llama_index.readers.",)
+
+    # Item #3: Only these methods may be called on the reader instance.
+    ALLOWED_LOAD_METHODS = ("load_data", "lazy_load", "aload_data")
+
+    # Known auth-related error patterns (case-insensitive matching)
+    _AUTH_ERROR_PATTERNS = (
+        "401", "403", "unauthorized", "forbidden",
+        "invalid token", "expired token", "authentication failed",
+        "access denied", "invalid credentials", "token expired",
+    )
+
+    # Known transient error patterns (retry-worthy)
+    _TRANSIENT_ERROR_PATTERNS = (
+        "429", "500", "502", "503", "504",
+        "rate limit", "too many requests", "timeout",
+        "connection reset", "connection refused",
+        "temporary failure", "service unavailable",
+    )
+
+    def __init__(self, config: LlamaIndexPluginReaderConfig):
+        """Initialize by dynamically importing and instantiating the reader.
+
+        Args:
+            config: Plugin configuration specifying which reader to load and how.
+
+        Raises:
+            ReaderImportError: If the required package is not installed.
+            ValueError: If required config fields are missing.
+        """
+        self._config = config
+        self._reader = None
+        self._validate_config()
+        self._import_and_init_reader()
+
+    def _validate_config(self) -> None:
+        """Validate that required configuration fields are present."""
+        if not self._config.reader_class:
+            raise ValueError(
+                "LlamaIndexPluginReaderConfig.reader_class is required "
+                "(e.g. 'ConfluenceReader')"
+            )
+        if not self._config.module_path and not self._config.package:
+            raise ValueError(
+                "LlamaIndexPluginReaderConfig requires either module_path "
+                "(e.g. 'llama_index.readers.confluence') or package "
+                "(e.g. 'llama-index-readers-confluence')"
+            )
+
+    def _validate_module_path(self, module_path: str) -> None:
+        """Item #1: Validate module path against namespace allowlist before import.
+
+        Prevents arbitrary code execution via malicious module_path values.
+        Validation applies to the RESOLVED path (after _resolve_module_path).
+
+        Raises:
+            ReaderImportError: If module_path is not in allowed namespaces.
+        """
+        if not any(module_path.startswith(prefix) for prefix in self.ALLOWED_MODULE_PREFIXES):
+            raise ReaderImportError(
+                f"Module '{module_path}' is not in the allowed namespace. "
+                f"Allowed prefixes: {self.ALLOWED_MODULE_PREFIXES}. "
+                f"To allow custom namespaces, subclass and override ALLOWED_MODULE_PREFIXES."
+            )
+
+    def _resolve_env_vars(self, args: dict) -> dict:
+        """Item #4: Resolve $VAR_NAME references in dict values from environment.
+
+        Only resolves top-level string values matching $UPPER_CASE_NAME.
+        Nested dicts, non-string values, lowercase vars, and mid-string
+        dollar signs are passed through unchanged.
+
+        Raises:
+            ValueError: If a referenced environment variable is not set.
+        """
+        if not args:
+            return args
+        resolved = {}
+        for key, value in args.items():
+            if isinstance(value, str):
+                match = _ENV_VAR_PATTERN.match(value)
+                if match:
+                    env_name = match.group(1)
+                    env_value = os.environ.get(env_name)
+                    if env_value is None:
+                        raise ValueError(
+                            f"Config field '{key}' references ${env_name} "
+                            f"but it is not set in the environment"
+                        )
+                    resolved[key] = env_value
+                    continue
+            resolved[key] = value
+        return resolved
+
+    def _resolve_module_path(self) -> str:
+        """Resolve the Python module path from config.
+
+        Priority: module_path > derived from package name.
+        """
+        if self._config.module_path:
+            return self._config.module_path
+        # Derive from package: "llama-index-readers-confluence" → "llama_index.readers.confluence"
+        parts = self._config.package.replace("-", "_").split("_")
+        # Handle "llama_index_readers_X" pattern
+        if len(parts) >= 4 and parts[0] == "llama" and parts[1] == "index":
+            return f"llama_index.readers.{'.'.join(parts[3:])}"
+        # Fallback: just replace dashes
+        return self._config.package.replace("-", "_")
+
+    def _import_and_init_reader(self) -> None:
+        """Dynamically import the reader module and instantiate the reader class.
+
+        Security measures:
+            - Item #1: Namespace allowlist validation before import
+            - Item #2: Interface validation before instantiation
+            - Item #4: Environment variable resolution for credentials
+            - Item #7: Safe package name validation in error messages
+        """
+        module_path = self._resolve_module_path()
+        class_name = self._config.reader_class
+
+        # Item #1: Validate namespace before importing
+        self._validate_module_path(module_path)
+
+        logger.info(
+            f"LlamaIndexPlugin: importing {class_name} from {module_path} "
+            f"(package: {self._config.package or 'not specified'})"
+        )
+
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as e:
+            # Item #7: Only suggest pip install for validated package names
+            if self._config.package and _VALID_PACKAGE_PATTERN.match(self._config.package):
+                msg = (
+                    f"Failed to import '{module_path}'. "
+                    f"Install the reader package: pip install {self._config.package}"
+                )
+            else:
+                msg = (
+                    f"Failed to import '{module_path}'. "
+                    f"Ensure the reader package is installed."
+                )
+            logger.error(msg)
+            raise ReaderImportError(msg) from e
+
+        try:
+            reader_cls = getattr(module, class_name)
+        except AttributeError as e:
+            available = [a for a in dir(module) if not a.startswith("_")]
+            msg = (
+                f"Class '{class_name}' not found in '{module_path}'. "
+                f"Available: {available[:10]}"
+            )
+            logger.error(msg)
+            raise ReaderImportError(msg) from e
+
+        # Item #2: Interface validation BEFORE instantiation
+        if not callable(reader_cls):
+            raise ReaderImportError(f"'{class_name}' in '{module_path}' is not callable")
+
+        load_method_name = self._config.load_method or "load_data"
+        if not hasattr(reader_cls, load_method_name) and not hasattr(reader_cls, "lazy_load"):
+            raise ReaderImportError(
+                f"'{class_name}' does not implement '{load_method_name}()' or 'lazy_load()'. "
+                f"It may not be a LlamaIndex reader."
+            )
+
+        # Item #4: Resolve environment variables in init_args
+        init_args = self._resolve_env_vars(self._config.init_args or {})
+
+        try:
+            self._reader = reader_cls(**init_args)
+            # Item #5: Log keys only, NEVER values
+            logger.info(
+                f"LlamaIndexPlugin: {class_name} initialized successfully "
+                f"(init_args keys: {list(init_args.keys())})"
+            )
+        except TypeError as e:
+            msg = (
+                f"Failed to instantiate {class_name} with args {list(init_args.keys())}. "
+                f"Check init_args match the constructor signature. Error: {e}"
+            )
+            logger.error(msg)
+            raise ValueError(msg) from e
+        except Exception as e:
+            if self._is_auth_error(e):
+                msg = (
+                    f"Authentication failed when initializing {class_name}. "
+                    f"Check credentials in init_args. Error: {e}"
+                )
+                logger.error(msg)
+                raise ReaderAuthError(msg) from e
+            raise
+
+    def _is_auth_error(self, error: Exception) -> bool:
+        """Detect if an exception is an authentication/authorization failure."""
+        error_str = str(error).lower()
+        return any(pattern in error_str for pattern in self._AUTH_ERROR_PATTERNS)
+
+    def _is_transient_error(self, error: Exception) -> bool:
+        """Detect if an exception is a transient/retryable failure."""
+        error_str = str(error).lower()
+        return any(pattern in error_str for pattern in self._TRANSIENT_ERROR_PATTERNS)
+
+    def read(self, input_source: Any = None) -> List[Document]:
+        """Read documents using the configured LlamaIndex reader.
+
+        Applies timeout, retry with backoff, and error classification.
+
+        Args:
+            input_source: Optional input passed to load_args (reader-specific).
+                          Can be a space_key, URL, file path, etc.
+
+        Returns:
+            List of Document objects. Empty list if fail_on_error=False and read fails.
+
+        Raises:
+            ReaderAuthError: On authentication failures (not retried).
+            ReaderTimeoutError: When timeout_seconds is exceeded.
+            RuntimeError: On non-transient failures when fail_on_error=True.
+        """
+        load_fn = self._resolve_load_function()
+        if load_fn is None:
+            return []
+
+        load_args = self._build_load_args(input_source)
+        return self._execute_with_retries(load_fn, load_args)
+
+    def _resolve_load_function(self) -> Optional[Any]:
+        """Resolve the callable load method from the reader instance.
+
+        Item #3: Validates load_method against ALLOWED_LOAD_METHODS.
+
+        Returns:
+            The load function, or None if resolution fails (with appropriate error/log).
+        """
+        if self._reader is None:
+            logger.error("LlamaIndexPlugin: reader not initialized — cannot read")
+            if self._config.fail_on_error:
+                raise RuntimeError("Reader not initialized")
+            return None
+
+        load_method_name = self._config.load_method or "load_data"
+
+        # Item #3: Restrict to safe method names only
+        if load_method_name not in self.ALLOWED_LOAD_METHODS:
+            msg = (
+                f"load_method '{load_method_name}' is not allowed. "
+                f"Permitted: {self.ALLOWED_LOAD_METHODS}"
+            )
+            logger.error(msg)
+            raise ValueError(msg)
+
+        load_fn = getattr(self._reader, load_method_name, None)
+
+        if load_fn is None:
+            msg = (
+                f"Reader {self._config.reader_class} has no method '{load_method_name}'. "
+                f"Available methods: {[m for m in dir(self._reader) if not m.startswith('_')][:15]}"
+            )
+            logger.error(msg)
+            if self._config.fail_on_error:
+                raise AttributeError(msg)
+            return None
+
+        return load_fn
+
+    def _build_load_args(self, input_source: Any = None) -> dict:
+        """Assemble the keyword arguments for the load function.
+
+        Item #4: Resolves $VAR_NAME environment variable references in load_args.
+        Merges configured load_args with an optional input_source.
+        """
+        load_args = self._resolve_env_vars(dict(self._config.load_args or {}))
+        if input_source is not None:
+            load_args["input_source"] = input_source
+        return load_args
+
+    def _execute_with_retries(self, load_fn: Any, load_args: dict) -> List[Document]:
+        """Execute load_fn with retry loop, timeout, and error classification.
+
+        Args:
+            load_fn: The reader's load method.
+            load_args: Keyword arguments for the load method.
+
+        Returns:
+            List of Documents on success, or [] on graceful failure.
+        """
+        max_attempts = 1 + (self._config.max_retries or 0)
+        last_error: Optional[Exception] = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                documents = self._execute_with_timeout(load_fn, load_args)
+                return self._post_process(documents)
+            except ReaderAuthError:
+                raise
+            except (ReaderTimeoutError, Exception) as e:
+                last_error = e
+                if not self._handle_attempt_error(
+                    last_error, attempt, max_attempts
+                ):
+                    break
+
+        return self._handle_exhausted_retries(max_attempts, last_error)
+
+    def _handle_attempt_error(self, error: Exception, attempt: int, max_attempts: int) -> bool:
+        """Classify and handle an error from a single attempt.
+
+        Args:
+            error: The exception that occurred.
+            attempt: Current attempt number (1-based).
+            max_attempts: Total allowed attempts.
+
+        Returns:
+            True if should continue retrying, False if should stop.
+        """
+        if isinstance(error, ReaderTimeoutError):
+            logger.warning(
+                f"LlamaIndexPlugin: timeout on attempt {attempt}/{max_attempts} "
+                f"({self._config.timeout_seconds}s exceeded)"
+            )
+            if attempt < max_attempts:
+                self._backoff(attempt)
+                return True
+            return False
+
+        if self._is_auth_error(error):
+            msg = (
+                f"LlamaIndexPlugin: authentication failed — "
+                f"{self._config.reader_class}: {error}"
+            )
+            logger.error(msg)
+            raise ReaderAuthError(msg) from error
+
+        if self._is_transient_error(error) and attempt < max_attempts:
+            logger.warning(
+                f"LlamaIndexPlugin: transient error on attempt "
+                f"{attempt}/{max_attempts}: {error}"
+            )
+            self._backoff(attempt)
+            return True
+
+        # Non-transient, non-auth error — stop retrying
+        load_method_name = self._config.load_method or "load_data"
+        logger.error(
+            f"LlamaIndexPlugin: {self._config.reader_class}.{load_method_name}() "
+            f"failed on attempt {attempt}: {error}",
+            exc_info=True,
+        )
+        return False
+
+    def _handle_exhausted_retries(
+        self, max_attempts: int, last_error: Optional[Exception]
+    ) -> List[Document]:
+        """Handle the case where all retry attempts have been exhausted.
+
+        Returns:
+            Empty list if fail_on_error=False.
+
+        Raises:
+            RuntimeError: If fail_on_error=True.
+        """
+        if self._config.fail_on_error:
+            raise RuntimeError(
+                f"LlamaIndexPlugin: all {max_attempts} attempt(s) failed for "
+                f"{self._config.reader_class}. Last error: {last_error}"
+            ) from last_error
+
+        logger.warning(
+            f"LlamaIndexPlugin: returning empty result after {max_attempts} failed "
+            f"attempt(s). Last error: {last_error}"
+        )
+        return []
+
+    def _execute_with_timeout(
+        self, load_fn: Any, load_args: dict
+    ) -> List[Document]:
+        """Execute the load function with a timeout guard.
+
+        Uses threading-based timeout (signal.alarm not safe in all contexts).
+        """
+        import concurrent.futures
+
+        timeout = self._config.timeout_seconds or 120
+
+        # Remove input_source from load_args if the reader doesn't accept it
+        # Try with input_source first, fall back without it
+        args_to_try = load_args.copy()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(self._call_load_fn, load_fn, args_to_try)
+            try:
+                return future.result(timeout=timeout)
+            except concurrent.futures.TimeoutError as e:
+                future.cancel()
+                raise ReaderTimeoutError(
+                    f"Reader {self._config.reader_class} exceeded "
+                    f"timeout of {timeout}s"
+                ) from e
+
+    def _call_load_fn(self, load_fn: Any, load_args: dict) -> List[Document]:
+        """Call the load function, handling input_source parameter flexibility."""
+        try:
+            return load_fn(**load_args)
+        except TypeError as e:
+            # If "input_source" isn't a valid param, try without it
+            if "input_source" in load_args and "unexpected keyword argument" in str(e):
+                logger.debug(
+                    "LlamaIndexPlugin: reader doesn't accept 'input_source', "
+                    "retrying without it"
+                )
+                args_without_source = {
+                    k: v for k, v in load_args.items() if k != "input_source"
+                }
+                return load_fn(**args_without_source)
+            raise
+
+    def _post_process(self, documents: Any) -> List[Document]:
+        """Validate and enrich returned documents."""
+        # Handle generators/iterators
+        if hasattr(documents, '__iter__') and not isinstance(documents, list):
+            documents = list(documents)
+
+        if not isinstance(documents, list):
+            logger.warning(
+                f"LlamaIndexPlugin: reader returned {type(documents).__name__} "
+                f"instead of list — wrapping"
+            )
+            documents = [documents] if documents else []
+
+        # Filter out non-Document items
+        valid_docs = []
+        for i, doc in enumerate(documents):
+            if isinstance(doc, Document):
+                valid_docs.append(doc)
+            elif hasattr(doc, 'text') and hasattr(doc, 'metadata'):
+                # Duck-typing: looks like a Document
+                valid_docs.append(doc)
+            else:
+                logger.debug(
+                    f"LlamaIndexPlugin: skipping non-Document item at index {i}: "
+                    f"{type(doc).__name__}"
+                )
+
+        # Apply metadata enrichment
+        if self._config.metadata_fn and valid_docs:
+            source_id = self._config.package or self._config.reader_class
+            try:
+                extra_metadata = self._config.metadata_fn(source_id)
+                if extra_metadata and isinstance(extra_metadata, dict):
+                    for doc in valid_docs:
+                        doc.metadata.update(extra_metadata)
+            except Exception as e:
+                logger.warning(f"LlamaIndexPlugin: metadata_fn failed: {e}")
+
+        # Log results
+        if not valid_docs:
+            logger.warning(
+                f"LlamaIndexPlugin: {self._config.reader_class} returned 0 documents"
+            )
+        else:
+            logger.info(
+                f"LlamaIndexPlugin: {self._config.reader_class} returned "
+                f"{len(valid_docs)} document(s)"
+            )
+
+        return valid_docs
+
+    def _backoff(self, attempt: int) -> None:
+        """Exponential backoff between retry attempts."""
+        base = self._config.retry_backoff_seconds or 2.0
+        delay = base * (2 ** (attempt - 1))
+        logger.info(f"LlamaIndexPlugin: backing off {delay:.1f}s before retry")
+        time.sleep(delay)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/reader_provider_config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/readers/reader_provider_config.py
@@ -10,7 +10,6 @@ from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config
 @dataclass
 class PDFReaderConfig(ReaderProviderConfig):
     return_full_document: bool = False
-    extract_tables: bool = True  # AdvancedPDFReaderProvider only: parse tables to markdown
     metadata_fn: Optional[Callable[[str], Dict[str, Any]]] = None
 
 @dataclass
@@ -190,3 +189,37 @@ class UniversalDirectoryReaderConfig(ReaderProviderConfig):
     bucket_name: Optional[str] = None
     key_prefix: Optional[str] = None
     collection_id: Optional[str] = None
+
+
+# Generic LlamaIndex plugin reader
+@dataclass
+class LlamaIndexPluginReaderConfig(ReaderProviderConfig):
+    """Configuration for the generic LlamaIndex reader plugin.
+    
+    Wraps any reader from the LlamaIndex ecosystem with just configuration.
+    See: https://developers.llamaindex.ai/python/framework-api-reference/readers/
+    
+    Args:
+        package: pip package name (e.g. "llama-index-readers-confluence")
+        module_path: Full Python module path (e.g. "llama_index.readers.confluence")
+        reader_class: Class name to import (e.g. "ConfluenceReader")
+        init_args: Dict of keyword arguments for the reader constructor
+        load_method: Method to call for loading (default: "load_data")
+        load_args: Dict of keyword arguments for the load method
+        timeout_seconds: Max seconds for the read operation (default: 120)
+        max_retries: Number of retries on transient failures (default: 2)
+        retry_backoff_seconds: Initial backoff between retries (default: 2.0)
+        fail_on_error: If False, return [] on failure instead of raising (default: False)
+        metadata_fn: Optional function to enrich document metadata
+    """
+    package: str = ""
+    module_path: str = ""
+    reader_class: str = ""
+    init_args: Optional[Dict[str, Any]] = None
+    load_method: str = "load_data"
+    load_args: Optional[Dict[str, Any]] = None
+    timeout_seconds: int = 120
+    max_retries: int = 2
+    retry_backoff_seconds: float = 2.0
+    fail_on_error: bool = True
+    metadata_fn: Optional[Callable[[str], Dict[str, Any]]] = None

--- a/lexical-graph/tests/unit/indexing/load/readers/providers/test_llama_index_plugin_reader_provider.py
+++ b/lexical-graph/tests/unit/indexing/load/readers/providers/test_llama_index_plugin_reader_provider.py
@@ -1,0 +1,774 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Comprehensive unit tests for LlamaIndexPluginReaderProvider.
+
+Tests cover:
+    - Happy path (reader loads documents successfully)
+    - Import errors (package not installed)
+    - Class not found in module
+    - Invalid init_args (constructor mismatch)
+    - Auth failures (401/403 detection)
+    - Timeout enforcement
+    - Retry with exponential backoff on transient errors
+    - Graceful degradation (fail_on_error=False)
+    - Empty results (warning logged)
+    - Partial failures (non-Document items filtered)
+    - input_source flexibility (passed or omitted)
+    - Metadata enrichment
+    - Load method not found
+    - Generator/iterator results
+"""
+
+import logging
+import time
+import pytest
+from unittest.mock import Mock, MagicMock, patch, PropertyMock
+from dataclasses import dataclass
+
+from llama_index.core.schema import Document
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides):
+    """Create a LlamaIndexPluginReaderConfig with sensible test defaults."""
+    from graphrag_toolkit.lexical_graph.indexing.load.readers.reader_provider_config import (
+        LlamaIndexPluginReaderConfig,
+    )
+    defaults = {
+        "package": "llama-index-readers-confluence",
+        "module_path": "llama_index.readers.confluence",
+        "reader_class": "ConfluenceReader",
+        "init_args": {"base_url": "https://test.atlassian.net/wiki"},
+        "load_args": {"space_key": "ENG"},
+        "timeout_seconds": 5,
+        "max_retries": 0,
+        "fail_on_error": True,
+    }
+    defaults.update(overrides)
+    return LlamaIndexPluginReaderConfig(**defaults)
+
+
+def _mock_reader_module(reader_class_name="ConfluenceReader", load_return=None):
+    """Create a mock module with a mock reader class."""
+    mock_module = MagicMock()
+    mock_reader_instance = Mock()
+    mock_reader_instance.load_data = Mock(
+        return_value=load_return if load_return is not None else [
+            Document(text="Page 1 content", metadata={"title": "Page 1"}),
+            Document(text="Page 2 content", metadata={"title": "Page 2"}),
+        ]
+    )
+    mock_reader_class = Mock(return_value=mock_reader_instance)
+    setattr(mock_module, reader_class_name, mock_reader_class)
+    return mock_module, mock_reader_class, mock_reader_instance
+
+
+# ---------------------------------------------------------------------------
+# Happy Path
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    """Tests for successful document loading."""
+
+    def test_loads_documents_successfully(self):
+        """Reader returns documents — all pass through."""
+        mock_module, mock_cls, mock_reader = _mock_reader_module()
+        config = _make_config()
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert len(docs) == 2
+        assert docs[0].text == "Page 1 content"
+        assert docs[1].metadata["title"] == "Page 2"
+        mock_reader.load_data.assert_called_once_with(space_key="ENG")
+
+    def test_passes_input_source(self):
+        """input_source is passed through to load_args."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        config = _make_config(load_args={})
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            provider.read("https://wiki.example.com")
+
+        mock_reader.load_data.assert_called_once_with(
+            input_source="https://wiki.example.com"
+        )
+
+    def test_input_source_fallback_when_not_accepted(self):
+        """If reader doesn't accept input_source kwarg, retry without it."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        # First call raises TypeError (unexpected kwarg), second succeeds
+        mock_reader.load_data.side_effect = [
+            TypeError("unexpected keyword argument 'input_source'"),
+            [Document(text="worked", metadata={})],
+        ]
+        # Reset side_effect for the _call_load_fn retry
+        call_count = [0]
+        original_side_effect = mock_reader.load_data.side_effect
+
+        def flexible_load(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1 and "input_source" in kwargs:
+                raise TypeError("unexpected keyword argument 'input_source'")
+            return [Document(text="worked", metadata={})]
+
+        mock_reader.load_data.side_effect = flexible_load
+        config = _make_config(load_args={"space_key": "TEST"})
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read("some_input")
+
+        assert len(docs) == 1
+        assert docs[0].text == "worked"
+
+    def test_metadata_enrichment(self):
+        """metadata_fn enriches all returned documents."""
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(
+            metadata_fn=lambda source: {"source": "confluence", "team": "platform"}
+        )
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        for doc in docs:
+            assert doc.metadata["source"] == "confluence"
+            assert doc.metadata["team"] == "platform"
+
+
+# ---------------------------------------------------------------------------
+# Import Errors
+# ---------------------------------------------------------------------------
+
+class TestImportErrors:
+    """Tests for missing packages and classes."""
+
+    def test_raises_on_missing_package(self):
+        """ImportError with install instructions when package not found."""
+        config = _make_config(
+            package="llama-index-readers-confluence",
+            module_path="llama_index.readers.confluence",
+        )
+
+        with patch("importlib.import_module", side_effect=ImportError("No module named 'llama_index.readers.confluence'")):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+                ReaderImportError,
+            )
+            with pytest.raises(ReaderImportError) as exc_info:
+                LlamaIndexPluginReaderProvider(config)
+
+        assert "pip install" in str(exc_info.value)
+        assert "llama-index-readers-confluence" in str(exc_info.value)
+
+    def test_raises_on_missing_class(self):
+        """ImportError when class not found in module."""
+        mock_module = MagicMock()
+        # Make getattr raise AttributeError for ConfluenceReader
+        del mock_module.ConfluenceReader
+        config = _make_config(reader_class="ConfluenceReader")
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+                ReaderImportError,
+            )
+            with pytest.raises(ReaderImportError) as exc_info:
+                LlamaIndexPluginReaderProvider(config)
+
+        assert "not found" in str(exc_info.value)
+
+    def test_raises_on_invalid_init_args(self):
+        """ValueError when constructor args don't match reader signature."""
+        mock_module = MagicMock()
+        mock_cls = Mock(side_effect=TypeError("__init__() got unexpected keyword argument 'bogus'"))
+        mock_module.ConfluenceReader = mock_cls
+        config = _make_config(init_args={"bogus": "value"})
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            with pytest.raises(ValueError) as exc_info:
+                LlamaIndexPluginReaderProvider(config)
+
+        assert "init_args" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    """Tests for config validation."""
+
+    def test_raises_on_missing_reader_class(self):
+        """ValueError when reader_class not provided."""
+        config = _make_config(reader_class="")
+
+        from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+            LlamaIndexPluginReaderProvider,
+        )
+        with pytest.raises(ValueError, match="reader_class"):
+            LlamaIndexPluginReaderProvider(config)
+
+    def test_raises_on_missing_module_and_package(self):
+        """ValueError when neither module_path nor package provided."""
+        config = _make_config(module_path="", package="")
+
+        from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+            LlamaIndexPluginReaderProvider,
+        )
+        with pytest.raises(ValueError, match="module_path"):
+            LlamaIndexPluginReaderProvider(config)
+
+
+# ---------------------------------------------------------------------------
+# Auth Failures
+# ---------------------------------------------------------------------------
+
+class TestAuthFailures:
+    """Tests for authentication error detection."""
+
+    @pytest.mark.parametrize("error_msg", [
+        "401 Unauthorized",
+        "403 Forbidden",
+        "Invalid token provided",
+        "Token expired at 2026-01-01",
+        "Authentication failed: bad credentials",
+        "Access denied for user",
+    ])
+    def test_detects_auth_errors(self, error_msg):
+        """Auth-like errors raise ReaderAuthError and are NOT retried."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.side_effect = RuntimeError(error_msg)
+        config = _make_config(max_retries=3)  # Should NOT retry
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+                ReaderAuthError,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+
+            with pytest.raises(ReaderAuthError):
+                provider.read()
+
+        # Only called once — no retries on auth errors
+        assert mock_reader.load_data.call_count == 1
+
+    def test_auth_error_during_init(self):
+        """Auth error during reader construction is detected."""
+        mock_module = MagicMock()
+        mock_cls = Mock(side_effect=RuntimeError("401 Unauthorized: invalid API key"))
+        mock_module.ConfluenceReader = mock_cls
+        config = _make_config()
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+                ReaderAuthError,
+            )
+            with pytest.raises(ReaderAuthError):
+                LlamaIndexPluginReaderProvider(config)
+
+
+# ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+class TestTimeout:
+    """Tests for timeout enforcement."""
+
+    def test_raises_on_timeout(self):
+        """ReaderTimeoutError when reader exceeds timeout_seconds."""
+        mock_module, _, mock_reader = _mock_reader_module()
+
+        def slow_load(**kwargs):
+            time.sleep(10)
+            return []
+
+        mock_reader.load_data.side_effect = slow_load
+        config = _make_config(timeout_seconds=1, fail_on_error=True)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+                ReaderTimeoutError,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+
+            with pytest.raises((ReaderTimeoutError, RuntimeError)):
+                provider.read()
+
+    def test_timeout_returns_empty_when_not_fail_on_error(self):
+        """Timeout returns [] when fail_on_error=False."""
+        mock_module, _, mock_reader = _mock_reader_module()
+
+        def slow_load(**kwargs):
+            time.sleep(10)
+            return []
+
+        mock_reader.load_data.side_effect = slow_load
+        config = _make_config(timeout_seconds=1, fail_on_error=False)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert docs == []
+
+
+# ---------------------------------------------------------------------------
+# Retry with Backoff
+# ---------------------------------------------------------------------------
+
+class TestRetry:
+    """Tests for retry with exponential backoff on transient errors."""
+
+    def test_retries_on_transient_error(self):
+        """Transient errors (429, 503) trigger retry."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.side_effect = [
+            RuntimeError("429 Too Many Requests"),
+            [Document(text="success", metadata={})],
+        ]
+        config = _make_config(max_retries=1, retry_backoff_seconds=0.01)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert len(docs) == 1
+        assert docs[0].text == "success"
+        assert mock_reader.load_data.call_count == 2
+
+    def test_exhausts_retries_then_fails(self):
+        """After max_retries, raises if fail_on_error=True."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.side_effect = RuntimeError("503 Service Unavailable")
+        config = _make_config(max_retries=2, retry_backoff_seconds=0.01, fail_on_error=True)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+
+            with pytest.raises(RuntimeError, match="all 3 attempt"):
+                provider.read()
+
+        # 1 initial + 2 retries = 3 total
+        assert mock_reader.load_data.call_count == 3
+
+    def test_exhausts_retries_returns_empty_gracefully(self):
+        """After max_retries with fail_on_error=False, returns []."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.side_effect = RuntimeError("500 Internal Server Error")
+        config = _make_config(max_retries=1, retry_backoff_seconds=0.01, fail_on_error=False)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert docs == []
+
+    def test_non_transient_error_not_retried(self):
+        """Non-transient errors (ValueError, etc.) are NOT retried."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.side_effect = ValueError("Invalid space_key format")
+        config = _make_config(max_retries=3, retry_backoff_seconds=0.01, fail_on_error=True)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+
+            with pytest.raises(RuntimeError):
+                provider.read()
+
+        # Only 1 attempt — no retries for non-transient errors
+        assert mock_reader.load_data.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Empty Results
+# ---------------------------------------------------------------------------
+
+class TestEmptyResults:
+    """Tests for empty result handling."""
+
+    def test_empty_list_returns_with_warning(self, caplog):
+        """Empty result logs warning but doesn't error."""
+        mock_module, _, mock_reader = _mock_reader_module(load_return=[])
+        config = _make_config()
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+
+            with caplog.at_level(logging.WARNING):
+                docs = provider.read()
+
+        assert docs == []
+        assert "0 documents" in caplog.text
+
+    def test_none_return_handled_gracefully(self):
+        """Reader returning None doesn't crash."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.return_value = None
+        config = _make_config(fail_on_error=False)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert docs == []
+
+
+# ---------------------------------------------------------------------------
+# Partial Failures / Invalid Documents
+# ---------------------------------------------------------------------------
+
+class TestPartialFailures:
+    """Tests for filtering invalid items from results."""
+
+    def test_filters_non_document_items(self):
+        """Non-Document items in the result list are filtered out."""
+        mixed_results = [
+            Document(text="valid 1", metadata={}),
+            "I am not a document",
+            42,
+            Document(text="valid 2", metadata={}),
+            None,
+        ]
+        mock_module, _, mock_reader = _mock_reader_module(load_return=mixed_results)
+        config = _make_config()
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert len(docs) == 2
+        assert docs[0].text == "valid 1"
+        assert docs[1].text == "valid 2"
+
+    def test_handles_generator_return(self):
+        """Reader returning a generator is consumed into a list."""
+        def doc_generator():
+            yield Document(text="gen 1", metadata={})
+            yield Document(text="gen 2", metadata={})
+            yield Document(text="gen 3", metadata={})
+
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.load_data.return_value = doc_generator()
+        config = _make_config()
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert len(docs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Module Path Resolution
+# ---------------------------------------------------------------------------
+
+class TestModuleResolution:
+    """Tests for deriving module_path from package name."""
+
+    def test_module_path_takes_priority(self):
+        """Explicit module_path is used over package derivation."""
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(
+            module_path="llama_index.readers.custom",
+            package="something-else",
+        )
+
+        with patch("importlib.import_module", return_value=mock_module) as mock_import:
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            LlamaIndexPluginReaderProvider(config)
+
+        mock_import.assert_called_once_with("llama_index.readers.custom")
+
+    def test_derives_module_from_package_name(self):
+        """Package name llama-index-readers-X → llama_index.readers.X."""
+        mock_module, _, _ = _mock_reader_module(reader_class_name="NotionReader")
+        config = _make_config(
+            module_path="",
+            package="llama-index-readers-notion",
+            reader_class="NotionReader",
+        )
+
+        with patch("importlib.import_module", return_value=mock_module) as mock_import:
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            LlamaIndexPluginReaderProvider(config)
+
+        mock_import.assert_called_once_with("llama_index.readers.notion")
+
+
+# ---------------------------------------------------------------------------
+# Load Method
+# ---------------------------------------------------------------------------
+
+class TestLoadMethod:
+    """Tests for custom load method configuration."""
+
+    def test_uses_custom_load_method(self):
+        """load_method config routes to the correct reader method."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        mock_reader.lazy_load = Mock(return_value=[
+            Document(text="lazy doc", metadata={})
+        ])
+        config = _make_config(load_method="lazy_load")
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            docs = provider.read()
+
+        assert len(docs) == 1
+        mock_reader.lazy_load.assert_called_once()
+
+    def test_missing_load_method_fails_gracefully(self):
+        """Disallowed load_method raises ValueError (security: only allowed methods)."""
+        mock_module, _, mock_reader = _mock_reader_module()
+        config = _make_config(load_method="custom_method", fail_on_error=True)
+
+        with patch("importlib.import_module", return_value=mock_module):
+            from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+                LlamaIndexPluginReaderProvider,
+            )
+            provider = LlamaIndexPluginReaderProvider(config)
+            with pytest.raises(ValueError, match="not allowed"):
+                provider.read()
+
+
+# ─── Security Hardening Tests (Items #1-7 from review) ────────────────────────
+
+from graphrag_toolkit.lexical_graph.indexing.load.readers.providers.llama_index_plugin_reader_provider import (
+    LlamaIndexPluginReaderProvider,
+    ReaderImportError,
+    ReaderAuthError,
+)
+
+
+class TestNamespaceAllowlist:
+    """Item #1: Verify namespace restriction prevents arbitrary module loading."""
+
+    def test_disallowed_module_raises(self):
+        """Module not in ALLOWED_MODULE_PREFIXES is rejected."""
+        config = _make_config(module_path="os", reader_class="system")
+        with pytest.raises(ReaderImportError, match="not in the allowed namespace"):
+            LlamaIndexPluginReaderProvider(config)
+
+    def test_shutil_blocked(self):
+        """Filesystem destruction via shutil.rmtree is prevented."""
+        config = _make_config(module_path="shutil", reader_class="rmtree")
+        with pytest.raises(ReaderImportError, match="not in the allowed namespace"):
+            LlamaIndexPluginReaderProvider(config)
+
+    def test_allowed_prefix_passes(self):
+        """Module in allowed namespace proceeds to import."""
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(module_path="llama_index.readers.confluence")
+        with patch("importlib.import_module", return_value=mock_module):
+            provider = LlamaIndexPluginReaderProvider(config)
+            assert provider._reader is not None
+
+    def test_custom_subclass_extends_allowlist(self):
+        """Subclass can extend ALLOWED_MODULE_PREFIXES for custom namespaces."""
+        class MyProvider(LlamaIndexPluginReaderProvider):
+            ALLOWED_MODULE_PREFIXES = ("llama_index.readers.", "mycompany.readers.")
+
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(module_path="mycompany.readers.internal")
+        with patch("importlib.import_module", return_value=mock_module):
+            provider = MyProvider(config)
+            assert provider._reader is not None
+
+
+class TestInterfaceValidation:
+    """Item #2: Verify interface check before instantiation."""
+
+    def test_non_callable_rejected(self):
+        """Non-callable attribute is rejected before constructor runs."""
+        mock_module = Mock()
+        mock_module.NotAClass = "just a string"
+        config = _make_config(module_path="llama_index.readers.test", reader_class="NotAClass")
+        with patch("importlib.import_module", return_value=mock_module):
+            with pytest.raises(ReaderImportError, match="is not callable"):
+                LlamaIndexPluginReaderProvider(config)
+
+    def test_missing_load_data_rejected(self):
+        """Class without load_data or lazy_load is rejected before instantiation."""
+        mock_module = Mock()
+        mock_cls = Mock()
+        mock_cls.load_data = None
+        del mock_cls.load_data
+        del mock_cls.lazy_load
+        mock_module.BadReader = mock_cls
+        config = _make_config(module_path="llama_index.readers.test", reader_class="BadReader")
+        with patch("importlib.import_module", return_value=mock_module):
+            with pytest.raises(ReaderImportError, match="does not implement"):
+                LlamaIndexPluginReaderProvider(config)
+
+
+class TestLoadMethodRestriction:
+    """Item #3: Only allowed methods can be called."""
+
+    def test_dunder_method_blocked(self):
+        """Dunder methods like __delattr__ cannot be called."""
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(load_method="__delattr__")
+        with patch("importlib.import_module", return_value=mock_module):
+            provider = LlamaIndexPluginReaderProvider(config)
+            with pytest.raises(ValueError, match="not allowed"):
+                provider.read()
+
+    def test_arbitrary_method_blocked(self):
+        """Arbitrary method names are blocked."""
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(load_method="execute_shell")
+        with patch("importlib.import_module", return_value=mock_module):
+            provider = LlamaIndexPluginReaderProvider(config)
+            with pytest.raises(ValueError, match="not allowed"):
+                provider.read()
+
+
+class TestEnvVarResolution:
+    """Item #4: $VAR_NAME references resolved from environment."""
+
+    def test_resolves_env_var(self, monkeypatch):
+        """$VAR_NAME is replaced with environment value."""
+        monkeypatch.setenv("MY_TOKEN", "secret123")
+        mock_module, mock_cls, _ = _mock_reader_module()
+        config = _make_config(init_args={"token": "$MY_TOKEN", "url": "https://example.com"})
+        with patch("importlib.import_module", return_value=mock_module):
+            LlamaIndexPluginReaderProvider(config)
+        # Verify the constructor received the resolved value
+        mock_cls.assert_called_once_with(token="secret123", url="https://example.com")
+
+    def test_missing_env_var_raises(self):
+        """Reference to unset env var raises ValueError."""
+        config = _make_config(init_args={"token": "$NONEXISTENT_VAR_XYZ"})
+        mock_module, _, _ = _mock_reader_module()
+        with patch("importlib.import_module", return_value=mock_module):
+            with pytest.raises(ValueError, match="not set in the environment"):
+                LlamaIndexPluginReaderProvider(config)
+
+    def test_non_env_string_unchanged(self):
+        """Strings without $ prefix are passed through unchanged."""
+        mock_module, mock_cls, _ = _mock_reader_module()
+        config = _make_config(init_args={"url": "https://example.com", "count": "5"})
+        with patch("importlib.import_module", return_value=mock_module):
+            LlamaIndexPluginReaderProvider(config)
+        mock_cls.assert_called_once_with(url="https://example.com", count="5")
+
+    def test_lowercase_dollar_not_resolved(self):
+        """$lowercase is not treated as env var (only $UPPER_CASE)."""
+        mock_module, mock_cls, _ = _mock_reader_module()
+        config = _make_config(init_args={"note": "$not_an_env_var"})
+        with patch("importlib.import_module", return_value=mock_module):
+            LlamaIndexPluginReaderProvider(config)
+        mock_cls.assert_called_once_with(note="$not_an_env_var")
+
+
+class TestCredentialLogging:
+    """Item #5: Credential values must never appear in logs."""
+
+    def test_credentials_not_logged(self, caplog):
+        """Secret values in init_args never appear in log output."""
+        import logging as stdlib_logging
+        secret = "super_secret_token_value_12345"
+        mock_module, _, _ = _mock_reader_module()
+        config = _make_config(init_args={"github_token": secret})
+        with caplog.at_level(stdlib_logging.DEBUG):
+            with patch("importlib.import_module", return_value=mock_module):
+                try:
+                    LlamaIndexPluginReaderProvider(config)
+                except Exception:
+                    pass
+        assert secret not in caplog.text, "Credential value leaked into logs"
+
+
+class TestPackageNameValidation:
+    """Item #7: Only suggest pip install for validated package names."""
+
+    def test_valid_package_gets_install_hint(self):
+        """Valid llama-index-readers-* package gets pip install suggestion."""
+        config = _make_config(
+            package="llama-index-readers-confluence",
+            module_path="llama_index.readers.confluence",
+        )
+        with pytest.raises(ReaderImportError, match="pip install llama-index-readers-confluence"):
+            LlamaIndexPluginReaderProvider(config)
+
+    def test_invalid_package_no_install_hint(self):
+        """Non-llama-index package does NOT get pip install suggestion."""
+        config = _make_config(
+            package="some-random-package",
+            module_path="llama_index.readers.random",
+        )
+        with pytest.raises(ReaderImportError) as exc_info:
+            LlamaIndexPluginReaderProvider(config)
+        assert "pip install" not in str(exc_info.value)
+
+    def test_arbitrary_package_no_install_hint(self):
+        """Completely arbitrary package name does NOT get pip install suggestion."""
+        config = _make_config(
+            package="evil-package",
+            module_path="llama_index.readers.evil",
+        )
+        with pytest.raises(ReaderImportError) as exc_info:
+            LlamaIndexPluginReaderProvider(config)
+        assert "pip install" not in str(exc_info.value)


### PR DESCRIPTION
Clean PR as requested in #390 — contains only the 4 plugin files:

- `providers/__init__.py` (registration)
- `providers/llama_index_plugin_reader_provider.py` (implementation)
- `reader_provider_config.py` (config updates)
- `tests/test_llama_index_plugin_reader_provider.py` (test)

No unrelated changes. Supersedes #390.

---
**What it does:**
Allows using any LlamaIndex reader package as an extraction source via a generic plugin provider. Includes input validation, security hardening, and comprehensive tests.