### PR TITLE
[FEATURE] (benchmarks): Add multi-retriever benchmark harness with beam-search retrievers

### DIFF
--- a/benchmarks/datasets/benchmark.concurrentqa.all-retrievers
+++ b/benchmarks/datasets/benchmark.concurrentqa.all-retrievers
@@ -1,0 +1,4 @@
+benchmark_extract.ConcurrentQaBenchmarkExtract
+benchmark_build.ConcurrentQaBenchmarkBuild
+benchmark_query.ConcurrentQaBenchmarkQuery
+benchmark_evaluate.ConcurrentQaBenchmarkEvaluate

--- a/benchmarks/env.template
+++ b/benchmarks/env.template
@@ -22,6 +22,8 @@ export BENCHMARK_DATA_DIR=<OPTIONAL: Local directory containing benchmark data t
 export BENCHMARK_DATA_S3_URI=<OPTIONAL: S3 URI for benchmark data synced at runtime, e.g. s3://graphrag-toolkit-benchmarking/, default: Empty>
 export BENCHMARK_QA_LIMIT=<OPTIONAL: Max number of QA pairs to evaluate for prototype runs, default: Empty (all pairs)>
 export BENCHMARK_IS_PROTOTYPE=<OPTIONAL: Use prototype datasets (e.g. cuad-prototype instead of cuad), true or false, default: Empty (false)>
+export BENCHMARK_ALL_RETRIEVERS=<OPTIONAL: When "true", run all retrievers in a single pass (extract+build once, then query+evaluate per retriever). Incompatible with DELETE_ON_PASS=True, default: Empty (false)>
+export BENCHMARK_DATASET=<OPTIONAL: Dataset for all-retrievers mode – one of cuad, concurrentqa, pga, pga_bio, pga_stat, wikihow. Required when BENCHMARK_ALL_RETRIEVERS=true, default: Empty>
 
 export EXISTING_VPC_ID=<OPTIONAL: Existing VPC ID to reuse instead of creating a new VPC, default: Empty>
 export EXISTING_SUBNET_IDS=<OPTIONAL: Comma-delimited existing subnet IDs to reuse (min 2 across 2 AZs, must be provided with EXISTING_VPC_ID), default: Empty>

