### PR TITLE
[FIX] Stop FMObservabilityPublisher leaking its poller thread

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/utils/fm_observability.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/utils/fm_observability.py
@@ -525,6 +525,7 @@ class FMObservabilityPublisher():
         self.subscribers = subscribers
         self.interval_seconds = interval_seconds
         self.allow_continue = True
+        self._lock = threading.Lock()
         self.poller = FMObservabilityQueuePoller()
         self.poller.start()
 
@@ -534,17 +535,23 @@ class FMObservabilityPublisher():
 
     def close(self):
         """
-        Disables the continuation functionality by updating the internal flag.
+        Stops publishing and shuts down the poller thread.
 
-        This method prevents further continuation of a process by setting the
-        `allow_continue` attribute to `False`. Once invoked, the attribute will
-        indicate that continuation should not occur.
+        Sets `allow_continue` to `False` so that no further poller is scheduled,
+        stops the current poller, and publishes its final stats to the subscribers.
+        Calling this more than once has no additional effect.
 
         Attributes:
             allow_continue (bool): Indicates whether continuation is permitted or not.
                 Set to `False` to disable continuation.
         """
-        self.allow_continue = False
+        with self._lock:
+            if not self.allow_continue:
+                return
+            self.allow_continue = False
+            stats = self.poller.stop()
+        for subscriber in self.subscribers:
+            subscriber.on_new_stats(stats)
 
     def __enter__(self):
         """
@@ -578,16 +585,17 @@ class FMObservabilityPublisher():
         Returns:
             None
         """
-        stats = self.poller.stop()
-        self.poller = FMObservabilityQueuePoller()
-        self.poller.start()
-        if self.allow_continue:
+        with self._lock:
+            if not self.allow_continue:
+                logging.debug('Publisher is closed; not starting a new poller')
+                return
+            stats = self.poller.stop()
+            self.poller = FMObservabilityQueuePoller()
+            self.poller.start()
             logging.debug('Scheduling new poller')
             t = threading.Timer(self.interval_seconds, self.publish_stats)
             t.daemon = True
             t.start()
-        else:
-            logging.debug('Shutting down publisher')
         for subscriber in self.subscribers:
             subscriber.on_new_stats(stats)
 

--- a/lexical-graph/tests/unit/utils/test_fm_observability.py
+++ b/lexical-graph/tests/unit/utils/test_fm_observability.py
@@ -445,6 +445,9 @@ class TestObservabilityIntegration:
     def test_publisher_initialization_sets_up_handlers(self, mock_settings, mock_queue_class):
         """Verify FMObservabilityPublisher sets up handlers on initialization."""
         mock_queue_instance = Mock()
+        # Poll rather than spin: a bare Mock returns a truthy child immediately,
+        # turning the poller's one-second get() into a busy loop.
+        mock_queue_instance.get.side_effect = queue.Empty
         mock_queue_class.return_value = mock_queue_instance
         mock_callback_manager = Mock()
         mock_settings.callback_manager = mock_callback_manager
@@ -466,6 +469,9 @@ class TestObservabilityIntegration:
     def test_publisher_context_manager(self, mock_settings, mock_queue_class):
         """Verify FMObservabilityPublisher works as context manager."""
         mock_queue_instance = Mock()
+        # Poll rather than spin: a bare Mock returns a truthy child immediately,
+        # turning the poller's one-second get() into a busy loop.
+        mock_queue_instance.get.side_effect = queue.Empty
         mock_queue_class.return_value = mock_queue_instance
         mock_callback_manager = Mock()
         mock_settings.callback_manager = mock_callback_manager
@@ -478,7 +484,63 @@ class TestObservabilityIntegration:
         # After exiting context, should be closed
         assert publisher.allow_continue is False
 
