### PR TITLE
[FEATURE] (benchmarks): Add PGA bio/stat split evaluation support

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -394,11 +394,13 @@ After running all retrievers, generate `comparison_report.json` at `benchmark-re
    }
    ```
 
-2. Add QA file mapping in `benchmarks/scripts/benchmark_query.py`:
+2. Add QA file mapping in `benchmarks/utils/dataset_config.py`:
    ```python
    QA_FILE_MAP = {
        ...
-       'my-dataset': ['qa.json'],
+       'my-dataset': {'files': ['qa.json']},
+       # For a split that shares a parent directory:
+       # 'my-dataset_subset': {'files': ['subset.json'], 'parent': 'my-dataset'},
    }
    ```
 

--- a/benchmarks/env.template
+++ b/benchmarks/env.template
@@ -22,6 +22,7 @@ export BENCHMARK_DATA_DIR=<OPTIONAL: Local directory containing benchmark data t
 export BENCHMARK_DATA_S3_URI=<OPTIONAL: S3 URI for benchmark data synced at runtime, e.g. s3://graphrag-toolkit-benchmarking/, default: Empty>
 export BENCHMARK_QA_LIMIT=<OPTIONAL: Max number of QA pairs to evaluate for prototype runs, default: Empty (all pairs)>
 export BENCHMARK_IS_PROTOTYPE=<OPTIONAL: Use prototype datasets (e.g. cuad-prototype instead of cuad), true or false, default: Empty (false)>
+export BENCHMARK_DATASET=<OPTIONAL: Dataset to evaluate. Supports split variants (e.g. pga_bio, pga_stat) that share a parent dataset's data directory, default: Empty>
 
 export EXISTING_VPC_ID=<OPTIONAL: Existing VPC ID to reuse instead of creating a new VPC, default: Empty>
 export EXISTING_SUBNET_IDS=<OPTIONAL: Comma-delimited existing subnet IDs to reuse (min 2 across 2 AZs, must be provided with EXISTING_VPC_ID), default: Empty>

--- a/benchmarks/scripts/benchmark_evaluate.py
+++ b/benchmarks/scripts/benchmark_evaluate.py
@@ -185,17 +185,18 @@ class PgaBenchmarkEvaluate(IntegrationTestBase):
         return 'Evaluate PGA benchmark responses using LLM-as-judge correctness and IDK metrics'
 
     def _run_test(self, handler: IntegrationTestHandler, params: Dict[str, Any]):
+        dataset_name = os.environ.get('BENCHMARK_DATASET', 'pga')
         retriever_id = os.environ.get('BENCHMARK_RETRIEVER', 'traversal')
 
         responses_path = params.get('benchmark_responses_path',
                                     os.path.join('benchmark-results',
-                                                 'pga',
+                                                 dataset_name,
                                                  retriever_id))
 
         run_benchmark_evaluate(
             handler,
             params,
-            dataset='pga',
+            dataset=dataset_name,
             responses_path=responses_path,
             metrics=['correctness', 'idk'],
         )

--- a/benchmarks/scripts/benchmark_query.py
+++ b/benchmarks/scripts/benchmark_query.py
@@ -11,6 +11,7 @@ import logging
 from benchmarks.scripts.integration_test_base import IntegrationTestBase
 from benchmarks.scripts.integration_test_handler import IntegrationTestHandler
 from benchmarks.utils.s3_utils import sync_benchmark_data_from_s3
+from benchmarks.utils.dataset_config import QA_FILE_MAP, get_data_subdir
 from benchmarks.utils.retriever_factory import create_query_engine, get_retriever_config, ByoKGQueryEngineWrapper
 from benchmarks.utils.token_tracker import TokenTrackingLLMCache, extract_token_usage
 from benchmarks.utils.metrics_summary import compute_metrics_summary
@@ -25,22 +26,14 @@ from llama_index.core.schema import QueryBundle
 
 logger = logging.getLogger(__name__)
 
-QA_FILE_MAP = {
-    'cuad': ['qa.json'],
-    'cuad-prototype': ['qa.json'],
-    'pga': ['pga_bio.json', 'pga_stat.json'],
-    'concurrentqa': ['qa.json'],
-    'concurrentqa-prototype': ['qa.json'],
-    'wikihow': ['qa.json'],
-}
-
 BENCHMARK_DATA_DIR = 'source-data'
 
 
 def load_qa_pairs(data_dir: str, dataset: str, qa_files: List[str], limit: Optional[int] = None):
     pairs = []
