### PR TITLE
[CHORE] Use env var for release tag in workflow (lexical-graph-3.18.x)

### DIFF
--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -108,8 +108,9 @@ jobs:
       - name: Cleanup existing release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG"
           # Extract base version (e.g. graphrag-lexical-graph/v3.18.0 from graphrag-lexical-graph/v3.18.0.dev3)
           BASE_VERSION="${TAG%.dev*}"
           # Find all dev releases matching this base version and delete their assets


### PR DESCRIPTION
## Description

related to: #364

Refactors the `Cleanup existing release assets` step in the lexical-graph release workflow to pass the release tag name through an environment variable rather than using direct context interpolation in the shell script.

This aligns with GitHub Actions recommended patterns for referencing event data in `run` steps, where environment variables are preferred over inline expressions for shell scripts.

Reference: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

## Changes

- Added `RELEASE_TAG` to the step's `env` block
- Reference `$RELEASE_TAG` in the script instead of `${{ github.event.release.tag_name }}`

## Problem

The workflow used inline `${{ }}` expression interpolation directly in a shell script body. GitHub Actions best practices recommend using environment variables for passing context data into `run` steps.

Related issue (if any): #

## Testing

- [x] Ran script injection validation (checks for `${{ github.event.* }}` in `run:` blocks)
  - Before fix: **FAIL** — `lexical-graph-release.yml:112` (`TAG="${{ github.event.release.tag_name }}"` in inline script)
  - After fix: **PASS** — No untrusted context in inline scripts
- [x] Follows GitHub recommended pattern: "Use an intermediate environment variable"
  - Untrusted value set in `env:` block (`RELEASE_TAG: ${{ github.event.release.tag_name }}`)
  - Referenced as shell variable (`$RELEASE_TAG`) in `run:` script
  - Value stored in memory as variable — does not interact with script generation
  - Shell variable is double-quoted to avoid word splitting
- [x] Existing tests pass
- [x] No behavioral change — workflow operates identically

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.