-    
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Queue')
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_close_stops_poller_thread(self, mock_settings, mock_queue_class):
+        """Verify close() stops the poller instead of leaving it running."""
+        mock_queue_instance = Mock()
+        mock_queue_instance.get.side_effect = queue.Empty
+        mock_queue_class.return_value = mock_queue_instance
+        mock_settings.callback_manager = Mock()
+
+        publisher = FMObservabilityPublisher(subscribers=[], interval_seconds=30.0)
+        poller = publisher.poller
+        assert poller.is_alive()
+
+        publisher.close()
+
+        poller.join(timeout=5)
+        assert poller._discontinue.is_set()
+        assert not poller.is_alive()
+
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Queue')
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_no_replacement_poller_after_close(self, mock_settings, mock_queue_class):
+        """Verify a timer firing after close() does not start a new poller."""
+        mock_queue_instance = Mock()
+        mock_queue_instance.get.side_effect = queue.Empty
+        mock_queue_class.return_value = mock_queue_instance
+        mock_settings.callback_manager = Mock()
+
+        publisher = FMObservabilityPublisher(subscribers=[], interval_seconds=0.2)
+        poller = publisher.poller
+        publisher.close()
+
+        # Let the timer scheduled in __init__ fire.
+        time.sleep(0.6)
+
+        assert publisher.poller is poller
+        assert not poller.is_alive()
+
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Queue')
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_close_publishes_final_stats_once(self, mock_settings, mock_queue_class):
+        """Verify close() publishes final stats to subscribers exactly once."""
+        mock_queue_instance = Mock()
+        mock_queue_instance.get.side_effect = queue.Empty
+        mock_queue_class.return_value = mock_queue_instance
+        mock_settings.callback_manager = Mock()
+
+        subscriber = Mock(spec=FMObservabilitySubscriber)
+        publisher = FMObservabilityPublisher(subscribers=[subscriber], interval_seconds=30.0)
+
+        publisher.close()
+        publisher.close()
+
+        assert subscriber.on_new_stats.call_count == 1
+        assert isinstance(subscriber.on_new_stats.call_args[0][0], FMObservabilityStats)
+
+
     @patch('graphrag_toolkit.lexical_graph.utils.fm_observability._fm_observability_queue')
     def test_handler_event_end_puts_event_in_queue(self, mock_queue):
         """Verify FMObservabilityHandler puts completed events in queue."""


### PR DESCRIPTION
## Description

`FMObservabilityPublisher.close()` does not stop its poller thread, so every publisher leaves one running. Under the unit tests that leaked poller busy-loops on a mocked queue and retains every call it makes.

## Changes

- `close()` stops the poller, publishes its final stats, and is idempotent
- `publish_stats()` returns early when the publisher is closed, instead of starting a replacement poller first
- a lock guards both paths, since the Timer thread and the caller of `close()` can race
- the mocked queue in `test_fm_observability.py` raises `queue.Empty`, so the poller polls instead of spinning
- three regression tests: the poller stops on close, no replacement poller appears after the timer fires, final stats publish once

## Problem

`close()` sets `allow_continue = False` and returns. The `threading.Timer` scheduled in `__init__` then fires `publish_stats()`, which stops the current poller and starts a replacement before it checks `allow_continue`. Every publisher leaves a live `FMObservabilityQueuePoller` behind, and calling `close()` does not change that.

With a real queue the leaked thread is idle, because `Queue.get(timeout=1)` blocks for a second per iteration. Under the unit tests it is not idle. The tests patch `fm_observability.Queue` with a plain `Mock`, and `Mock.get()` returns a truthy child immediately rather than raising, so the poll becomes a busy loop. The Mock retains every iteration in `mock_calls`, and nothing trims it.

Related issue (if any): Fixes #450

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Ran the repro from the issue against both sides. On `main` the poller is alive after `close()` and `_discontinue` is unset; on this branch the poller is stopped and `_discontinue` is set.

Full unit suite on this branch: 1871 passed, peak RSS 443 MB, 43 s. The issue measured 10.3 GB peak for the same suite before the fix. One unrelated error remains locally, `test_boto3_botocore_version_alignment`, which shells out to pip and fails in a uv-created venv.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)