+    data_subdir = get_data_subdir(dataset)
     for f in qa_files:
-        path = os.path.join(data_dir, dataset, f)
+        path = os.path.join(data_dir, data_subdir, f)
         with open(path) as fh:
             pairs.extend(json.load(fh))
     if limit:
@@ -93,7 +86,7 @@ def run_benchmark_query(handler: IntegrationTestHandler,
     """
     sync_benchmark_data_from_s3(dataset, data_dir)
 
-    qa_files = QA_FILE_MAP.get(dataset, ['qa.json'])
+    qa_files = QA_FILE_MAP.get(dataset, {}).get('files', ['qa.json'])
     qa_pairs = load_qa_pairs(data_dir, dataset, qa_files, qa_limit)
 
     GraphRAGConfig.response_llm = response_llm
@@ -383,6 +376,7 @@ class PgaBenchmarkQuery(IntegrationTestBase):
 
     def _run_test(self, handler: IntegrationTestHandler, params: Dict[str, Any]):
         limit_str = os.environ.get('BENCHMARK_QA_LIMIT')
+        dataset_name = os.environ.get('BENCHMARK_DATASET', 'pga')
         retriever_id = os.environ.get('BENCHMARK_RETRIEVER', 'traversal')
         agentic_max_iterations = int(os.environ.get('AGENTIC_MAX_ITERATIONS', '3'))
         byokg_max_iterations = int(os.environ.get('BYOKG_MAX_ITERATIONS', '2'))
@@ -390,7 +384,7 @@ class PgaBenchmarkQuery(IntegrationTestBase):
         run_benchmark_query(
             handler,
             params,
-            dataset='pga',
+            dataset=dataset_name,
             data_dir=BENCHMARK_DATA_DIR,
             graph_store_conn=os.environ.get('GRAPH_STORE'),
             vector_store_conn=os.environ.get('VECTOR_STORE'),

--- a/benchmarks/tests/test_dataset_config.py
+++ b/benchmarks/tests/test_dataset_config.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from benchmarks.utils.dataset_config import QA_FILE_MAP, get_data_subdir
+
+
+class TestGetDataSubdir:
+    """Tests for get_data_subdir parent resolution logic."""
+
+    def test_pga_bio_resolves_to_pga(self):
+        assert get_data_subdir('pga_bio') == 'pga'
+
+    def test_pga_stat_resolves_to_pga(self):
+        assert get_data_subdir('pga_stat') == 'pga'
+
+    def test_pga_parent_resolves_to_itself(self):
+        assert get_data_subdir('pga') == 'pga'
+
+    def test_cuad_resolves_to_itself(self):
+        assert get_data_subdir('cuad') == 'cuad'
+
+    def test_concurrentqa_resolves_to_itself(self):
+        assert get_data_subdir('concurrentqa') == 'concurrentqa'
+
+    def test_wikihow_resolves_to_itself(self):
+        assert get_data_subdir('wikihow') == 'wikihow'
+
+    def test_unknown_dataset_falls_back_to_itself(self):
+        assert get_data_subdir('nonexistent') == 'nonexistent'
+
+    def test_empty_string_falls_back_to_itself(self):
+        assert get_data_subdir('') == ''
+
+
+class TestQAFileMap:
+    """Tests for QA_FILE_MAP structure integrity."""
+
+    def test_all_entries_have_files_key(self):
+        for key, entry in QA_FILE_MAP.items():
+            assert 'files' in entry, f"Entry '{key}' is missing 'files' key"
+            assert isinstance(entry['files'], list), f"Entry '{key}' files is not a list"
+            assert len(entry['files']) > 0, f"Entry '{key}' has empty files list"
+
+    def test_parent_entries_reference_valid_parent(self):
+        for key, entry in QA_FILE_MAP.items():
+            if 'parent' in entry:
+                parent = entry['parent']
+                assert parent in QA_FILE_MAP, (
+                    f"Entry '{key}' references parent '{parent}' which is not in QA_FILE_MAP"
+                )
+                assert 'parent' not in QA_FILE_MAP[parent], (
+                    f"Parent '{parent}' of '{key}' is itself a child — no chained parents"
+                )

--- a/benchmarks/utils/dataset_config.py
+++ b/benchmarks/utils/dataset_config.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared dataset configuration for benchmark scripts.
+
+QA_FILE_MAP defines, for each dataset key:
+  - files: list of QA JSON filenames to load
+  - parent (optional): the parent dataset whose directory is shared on disk/S3
+
+Splits like 'pga_bio' declare a 'parent' so that S3 sync and file loading
+resolve to the correct shared subdirectory.
+"""
+
+from typing import Dict, Any
+
+QA_FILE_MAP: Dict[str, Dict[str, Any]] = {
+    'cuad': {'files': ['qa.json']},
+    'cuad-prototype': {'files': ['qa.json']},
+    'pga': {'files': ['pga_bio.json', 'pga_stat.json']},
+    'pga_bio': {'files': ['pga_bio.json'], 'parent': 'pga'},
+    'pga_stat': {'files': ['pga_stat.json'], 'parent': 'pga'},
+    'concurrentqa': {'files': ['qa.json']},
+    'concurrentqa-prototype': {'files': ['qa.json']},
+    'wikihow': {'files': ['qa.json']},
+}
+
+
+def get_data_subdir(dataset: str) -> str:
+    """Resolve the filesystem subdirectory for a dataset.
+
+    Splits (e.g. 'pga_bio') declare a 'parent' in QA_FILE_MAP and share
+    their parent's data directory on disk and in S3.
+    """
+    entry = QA_FILE_MAP.get(dataset, {})
+    return entry.get('parent', dataset)

--- a/benchmarks/utils/s3_utils.py
+++ b/benchmarks/utils/s3_utils.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import logging
 
+from benchmarks.utils.dataset_config import get_data_subdir
+
 logger = logging.getLogger(__name__)
 
 
@@ -11,17 +13,22 @@ def sync_benchmark_data_from_s3(dataset: str, data_dir: str):
     """
     If BENCHMARK_DATA_S3_URI is set and the local dataset directory doesn't exist,
     sync the dataset from S3.
+
+    PGA splits (pga_bio, pga_stat) share a single 'pga' directory in S3 and locally,
+    so the mapping is applied here to stay consistent with load_qa_pairs().
     """
     s3_uri = os.environ.get('BENCHMARK_DATA_S3_URI')
     if not s3_uri:
         return
 
-    local_dataset_dir = os.path.join(data_dir, dataset)
+    sync_dataset = get_data_subdir(dataset)
+
+    local_dataset_dir = os.path.join(data_dir, sync_dataset)
     if os.path.exists(local_dataset_dir):
         logger.info(f'Dataset directory already exists: {local_dataset_dir}')
         return
 
-    s3_dataset_uri = s3_uri.rstrip('/') + '/' + dataset + '/'
+    s3_dataset_uri = s3_uri.rstrip('/') + '/' + sync_dataset + '/'
     logger.info(f'Syncing benchmark data from {s3_dataset_uri} to {local_dataset_dir}')
     os.makedirs(local_dataset_dir, exist_ok=True)
     try:

--- a/integration-tests/env.template
+++ b/integration-tests/env.template
@@ -22,6 +22,7 @@ export BENCHMARK_DATA_DIR=<OPTIONAL: Local directory containing benchmark data t
 export BENCHMARK_DATA_S3_URI=<OPTIONAL: S3 URI for benchmark data synced at runtime, e.g. s3://graphrag-toolkit-benchmarking/, default: Empty>
 export BENCHMARK_QA_LIMIT=<OPTIONAL: Max number of QA pairs to evaluate for prototype runs, default: Empty (all pairs)>
 export BENCHMARK_IS_PROTOTYPE=<OPTIONAL: Use prototype datasets (e.g. cuad-prototype instead of cuad), true or false, default: Empty (false)>
+export BENCHMARK_DATASET=<OPTIONAL: Dataset to evaluate. Supports split variants (e.g. pga_bio, pga_stat) that share a parent dataset's data directory, default: Empty>
 
 export EXISTING_VPC_ID=<OPTIONAL: Existing VPC ID to reuse instead of creating a new VPC, default: Empty>
 export EXISTING_SUBNET_IDS=<OPTIONAL: Comma-delimited existing subnet IDs to reuse (min 2 across 2 AZs, must be provided with EXISTING_VPC_ID), default: Empty>


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Allow running benchmarks against just the PGA bio or PGA stat subset by setting BENCHMARK_DATASET=pga_bio or BENCHMARK_DATASET=pga_stat.

## Changes

<!-- List the key changes made -->

- Add 'pga_bio' and 'pga_stat' entries to QA_FILE_MAP
- Resolve data subdirectory to 'pga' for all pga* datasets in load_qa_pairs() and sync_benchmark_data_from_s3()
- Read dataset_name from BENCHMARK_DATASET env var in PgaBenchmarkQuery

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