--- a/benchmarks/scripts/run_all_retrievers.sh
+++ b/benchmarks/scripts/run_all_retrievers.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# run_all_retrievers.sh — Run extract + build once, then query + evaluate for each retriever.
+#
+# Usage:
+#   bash benchmarks/scripts/run_all_retrievers.sh <dataset>
+#
+# Where <dataset> is one of: cuad, concurrentqa, pga, pga_bio, pga_stat, wikihow
+
+set -euo pipefail
+
+DATASET="${1:-}"
+
+if [[ -z "$DATASET" ]]; then
+    echo "Usage: $0 <dataset>"
+    echo "  dataset: cuad | concurrentqa | pga | pga_bio | pga_stat | wikihow"
+    exit 1
+fi
+
+# Map dataset argument to test class name prefixes
+case "$DATASET" in
+    cuad)
+        EXTRACT_CLASS="benchmark_extract.CuadBenchmarkExtract"
+        BUILD_CLASS="benchmark_build.CuadBenchmarkBuild"
+        QUERY_CLASS="benchmark_query.CuadBenchmarkQuery"
+        EVALUATE_CLASS="benchmark_evaluate.CuadBenchmarkEvaluate"
+        ;;
+    concurrentqa)
+        EXTRACT_CLASS="benchmark_extract.ConcurrentQaBenchmarkExtract"
+        BUILD_CLASS="benchmark_build.ConcurrentQaBenchmarkBuild"
+        QUERY_CLASS="benchmark_query.ConcurrentQaBenchmarkQuery"
+        EVALUATE_CLASS="benchmark_evaluate.ConcurrentQaBenchmarkEvaluate"
+        ;;
+    pga|pga_bio|pga_stat)
+        EXTRACT_CLASS="benchmark_extract.PgaBenchmarkExtract"
+        BUILD_CLASS="benchmark_build.PgaBenchmarkBuild"
+        QUERY_CLASS="benchmark_query.PgaBenchmarkQuery"
+        EVALUATE_CLASS="benchmark_evaluate.PgaBenchmarkEvaluate"
+        ;;
+    wikihow)
+        EXTRACT_CLASS="benchmark_extract.WikihowBenchmarkExtract"
+        BUILD_CLASS="benchmark_build.WikihowBenchmarkBuild"
+        QUERY_CLASS="benchmark_query.WikihowBenchmarkQuery"
+        EVALUATE_CLASS="benchmark_evaluate.WikihowBenchmarkEvaluate"
+        ;;
+    *)
+        echo "ERROR: Unknown dataset '$DATASET'"
+        echo "  Valid values: cuad, concurrentqa, pga, pga_bio, pga_stat, wikihow"
+        exit 1
+        ;;
+esac
+
+# All retrievers to benchmark in a single pass
+RETRIEVERS=(
+    traversal
+    topic-beam-chunk_only
+    topic_beam_search
+    chunk_based_semantic
+    entity_network
+    chunk_based
+    entity_based
+    topic_based
+)
+
+echo "============================================================"
+echo " Multi-Retriever Benchmark: $DATASET"
+echo " Retrievers: ${RETRIEVERS[*]}"
+echo "============================================================"
+echo ""
+
+# --- Phase 1: Extract + Build (run once) ---
+echo ">>> Phase 1: Extract + Build"
+echo "    Running: $EXTRACT_CLASS"
+export TESTS="$EXTRACT_CLASS"
+python test_suite.py "$EXTRACT_CLASS"
+
+echo "    Running: $BUILD_CLASS"
+export TESTS="$BUILD_CLASS"
+python test_suite.py "$BUILD_CLASS"
+
+echo ">>> Phase 1 complete."
+echo ""
+
+# --- Phase 2: Query + Evaluate per retriever ---
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_RETRIEVERS=()
+
+for RETRIEVER in "${RETRIEVERS[@]}"; do
+    echo "------------------------------------------------------------"
+    echo ">>> Phase 2: Query + Evaluate [$RETRIEVER]"
+    echo "------------------------------------------------------------"
+
+    export BENCHMARK_RETRIEVER="$RETRIEVER"
+
+    echo "    Running: $QUERY_CLASS (retriever=$RETRIEVER)"
+    export TESTS="$QUERY_CLASS"
+    if python test_suite.py "$QUERY_CLASS"; then
+        echo "    Running: $EVALUATE_CLASS (retriever=$RETRIEVER)"
+        export TESTS="$EVALUATE_CLASS"
+        if python test_suite.py "$EVALUATE_CLASS"; then
+            echo "    PASSED: $RETRIEVER"
+            PASS_COUNT=$((PASS_COUNT + 1))
+        else
+            echo "    FAILED (evaluate): $RETRIEVER"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            FAILED_RETRIEVERS+=("$RETRIEVER")
+        fi
+    else
+        echo "    FAILED (query): $RETRIEVER"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAILED_RETRIEVERS+=("$RETRIEVER")
+    fi
+
+    echo ""
+done
+
+# --- Summary ---
+echo "============================================================"
+echo " SUMMARY: $DATASET"
+echo "   Passed: $PASS_COUNT / ${#RETRIEVERS[@]}"
+echo "   Failed: $FAIL_COUNT / ${#RETRIEVERS[@]}"
+if [[ ${#FAILED_RETRIEVERS[@]} -gt 0 ]]; then
+    echo "   Failed retrievers: ${FAILED_RETRIEVERS[*]}"
+fi
+echo "============================================================"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+    exit 1
+fi

--- a/benchmarks/scripts/run_all_retrievers.sh
+++ b/benchmarks/scripts/run_all_retrievers.sh
@@ -19,6 +19,17 @@ if [[ -z "$DATASET" ]]; then
     exit 1
 fi
 
+# Guard: --delete-on-pass is incompatible with multi-retriever mode because
+# test_suite.py deletes the stack on the first passing run, leaving subsequent
+# retrievers without infrastructure.
+if [[ "${DELETE_ON_PASS:-}" == "True" || "${DELETE_ON_PASS:-}" == "true" ]]; then
+    echo "ERROR: BENCHMARK_ALL_RETRIEVERS is incompatible with DELETE_ON_PASS=True."
+    echo "  The stack would be torn down after the first passing retriever,"
+    echo "  leaving remaining retrievers without infrastructure."
+    echo "  Please set DELETE_ON_PASS=False or omit --delete-on-pass."
+    exit 1
+fi
+
 # Map dataset argument to test class name prefixes
 case "$DATASET" in
     cuad)

--- a/benchmarks/tests/test_benchmark_query.py
+++ b/benchmarks/tests/test_benchmark_query.py
@@ -349,7 +349,7 @@ class TestRetrieverConfigReproducibility:
         recorded for the sub-retrievers that set them."""
         hp = get_retriever_config(retriever_id)['hyperparameters']
         assert hp['max_statements'] == 200
-        assert hp['max_search_results'] == 5
+        assert hp['max_search_results'] == 10
         assert hp['vss_top_k'] == 10
 
     @settings(max_examples=50)

--- a/benchmarks/tests/test_retriever_factory.py
+++ b/benchmarks/tests/test_retriever_factory.py
@@ -49,7 +49,7 @@ class TestSubRetrieverFactoryCorrectnessProperty:
     entity_network, chunk_based_semantic}, the factory SHALL create a
     CompositeTraversalBasedRetriever with exactly one retriever of the corresponding
     type, weight 1.0, and ProcessorArgs with reranker='tfidf', vss_top_k=10,
-    max_search_results=5, max_statements=200, derive_subqueries=False.
+    max_search_results=10, max_statements=200, derive_subqueries=False.
     """
 
     @settings(max_examples=100)
@@ -58,7 +58,7 @@ class TestSubRetrieverFactoryCorrectnessProperty:
         """
         For each sub-retriever ID, verify the factory calls for_traversal_based_search
         with exactly one retriever of the corresponding type, weight 1.0, and correct
-        ProcessorArgs (reranker='tfidf', vss_top_k=10, max_search_results=5,
+        ProcessorArgs (reranker='tfidf', vss_top_k=10, max_search_results=10,
         max_statements=200, derive_subqueries=False).
         """
         mock_graph_store = MagicMock()
@@ -123,8 +123,8 @@ class TestSubRetrieverFactoryCorrectnessProperty:
                 f"Expected vss_top_k=10 for '{retriever_id}', "
                 f"got vss_top_k={call_kwargs.get('vss_top_k')}"
             )
-            assert call_kwargs.get('max_search_results') == 5, (
-                f"Expected max_search_results=5 for '{retriever_id}', "
+            assert call_kwargs.get('max_search_results') == 10, (
+                f"Expected max_search_results=10 for '{retriever_id}', "
                 f"got max_search_results={call_kwargs.get('max_search_results')}"
             )
             assert call_kwargs.get('max_statements') == 200, (

--- a/benchmarks/utils/retriever_factory.py
+++ b/benchmarks/utils/retriever_factory.py
@@ -18,12 +18,16 @@ from benchmarks.utils.agentic_retriever import AgenticRetriever
 from graphrag_toolkit.lexical_graph.retrieval.retrievers import (
     ChunkBasedSearch,
     ChunkBasedSemanticSearch,
+    ChunkCosineSimilaritySearch,
     EntityBasedSearch,
     EntityNetworkSearch,
     RerankingBeamGraphSearch,
+    SemanticChunkBeamGraphSearch,
+    SemanticGuidedChunkRetriever,
     SemanticGuidedRetriever,
     StatementCosineSimilaritySearch,
     TopicBasedSearch,
+    TopicBeamSearch,
 )
 from graphrag_toolkit.lexical_graph.retrieval.retrievers.composite_traversal_based_retriever import (
     WeightedTraversalBasedRetriever,
@@ -40,6 +44,8 @@ VALID_RETRIEVER_IDS = [
     'chunk_based_semantic',
     'semantic_guided',
     'semantic-path_weighted',
+    'topic-beam-chunk_only',
+    'topic_beam_search',
     'agentic',
     'byokg_agentic',
 ]
@@ -56,12 +62,16 @@ _SUB_RETRIEVER_MAP = {
 # Sub-retriever IDs, derived from _SUB_RETRIEVER_MAP.
 SUB_RETRIEVER_IDS = list(_SUB_RETRIEVER_MAP)
 
-# Common ProcessorArgs kwargs for individual sub-retriever benchmarks
+# NOTE: max_search_results=10 intentionally applies to ALL sub-retrievers for
+# consistent context window size across comparisons. Existing baselines need
+# re-evaluation against this value.
 _SUB_RETRIEVER_PROCESSOR_ARGS = {
     'reranker': 'tfidf',
     'vss_top_k': 10,
-    'max_search_results': 5,
+    'max_search_results': 10,
     'max_statements': 200,
+    'max_context_tokens': 3000,
+    'token_truncation_mode': 'per_topic_cap',
     'derive_subqueries': False,
 }
 
@@ -125,6 +135,12 @@ def create_query_engine(
             **({"llm": llm} if llm else {}),
         )
 
+    if retriever_id == 'topic-beam-chunk_only':
+        return _create_topic_beam_chunk_only(graph_store, vector_store, llm=llm)
+
+    if retriever_id == 'topic_beam_search':
+        return _create_topic_beam_search(graph_store, vector_store, llm=llm)
+
     if retriever_id == 'semantic-path_weighted':
         return _create_semantic_path_weighted(graph_store, vector_store, llm=llm)
 
@@ -174,7 +190,8 @@ def get_retriever_config(
     elif retriever_id == 'byokg_agentic':
         hyperparameters = {'max_iterations': byokg_max_iterations}
     else:
-        # traversal, semantic_guided, semantic-path_weighted:
+        # traversal, semantic_guided, semantic-path_weighted,
+        # topic-beam-chunk_only, topic_beam_search:
         # no harness-level overrides, so the retrieval library defaults apply.
         hyperparameters = {}
 
@@ -183,6 +200,63 @@ def get_retriever_config(
         'response_llm': response_llm,
         'hyperparameters': hyperparameters,
     }
+
+
+def _create_topic_beam_chunk_only(graph_store, vector_store, llm=None) -> LexicalGraphQueryEngine:
+    """
+    Creates a query engine using SemanticGuidedChunkRetriever with
+    ChunkCosineSimilaritySearch (vector seed) + SemanticChunkBeamGraphSearch
+    (beam search over entity graph at chunk level).
+
+    This retriever embeds the query, finds seed chunks via cosine similarity,
+    then performs beam search (width=10, depth=3) over the entity graph to
+    discover related chunks sharing entities.
+    """
+    retriever = SemanticGuidedChunkRetriever(
+        vector_store=vector_store,
+        graph_store=graph_store,
+        retrievers=[
+            ChunkCosineSimilaritySearch(
+                vector_store=vector_store,
+                graph_store=graph_store,
+            ),
+            SemanticChunkBeamGraphSearch(
+                vector_store=vector_store,
+                graph_store=graph_store,
+            ),
+        ],
+    )
+
+    return LexicalGraphQueryEngine(
+        graph_store,
+        vector_store,
+        retriever=retriever,
+        context_format='bedrock_xml',
+        **({"llm": llm} if llm else {}),
+    )
+
+
+def _create_topic_beam_search(graph_store, vector_store, llm=None) -> LexicalGraphQueryEngine:
+    """
+    Creates a query engine using TopicBeamSearch directly.
+
+    Topic-seeded beam search: embeds query -> top-k topics from topic vector
+    index -> beam-search across topic graph via same-chunk/adjacent-chunk
+    co-occurrence edges (width 100, depth 6, path_weighted scoring) -> expand
+    winning topics into statements -> optional topic reranking -> synthesize.
+    """
+    retriever = TopicBeamSearch(
+        vector_store=vector_store,
+        graph_store=graph_store,
+    )
+
+    return LexicalGraphQueryEngine(
+        graph_store,
+        vector_store,
+        retriever=retriever,
+        context_format='bedrock_xml',
+        **({"llm": llm} if llm else {}),
+    )
 
 
 def _create_semantic_path_weighted(graph_store, vector_store, llm=None) -> LexicalGraphQueryEngine:

--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -89,6 +89,8 @@ if [[ "$#" -gt 0 ]]; then
     echo "  --benchmark-data-s3-uri <S3 URI for benchmark data (synced at runtime instead of uploading)>"
     echo "  --benchmark-qa-limit <max number of QA pairs to evaluate (for prototype runs)>"
     echo "  --benchmark-prototype"
+    echo "  --benchmark-all-retrievers  Run all retrievers in a single pass (loops query+evaluate per retriever)"
+    echo "  --benchmark-dataset <dataset>  Dataset for all-retrievers mode (cuad|concurrentqa|pga|pga_bio|pga_stat|wikihow)"
     echo "  --existing-vpc-id <Existing VPC ID to reuse (skip VPC creation)>"
     echo "  --existing-subnet-ids <Comma-separated existing subnet IDs (min 2, spanning 2 AZs)>"
     echo "  --prev-stack <Previous stack name or ID>"
@@ -183,6 +185,8 @@ while [[ "$#" -gt 0 ]]; do
         --benchmark-data-s3-uri) BENCHMARK_DATA_S3_URI="$2"; shift ;;
         --benchmark-qa-limit) BENCHMARK_QA_LIMIT="$2"; shift ;;
         --benchmark-prototype) BENCHMARK_IS_PROTOTYPE=true ;;
+        --benchmark-all-retrievers) BENCHMARK_ALL_RETRIEVERS=true ;;
+        --benchmark-dataset) BENCHMARK_DATASET="$2"; shift ;;
         --existing-vpc-id) EXISTING_VPC_ID="$2"; shift ;;
         --existing-subnet-ids) EXISTING_SUBNET_IDS="$2"; shift ;;
         --prev-stack) PREV_STACK_NAME="$2"; shift ;;
