### PR TITLE
fix: stop FMObservabilityPublisher.close() from leaking its poller thread

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/utils/fm_observability.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/utils/fm_observability.py
@@ -525,6 +525,7 @@ class FMObservabilityPublisher():
         self.subscribers = subscribers
         self.interval_seconds = interval_seconds
         self.allow_continue = True
+        self._lock = threading.Lock()
         self.poller = FMObservabilityQueuePoller()
         self.poller.start()
 
@@ -534,17 +535,19 @@ class FMObservabilityPublisher():
 
     def close(self):
         """
-        Disables the continuation functionality by updating the internal flag.
+        Disables the continuation functionality and stops the current poller.
 
         This method prevents further continuation of a process by setting the
-        `allow_continue` attribute to `False`. Once invoked, the attribute will
-        indicate that continuation should not occur.
+        `allow_continue` attribute to `False` and synchronously stopping the
+        currently running poller thread, so no poller is left running past close().
 
         Attributes:
             allow_continue (bool): Indicates whether continuation is permitted or not.
                 Set to `False` to disable continuation.
         """
-        self.allow_continue = False
+        with self._lock:
+            self.allow_continue = False
+            self.poller.stop()
 
     def __enter__(self):
         """
@@ -578,16 +581,17 @@ class FMObservabilityPublisher():
         Returns:
             None
         """
-        stats = self.poller.stop()
-        self.poller = FMObservabilityQueuePoller()
-        self.poller.start()
-        if self.allow_continue:
-            logging.debug('Scheduling new poller')
-            t = threading.Timer(self.interval_seconds, self.publish_stats)
-            t.daemon = True
-            t.start()
-        else:
-            logging.debug('Shutting down publisher')
+        with self._lock:
+            stats = self.poller.stop()
+            if self.allow_continue:
+                self.poller = FMObservabilityQueuePoller()
+                self.poller.start()
+                logging.debug('Scheduling new poller')
+                t = threading.Timer(self.interval_seconds, self.publish_stats)
+                t.daemon = True
+                t.start()
+            else:
+                logging.debug('Shutting down publisher')
         for subscriber in self.subscribers:
             subscriber.on_new_stats(stats)
 

--- a/lexical-graph/tests/unit/utils/test_fm_observability.py
+++ b/lexical-graph/tests/unit/utils/test_fm_observability.py
@@ -445,6 +445,7 @@ class TestObservabilityIntegration:
     def test_publisher_initialization_sets_up_handlers(self, mock_settings, mock_queue_class):
         """Verify FMObservabilityPublisher sets up handlers on initialization."""
         mock_queue_instance = Mock()
+        mock_queue_instance.get = Mock(side_effect=queue.Empty)
         mock_queue_class.return_value = mock_queue_instance
         mock_callback_manager = Mock()
         mock_settings.callback_manager = mock_callback_manager
@@ -466,6 +467,7 @@ class TestObservabilityIntegration:
     def test_publisher_context_manager(self, mock_settings, mock_queue_class):
         """Verify FMObservabilityPublisher works as context manager."""
         mock_queue_instance = Mock()
+        mock_queue_instance.get = Mock(side_effect=queue.Empty)
         mock_queue_class.return_value = mock_queue_instance
         mock_callback_manager = Mock()
         mock_settings.callback_manager = mock_callback_manager
@@ -478,7 +480,35 @@ class TestObservabilityIntegration:
         # After exiting context, should be closed
         assert publisher.allow_continue is False
 
-    
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_close_stops_the_current_poller(self, mock_settings):
+        """close() must synchronously stop the running poller, not just flip allow_continue."""
+        mock_settings.callback_manager = Mock()
+
+        publisher = FMObservabilityPublisher(subscribers=[], interval_seconds=30.0)
+        live_poller = publisher.poller
+
+        publisher.close()
+
+        assert live_poller._discontinue.is_set()
+        live_poller.join(timeout=5)
+        assert not live_poller.is_alive()
+
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_publish_stats_does_not_replace_poller_after_close(self, mock_settings):
+        """A publish_stats() tick firing after close() must not leave a fresh, unstopped poller."""
+        mock_settings.callback_manager = Mock()
+
+        publisher = FMObservabilityPublisher(subscribers=[], interval_seconds=30.0)
+        original_poller = publisher.poller
+
+        publisher.close()
+        # Simulate the in-flight Timer (scheduled before close()) firing afterwards.
+        publisher.publish_stats()
+
+        assert publisher.poller is original_poller
+        assert publisher.poller._discontinue.is_set()
+
     @patch('graphrag_toolkit.lexical_graph.utils.fm_observability._fm_observability_queue')
     def test_handler_event_end_puts_event_in_queue(self, mock_queue):
         """Verify FMObservabilityHandler puts completed events in queue."""


### PR DESCRIPTION
## Description

`FMObservabilityPublisher.close()` set `allow_continue = False` but never touched the poller, so a poller thread survived every `close()` call.

## Problem

`publish_stats()` unconditionally stops the current poller and starts a replacement (lines 581-583 before the fix) and only checks `allow_continue` afterward to decide whether to reschedule itself. The `threading.Timer` scheduled in `__init__`, or an in-flight tick, can still fire after `close()` sets `allow_continue = False`, so the replacement poller it creates is started but never stopped and keeps running for the rest of the process.

The same gap turns two of the file's own tests into a busy loop: `test_publisher_initialization_sets_up_handlers` and `test_publisher_context_manager` mock `Queue` with a plain `Mock`, so `Mock.get()` returns immediately instead of raising `queue.Empty`, and the leaked poller spins instead of idling on a real 1-second block.

Related issue: #450

## Changes

- `close()` now stops the current poller synchronously (under a new `threading.Lock` shared with `publish_stats()`).
- `publish_stats()` only creates and starts a replacement poller while `allow_continue` is still true, checked under the same lock, so a tick that fires after `close()` cannot leave a fresh poller running.
- `test_publisher_initialization_sets_up_handlers` / `test_publisher_context_manager`: gave the mocked queue `get.side_effect = queue.Empty`, matching the `mock_fm_queue` fixture already used elsewhere in the file, so the poller polls instead of spinning.
- Added `test_close_stops_the_current_poller` and `test_publish_stats_does_not_replace_poller_after_close`, which fail on unmodified `main` and pass with the fix.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

New tests fail on `main` (`assert False` on `_discontinue.is_set()`; poller identity check fails because `publish_stats()` always replaces it) and pass on this branch. Full `lexical-graph` suite: 1793 passed, 1 skipped, coverage 61.98% (repo gate is 56%), run in a clean `python:3.12-slim` container with the CI-matching `pytest --cov-config=.coveragerc --cov=graphrag_toolkit.lexical_graph --cov-fail-under=56` invocation. `bandit -r lexical-graph/src/ -ll`: no issues. Not run: the `3.10`/`3.11` legs of the CI matrix (only checked `3.12` locally).

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