@@ -463,6 +467,8 @@ echo "TESTS                    : $TESTS"
 echo "BENCHMARK_DATA_DIR       : $BENCHMARK_DATA_DIR"
 echo "BENCHMARK_DATA_S3_URI    : $BENCHMARK_DATA_S3_URI"
 echo "BENCHMARK_QA_LIMIT       : $BENCHMARK_QA_LIMIT"
+echo "BENCHMARK_ALL_RETRIEVERS : ${BENCHMARK_ALL_RETRIEVERS:-}"
+echo "BENCHMARK_DATASET        : ${BENCHMARK_DATASET:-}"
 echo "EXISTING_VPC_ID          : $EXISTING_VPC_ID"
 echo "EXISTING_SUBNET_IDS      : $EXISTING_SUBNET_IDS"
 echo "PREV_STACK_NAME"         : $PREV_STACK_NAME

--- a/integration-tests/build-tests.sh
+++ b/integration-tests/build-tests.sh
@@ -397,6 +397,12 @@ fi
 if [[ "$BENCHMARK_IS_PROTOTYPE" ]]; then
 	echo "export BENCHMARK_IS_PROTOTYPE=$BENCHMARK_IS_PROTOTYPE" >> lexical-graph-examples/.env.testing
 fi
+if [[ "${BENCHMARK_ALL_RETRIEVERS:-}" ]]; then
+	echo "export BENCHMARK_ALL_RETRIEVERS=$BENCHMARK_ALL_RETRIEVERS" >> lexical-graph-examples/.env.testing
+fi
+if [[ "${BENCHMARK_DATASET:-}" ]]; then
+	echo "export BENCHMARK_DATASET=$BENCHMARK_DATASET" >> lexical-graph-examples/.env.testing
+fi
 
 zip -r graphrag-toolkit.zip graphrag-toolkit # zip under directory
 

--- a/integration-tests/env.template
+++ b/integration-tests/env.template
@@ -22,6 +22,8 @@ export BENCHMARK_DATA_DIR=<OPTIONAL: Local directory containing benchmark data t
 export BENCHMARK_DATA_S3_URI=<OPTIONAL: S3 URI for benchmark data synced at runtime, e.g. s3://graphrag-toolkit-benchmarking/, default: Empty>
 export BENCHMARK_QA_LIMIT=<OPTIONAL: Max number of QA pairs to evaluate for prototype runs, default: Empty (all pairs)>
 export BENCHMARK_IS_PROTOTYPE=<OPTIONAL: Use prototype datasets (e.g. cuad-prototype instead of cuad), true or false, default: Empty (false)>
+export BENCHMARK_ALL_RETRIEVERS=<OPTIONAL: When "true", run all retrievers in a single pass (extract+build once, then query+evaluate per retriever). Incompatible with DELETE_ON_PASS=True, default: Empty (false)>
+export BENCHMARK_DATASET=<OPTIONAL: Dataset for all-retrievers mode – one of cuad, concurrentqa, pga, pga_bio, pga_stat, wikihow. Required when BENCHMARK_ALL_RETRIEVERS=true, default: Empty>
 
 export EXISTING_VPC_ID=<OPTIONAL: Existing VPC ID to reuse instead of creating a new VPC, default: Empty>
 export EXISTING_SUBNET_IDS=<OPTIONAL: Comma-delimited existing subnet IDs to reuse (min 2 across 2 AZs, must be provided with EXISTING_VPC_ID), default: Empty>

--- a/integration-tests/test-scripts/run_test_suite.sh
+++ b/integration-tests/test-scripts/run_test_suite.sh
@@ -108,7 +108,12 @@ if [[ "$DO_SETUP" = true ]]; then
     pip list
 fi
 
-python test_suite.py "${REMAINING_ARGS[@]}"
+if [[ "${BENCHMARK_ALL_RETRIEVERS:-}" == "true" ]]; then
+    echo "Running all-retrievers benchmark loop for dataset: ${BENCHMARK_DATASET:-}"
+    bash benchmarks/scripts/run_all_retrievers.sh "$BENCHMARK_DATASET"
+else
+    python test_suite.py "${REMAINING_ARGS[@]}"
+fi
 
 popd
 

--- a/integration-tests/test-scripts/test_suite.py
+++ b/integration-tests/test-scripts/test_suite.py
@@ -264,15 +264,20 @@ def run_test_suite():
         
         if result == 'PASS' and delete_on_pass:
             delete_stack(stack_id, delete_stack_role)
-            
+
+        return result
             
     else:
         print('Exiting tests because of CloudFormation failure')
+        return 'FAIL'
 
 
 if __name__ == '__main__':
     start = time.time()
-    run_test_suite()
+    result = run_test_suite()
     end = time.time()
 
     print(end-start)
+
+    if result == 'FAIL':
+        sys.exit(1)


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
 Add multi-retriever benchmark harness with beam-search retrievers
## Changes

<!-- List the key changes made -->

- Add support for running all retrievers in a single benchmark pass:
- Add topic-beam-chunk_only and topic_beam_search to retriever factory
- Import ChunkCosineSimilaritySearch, SemanticChunkBeamGraphSearch, SemanticGuidedChunkRetriever, TopicBeamSearch
- Tune shared sub-retriever params: max_search_results=10, max_context_tokens=3000, token_truncation_mode=per_topic_cap
- Create run_all_retrievers.sh loop script (extract+build once, query+evaluate per retriever)
- Create benchmark.concurrentqa.all-retrievers dataset file
- Forward BENCHMARK_ALL_RETRIEVERS and BENCHMARK_DATASET env vars through build-tests.sh to .env.testing
- Conditionally invoke run_all_retrievers.sh from run_test_suite.sh

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
