### PR TITLE
[FEATURE] (lexical-graph): Auto-tuning batch extraction

### DIFF
--- a/docs-site/src/content/docs/lexical-graph/configuring-batch-extraction.mdx
+++ b/docs-site/src/content/docs/lexical-graph/configuring-batch-extraction.mdx
@@ -20,7 +20,10 @@ title: Configuring Batch Extraction
       - [security_group_ids](#security_group_ids)
     - [File management](#file-management)
       - [delete_on_success](#delete_on_success)
+    - [Auto-tuning](#auto-tuning)
+      - [auto_tune](#auto_tune)
   - [Optimizing batch extraction performance](#optimizing-batch-extraction-performance)
+  - [Auto-tuning batch extraction](#auto-tuning-batch-extraction)
 
 ### Overview
 
@@ -78,11 +81,17 @@ An array of security group IDs within your VPC for protecting batch inference jo
 
 Controls whether input and output JSON files are automatically deleted from the local filesystem after successful batch job completion. By default, this is set to `True`. Note that this setting does not affect files stored in S3, which are preserved regardless.
 
+#### Auto-tuning
+
+##### `auto_tune`
+
+When set to `True`, enables [auto-tuning batch extraction](#auto-tuning-batch-extraction). Instead of pulling a fixed number of source documents per iteration, the framework streams and chunks documents incrementally, filling `GraphRAGConfig.extraction_num_workers` buckets up to `max_batch_size` chunks each before submitting a round of batch jobs. For small inputs it consolidates chunks into the fewest jobs needed. With auto-tuning enabled you only need to specify `extraction_num_workers` and `max_batch_size`; `extraction_batch_size` becomes a derived value (if you set it explicitly, it acts as an optional upper bound on the number of documents consumed per round). The default is `False`.
+
 ### Optimizing batch extraction performance
 
 The most important settings for controlling batch extraction performance are:
 
-  - `GraphRAGConfig.extraction_batch_size`: Sets how many source documents go to the extraction pipeline. When calculating this value, consider that the total number of chunks (source documents × average chunks per document) should be sufficient to fill your planned simultaneous batch jobs.
+  - `GraphRAGConfig.extraction_batch_size`: Sets how many source documents go to the extraction pipeline. When calculating this value, consider that the total number of chunks (source documents × average chunks per document) should be sufficient to fill your planned simultaneous batch jobs. If you enable [auto-tuning](#auto-tuning-batch-extraction), you no longer need to calculate this value — the framework derives it for you.
   - `GraphRAGConfig.extraction_num_workers`: Sets how many CPUs run batch jobs simultaneously.
   - `BatchConfig.max_num_concurrent_batches`: Sets how many concurrent batch jobs each worker runs.
   - `BatchConfig.max_batch_size`: Sets the maximum number of chunks per batch job.
@@ -94,3 +103,33 @@ To maximize the efficiency of batch extraction, follow these three key principle
   - **Leverage parallel processing** Take advantage of parallel job execution using `GraphRAGConfig.extraction_num_workers` and `BatchConfig.max_num_concurrent_batches`. The total number of jobs (number of workers × number of concurrent batches) must stay within Bedrock's quota of 20 combined in-progress and submitted batch inference jobs per region. If you exceed this limit, additional jobs will wait in the queue until capacity becomes available.
 
 Each batch inference job submitted to Amazon Bedrock must contain at least 100 records. If a batch job contains fewer than 100 records, batch extraction falls back to performing chunk-by-chunk extraction. (Batch extraction will also fall back to performing chunk-by-chunk extraction if there are a last few records left over after processing one or more batches containing `max_batch_size` records.) The batch extraction process issues a warning whenever it begins processing a set of records chunk-by-chunk.
+
+### Auto-tuning batch extraction
+
+The performance guidance above requires you to reason about the relationship between `extraction_batch_size` (source documents pulled per iteration), the average number of chunks per document, `extraction_num_workers`, and `max_batch_size` in order to keep batch jobs well-utilized. Getting this wrong produces either many small, under-utilized jobs (slow, because of per-job overhead and the sub-100-record fallback) or jobs that need to be re-split.
+
+Auto-tuning removes this manual calculation. Set `auto_tune=True` on your `BatchConfig`:
+
+```python
+batch_config = BatchConfig(
+    role_arn=batch_inference_role,
+    region=aws_region_name,
+    bucket_name=s3_results_bucket,
+    max_batch_size=25000,
+    max_num_concurrent_batches=3,
+    auto_tune=True,
+)
+```
+
+With auto-tuning enabled, the framework:
+
+  - **Streams and chunks documents incrementally** rather than materializing a fixed `extraction_batch_size` of documents up front.
+  - **Accumulates chunks in document order and packs them contiguously into jobs of `max_batch_size`** — the same count-based packing the fixed-`batch_size` path already uses — so every job except the last of a round is filled to `max_batch_size`.
+  - **Submits a round of up to `extraction_num_workers` jobs** once the accumulated chunks reach `extraction_num_workers × max_batch_size` (or before a document would overshoot that capacity), then resumes pulling documents for the next round.
+  - **Consolidates on exhaustion**: the remaining chunks are sliced into the minimum number of jobs (`ceil(remaining / max_batch_size)`, at most `extraction_num_workers`). If the final remainder is below the 100-record Bedrock minimum, it is merged into the previous round's last job (which may then slightly exceed `max_batch_size`, by at most 99 records, exactly as the fixed-`batch_size` path does) so it is still batched — unless that merge would push the job past Bedrock's hard per-job record limit, in which case the tail is left as its own round. Only a corpus small enough that it never fills a single round falls back to chunk-by-chunk extraction.
+
+Under auto-tuning you only need to specify `extraction_num_workers` and `max_batch_size`. `extraction_batch_size` becomes a derived value; if you set it explicitly it is treated as an optional upper bound on the number of documents consumed per round (useful for bounding memory). The extracted output is equivalent to the fixed-`batch_size` path for the same input — auto-tuning changes how jobs are sized and submitted, not the extraction results.
+
+**Concurrency under auto-tuning.** Auto-tuning submits up to `extraction_num_workers` batch jobs per round (each up to `max_batch_size` records) and treats `extraction_num_workers` as the unit of job concurrency. `BatchConfig.max_num_concurrent_batches` — which governs per-worker job concurrency in the fixed-`batch_size` path — is **not used** when auto-tuning is enabled. Size `extraction_num_workers` with Bedrock's per-region quota on in-progress and submitted batch jobs in mind.
+
+**Document integrity and large documents.** A document's chunks may be split across job boundaries (and, for very large documents, across rounds), exactly as in the fixed-`batch_size` path. Output integrity is preserved by `source_id`-keyed storage, which reassembles each document from its chunks regardless of how they were batched — so splitting does not fragment results. The framework still flushes a round before a document would overshoot capacity, keeping a document within one round when it fits. If a single document produces more chunks than a full round's capacity (`extraction_num_workers × max_batch_size`), it is split across rounds and the framework logs a warning; increase `max_batch_size` or `extraction_num_workers` to keep such documents within a single round.

--- a/docs-site/src/content/docs/lexical-graph/configuring-batch-extraction.mdx
+++ b/docs-site/src/content/docs/lexical-graph/configuring-batch-extraction.mdx
@@ -87,11 +87,13 @@ Controls whether input and output JSON files are automatically deleted from the 
 
 When set to `True`, enables [auto-tuning batch extraction](#auto-tuning-batch-extraction). Instead of pulling a fixed number of source documents per iteration, the framework streams and chunks documents incrementally, filling `GraphRAGConfig.extraction_num_workers` buckets up to `max_batch_size` chunks each before submitting a round of batch jobs. For small inputs it consolidates chunks into the fewest jobs needed. With auto-tuning enabled you only need to specify `extraction_num_workers` and `max_batch_size`; `extraction_batch_size` becomes a derived value (if you set it explicitly, it acts as an optional upper bound on the number of documents consumed per round). The default is `False`.
 
+Coordination with parallelization: under auto-tuning, `extraction_num_workers` sets how many batch jobs a round submits concurrently. `max_num_concurrent_batches` (the per-worker job concurrency of the fixed-batch path) does not apply, because each round job is a single batch. Document chunking runs in the main process so chunk counts are known before a round is packed; only extraction runs concurrently. Keep `extraction_num_workers` within Bedrock's quota of 20 combined in-progress and submitted batch jobs per region.
+
 ### Optimizing batch extraction performance
 
 The most important settings for controlling batch extraction performance are:
 
-  - `GraphRAGConfig.extraction_batch_size`: Sets how many source documents go to the extraction pipeline. When calculating this value, consider that the total number of chunks (source documents × average chunks per document) should be sufficient to fill your planned simultaneous batch jobs. If you enable [auto-tuning](#auto-tuning-batch-extraction), you no longer need to calculate this value — the framework derives it for you.
+  - `GraphRAGConfig.extraction_batch_size`: Sets how many source documents go to the extraction pipeline. When calculating this value, consider that the total number of chunks (source documents × average chunks per document) should be sufficient to fill your planned simultaneous batch jobs. If you enable [auto-tuning](#auto-tuning-batch-extraction), this value is determined dynamically and you no longer need to calculate it; setting it explicitly only caps the number of documents consumed per round.
   - `GraphRAGConfig.extraction_num_workers`: Sets how many CPUs run batch jobs simultaneously.
   - `BatchConfig.max_num_concurrent_batches`: Sets how many concurrent batch jobs each worker runs.
   - `BatchConfig.max_batch_size`: Sets the maximum number of chunks per batch job.

--- a/integration-tests/lexical.long
+++ b/integration-tests/lexical.long
@@ -1,4 +1,5 @@
 batch_extract.BatchExtractToS3
+batch_extract.BatchExtractAutoTuneToS3
 batch_build.BuildFromS3
 query.MultiHopQuery
 query.ChunkBasedSemanticSearchMultiHopQuery

--- a/integration-tests/test-scripts/graphrag_toolkit_tests/batch_extract.py
+++ b/integration-tests/test-scripts/graphrag_toolkit_tests/batch_extract.py
@@ -116,8 +116,194 @@ class BatchExtractToS3(IntegrationTestBase):
                     
             handler.run_assertions(BatchExtractAssertions)
         
+class BatchExtractAutoTuneToS3(IntegrationTestBase):
+
+    @property
+    def description(self):
+        return 'Extract propositions and topics using auto-tuning Bedrock batch inference (num_workers + max_batch_size only), and save to S3'
+
+    def _run_test(self, handler:IntegrationTestHandler, params:Dict[str, Any]):
+
+        GraphRAGConfig.extraction_llm = os.environ.get('TEST_EXTRACTION_LLM', 'anthropic.claude-sonnet-4-6')
+        # Under auto-tuning, batch_size is a derived value; the user only needs
+        # to specify num_workers (here) and max_batch_size (on BatchConfig).
+        GraphRAGConfig.extraction_num_workers = 2
+
+        s3_results_bucket = os.environ['S3_RESULTS_BUCKET']
+        s3_results_prefix = os.environ['S3_RESULTS_PREFIX']
+        aws_region_name = os.environ['AWS_REGION_NAME']
+        batch_inference_role = os.environ['BATCH_INFERENCE_ROLE']
+        batch_inference_prefix = f'{s3_results_prefix}/batch-inference-auto-tune'
+        extracted_prefix = f'{s3_results_prefix}/extracted-auto-tune'
+
+        extracted_docs = S3BasedDocs(
+            region=aws_region_name,
+            bucket_name=s3_results_bucket,
+            key_prefix=extracted_prefix
+        )
+
+        infer_config = InferClassificationsConfig(
+            num_samples=5,
+            num_iterations=10
+        )
+
+        # Under auto-tuning the user specifies only num_workers (above) and
+        # max_batch_size; batch_size is derived. max_num_concurrent_batches is
+        # not used in auto-tuning mode (num_workers is the unit of concurrency).
+        batch_config = BatchConfig(
+            region=aws_region_name,
+            bucket_name=s3_results_bucket,
+            key_prefix=batch_inference_prefix,
+            role_arn=batch_inference_role,
+            max_batch_size=250,
+            auto_tune=True
+        )
+
+        indexing_config = IndexingConfig(
+            extraction=ExtractionConfig(
+                infer_entity_classifications=infer_config,
+            ),
+            build=BuildConfig(
+                include_local_entities=True
+            ),
+            batch_config=batch_config
+        )
+
+        with(
+            GraphStoreFactory.for_graph_store(
+                os.environ['GRAPH_STORE'],
+                log_formatting=NonRedactedGraphQueryLogFormatting()
+            ) as graph_store,
+            VectorStoreFactory.for_vector_store(os.environ['VECTOR_STORE']) as vector_store
+        ):
+
+            reader = JSONArrayReader(text_fn=get_text, metadata_fn=get_metadata)
+            docs = reader.load_data('./source-data/corpus-modified.json')
+
+            graph_index = LexicalGraphIndex(
+                graph_store,
+                vector_store,
+                indexing_config=indexing_config
+            )
+
+            graph_index.extract(docs, handler=extracted_docs, show_progress=True)
+
+            collection_id = extracted_docs.collection_id
+
+            params['auto_tune_batch_collection_id'] = collection_id
+
+            class BatchExtractAutoTuneAssertions(unittest.TestCase):
+
+                @classmethod
+                def setUpClass(cls):
+                    cls._num_extracted_docs = len([d for d in extracted_docs])
+                    cls._expected_num_docs = len(docs)
+
+                def test_extracted_one_doc_for_each_url(self):
+                    """Auto-tuned extraction produces one source doc per source URL,
+                    equivalent to the fixed-batch_size run over the same corpus."""
+
+                    self.assertEqual(self._num_extracted_docs, self._expected_num_docs)
+
+            handler.run_assertions(BatchExtractAutoTuneAssertions)
+
+class BatchExtractSmallBatchToS3(IntegrationTestBase):
+    """Fixed-batch_size baseline with a deliberately small (mis-chosen) batch_size,
+    to demonstrate the under-filled jobs that auto-tuning avoids. Compare this
+    run's batch-inference-small-batch/ job count and fill against the auto-tune
+    run's batch-inference-auto-tune/ over the same corpus."""
+
+    @property
+    def description(self):
+        return 'Extract propositions and topics with a deliberately small fixed batch_size (baseline for the auto-tuning comparison), and save to S3'
+
+    def _run_test(self, handler:IntegrationTestHandler, params:Dict[str, Any]):
+
+        GraphRAGConfig.extraction_llm = os.environ.get('TEST_EXTRACTION_LLM', 'anthropic.claude-sonnet-4-6')
+        # A small batch_size under-fills batch jobs: 10 docs per outer batch,
+        # split across 2 workers, is far below num_workers x max_batch_size.
+        GraphRAGConfig.extraction_batch_size = 10
+        GraphRAGConfig.extraction_num_workers = 2
+
+        s3_results_bucket = os.environ['S3_RESULTS_BUCKET']
+        s3_results_prefix = os.environ['S3_RESULTS_PREFIX']
+        aws_region_name = os.environ['AWS_REGION_NAME']
+        batch_inference_role = os.environ['BATCH_INFERENCE_ROLE']
+        batch_inference_prefix = f'{s3_results_prefix}/batch-inference-small-batch'
+        extracted_prefix = f'{s3_results_prefix}/extracted-small-batch'
+
+        extracted_docs = S3BasedDocs(
+            region=aws_region_name,
+            bucket_name=s3_results_bucket,
+            key_prefix=extracted_prefix
+        )
+
+        infer_config = InferClassificationsConfig(
+            num_samples=5,
+            num_iterations=10
+        )
+
+        # Same max_batch_size and num_workers as the auto-tune run (auto_tune off),
+        # so the only difference is the small fixed batch_size.
+        batch_config = BatchConfig(
+            region=aws_region_name,
+            bucket_name=s3_results_bucket,
+            key_prefix=batch_inference_prefix,
+            role_arn=batch_inference_role,
+            max_batch_size=250,
+            max_num_concurrent_batches=2
+        )
+
+        indexing_config = IndexingConfig(
+            extraction=ExtractionConfig(
+                infer_entity_classifications=infer_config,
+            ),
+            build=BuildConfig(
+                include_local_entities=True
+            ),
+            batch_config=batch_config
+        )
+
+        with(
+            GraphStoreFactory.for_graph_store(
+                os.environ['GRAPH_STORE'],
+                log_formatting=NonRedactedGraphQueryLogFormatting()
+            ) as graph_store,
+            VectorStoreFactory.for_vector_store(os.environ['VECTOR_STORE']) as vector_store
+        ):
+
+            reader = JSONArrayReader(text_fn=get_text, metadata_fn=get_metadata)
+            docs = reader.load_data('./source-data/corpus-modified.json')
+
+            graph_index = LexicalGraphIndex(
+                graph_store,
+                vector_store,
+                indexing_config=indexing_config
+            )
+
+            graph_index.extract(docs, handler=extracted_docs, show_progress=True)
+
+            collection_id = extracted_docs.collection_id
+
+            params['small_batch_collection_id'] = collection_id
+
+            class BatchExtractSmallBatchAssertions(unittest.TestCase):
+
+                @classmethod
+                def setUpClass(cls):
+                    cls._num_extracted_docs = len([d for d in extracted_docs])
+                    cls._expected_num_docs = len(docs)
+
+                def test_extracted_one_doc_for_each_url(self):
+                    """Small-batch_size extraction still produces one source doc per URL;
+                    the difference vs auto-tuning is job count/fill, not correctness."""
+
+                    self.assertEqual(self._num_extracted_docs, self._expected_num_docs)
+
+            handler.run_assertions(BatchExtractSmallBatchAssertions)
+
 class BatchExtractFromS3ToS3(IntegrationTestBase):
-    
+
     @property
     def description(self):
         return 'Extract propositions and topics from documents in S3 using Bedrock batch inference, and save to S3'

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_config.py
@@ -29,6 +29,13 @@ class BatchConfig:
         max_batch_size (int): Maximum size of a single batch. Default is 25000.
         max_num_concurrent_batches (int): Maximum number of concurrent batches
             allowed. Default is 3.
+        auto_tune (bool): When True, enables auto-tuning batch extraction. The
+            framework streams and chunks documents incrementally, filling
+            num_workers buckets up to max_batch_size chunks each before
+            submitting a round of batch jobs (consolidating into fewer jobs for
+            small inputs). Under auto-tuning the user only needs to specify
+            num_workers and max_batch_size; batch_size becomes a derived value.
+            Default is False (fixed batch_size behavior).
     """
     role_arn:str
     region:str
@@ -40,3 +47,23 @@ class BatchConfig:
     max_batch_size:int=25000
     max_num_concurrent_batches:int=3
     delete_on_success:bool=True
+    auto_tune:bool=False
+
+    def __post_init__(self):
+        # Imported lazily to avoid a circular import: batch_inference_utils
+        # imports BatchConfig.
+        from graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils import (
+            BEDROCK_MIN_BATCH_SIZE,
+            BEDROCK_MAX_BATCH_SIZE,
+        )
+
+        if self.max_batch_size < BEDROCK_MIN_BATCH_SIZE:
+            raise ValueError(
+                f'max_batch_size ({self.max_batch_size}) is smaller than the '
+                f'minimum required by Bedrock ({BEDROCK_MIN_BATCH_SIZE})'
+            )
+        if self.max_batch_size > BEDROCK_MAX_BATCH_SIZE:
+            raise ValueError(
+                f'max_batch_size ({self.max_batch_size}) is larger than the '
+                f'maximum allowed by Bedrock ({BEDROCK_MAX_BATCH_SIZE})'
+            )

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/bucket_filler.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/bucket_filler.py
@@ -12,7 +12,9 @@ class BucketFiller:
     Collects document chunks in arrival order and slices them into Bedrock batch
     jobs of up to ``max_batch_size`` chunks, mirroring the fixed-``batch_size``
     path's ``node_batcher``/``split_nodes`` packing: jobs are filled to
-    ``max_batch_size`` and only the last job in a round holds the remainder.
+    ``max_batch_size``. As ``split_nodes`` does, a trailing job below
+    ``min_batch_size`` is folded into the previous job rather than emitted as an
+    under-minimum job that falls back to synchronous extraction.
 
     It deliberately does NOT balance occupancy across jobs or keep a document's
     chunks within a single job: balancing under-fills jobs, and per-document
@@ -22,14 +24,17 @@ class BucketFiller:
     Driven by ``ExtractionPipeline._extract_auto_tuned``.
     """
 
-    def __init__(self, num_workers: int, max_batch_size: int):
+    def __init__(self, num_workers: int, max_batch_size: int, min_batch_size: int = 1):
         if num_workers < 1:
             raise ValueError(f'num_workers must be >= 1 (got {num_workers})')
         if max_batch_size < 1:
             raise ValueError(f'max_batch_size must be >= 1 (got {max_batch_size})')
+        if min_batch_size < 1:
+            raise ValueError(f'min_batch_size must be >= 1 (got {min_batch_size})')
 
         self.num_workers = num_workers
         self.max_batch_size = max_batch_size
+        self.min_batch_size = min_batch_size
         self.round_capacity = num_workers * max_batch_size
         self._buffer: List[BaseNode] = []
 
@@ -57,13 +62,12 @@ class BucketFiller:
     def drain_round(self) -> List[List[BaseNode]]:
         """Slice up to one round's worth of buffered chunks into contiguous jobs.
 
-        Takes at most ``round_capacity`` chunks off the front of the buffer and
-        slices them into jobs of up to ``max_batch_size`` -- at most
-        ``num_workers`` jobs, each filled to ``max_batch_size`` except the last,
-        which holds the remainder. Any chunks beyond one round's capacity (only
-        possible for a single document larger than ``round_capacity``) remain
-        buffered for the next round. Returns an empty list when the buffer is
-        empty.
+        Takes at most ``round_capacity`` chunks off the front and slices them
+        into up to ``num_workers`` jobs of ``max_batch_size``. A trailing job
+        below ``min_batch_size`` is folded into the previous job (as
+        ``split_nodes`` does); a whole round below ``min_batch_size`` has no
+        previous job and is returned as one small job. Chunks beyond
+        ``round_capacity`` stay buffered. Returns [] when the buffer is empty.
         """
         if not self._buffer:
             return []
@@ -71,7 +75,15 @@ class BucketFiller:
         take = self._buffer[:self.round_capacity]
         self._buffer = self._buffer[self.round_capacity:]
 
-        return [
+        jobs = [
             take[i:i + self.max_batch_size]
             for i in range(0, len(take), self.max_batch_size)
         ]
+
+        # Mirror split_nodes: never leave a trailing job below the minimum when
+        # there is a prior job to absorb it.
+        if len(jobs) > 1 and len(jobs[-1]) < self.min_batch_size:
+            tail = jobs.pop()
+            jobs[-1].extend(tail)
+
+        return jobs

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/bucket_filler.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/bucket_filler.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from llama_index.core.schema import BaseNode
+
+
+class BucketFiller:
+    """Contiguous, count-based chunk accumulator for auto-tuning batch extraction.
+
+    Collects document chunks in arrival order and slices them into Bedrock batch
+    jobs of up to ``max_batch_size`` chunks, mirroring the fixed-``batch_size``
+    path's ``node_batcher``/``split_nodes`` packing: jobs are filled to
+    ``max_batch_size`` and only the last job in a round holds the remainder.
+
+    It deliberately does NOT balance occupancy across jobs or keep a document's
+    chunks within a single job: balancing under-fills jobs, and per-document
+    integrity is guaranteed downstream by ``source_id``-keyed storage
+    (``S3BasedDocs``), the same mechanism the fixed path relies on.
+
+    Driven by ``ExtractionPipeline._extract_auto_tuned``.
+    """
+
+    def __init__(self, num_workers: int, max_batch_size: int):
+        if num_workers < 1:
+            raise ValueError(f'num_workers must be >= 1 (got {num_workers})')
+        if max_batch_size < 1:
+            raise ValueError(f'max_batch_size must be >= 1 (got {max_batch_size})')
+
+        self.num_workers = num_workers
+        self.max_batch_size = max_batch_size
+        self.round_capacity = num_workers * max_batch_size
+        self._buffer: List[BaseNode] = []
+
+    def add_document_chunks(self, chunks: List[BaseNode]) -> None:
+        """Append a document's chunks to the ordered buffer."""
+        if chunks:
+            self._buffer.extend(chunks)
+
+    def pending(self) -> int:
+        """Return the number of chunks currently buffered."""
+        return len(self._buffer)
+
+    def would_overshoot(self, num_chunks: int) -> bool:
+        """Return True if appending ``num_chunks`` would push a non-empty buffer
+        past ``round_capacity``.
+
+        The caller flushes when this is True *before* appending, so a document
+        that fits within a round is not split across rounds -- while the flushed
+        round stays near-full (the buffer is already close to capacity). An empty
+        buffer never overshoots, so an oversized document is still accepted and
+        then drained in full rounds by the caller.
+        """
+        return bool(self._buffer) and (len(self._buffer) + num_chunks > self.round_capacity)
+
+    def drain_round(self) -> List[List[BaseNode]]:
+        """Slice up to one round's worth of buffered chunks into contiguous jobs.
+
+        Takes at most ``round_capacity`` chunks off the front of the buffer and
+        slices them into jobs of up to ``max_batch_size`` -- at most
+        ``num_workers`` jobs, each filled to ``max_batch_size`` except the last,
+        which holds the remainder. Any chunks beyond one round's capacity (only
+        possible for a single document larger than ``round_capacity``) remain
+        buffered for the next round. Returns an empty list when the buffer is
+        empty.
+        """
+        if not self._buffer:
+            return []
+
+        take = self._buffer[:self.round_capacity]
+        self._buffer = self._buffer[self.round_capacity:]
+
+        return [
+            take[i:i + self.max_batch_size]
+            for i in range(0, len(take), self.max_batch_size)
+        ]

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -17,14 +17,18 @@ from graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils import run_pip
 from graphrag_toolkit.lexical_graph.indexing.model import SourceType, SourceDocument, source_documents_from_source_types
 from graphrag_toolkit.lexical_graph.indexing.extract.pipeline_decorator import PipelineDecorator
 from graphrag_toolkit.lexical_graph.indexing.extract.source_doc_parser import SourceDocParser
-from graphrag_toolkit.lexical_graph.indexing.build.checkpoint import Checkpoint
+from graphrag_toolkit.lexical_graph.indexing.build.checkpoint import Checkpoint, CheckpointFilter
 from graphrag_toolkit.lexical_graph.indexing.extract.docs_to_nodes import DocsToNodes
 from graphrag_toolkit.lexical_graph.indexing.extract.id_rewriter import IdRewriter
+from graphrag_toolkit.lexical_graph.indexing.extract.batch_extractor_base import BatchExtractorBase
+from graphrag_toolkit.lexical_graph.indexing.extract.bucket_filler import BucketFiller
+from graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils import BEDROCK_MIN_BATCH_SIZE, BEDROCK_MAX_BATCH_SIZE
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
 from llama_index.core.node_parser import NodeParser
 from llama_index.core.utils import iter_batch
 from llama_index.core.ingestion import IngestionPipeline
+from llama_index.core.ingestion.pipeline import run_transformations
 from llama_index.core.extractors.interface import BaseExtractor
 from llama_index.core.schema import TransformComponent
 from llama_index.core.schema import BaseNode, Document
@@ -231,6 +235,10 @@ class ExtractionPipeline():
                 via keyword arguments.
         """
         components = components or []
+        # Capture whether the caller explicitly supplied batch_size before it is
+        # coalesced to the config default. Under auto-tuning this distinguishes a
+        # user-requested per-round document cap from the (irrelevant) default.
+        explicit_batch_size = batch_size
         num_workers = coalesce(num_workers, GraphRAGConfig.extraction_num_workers)
         batch_size = coalesce(batch_size, GraphRAGConfig.extraction_batch_size)
         include_classification_in_entity_id = coalesce(include_classification_in_entity_id, GraphRAGConfig.include_classification_in_entity_id)
@@ -306,6 +314,38 @@ class ExtractionPipeline():
         self.extraction_filters = extraction_filters or FilterConfig()
         self.extract_timestamp = extract_timestamp
         self.pipeline_kwargs = kwargs
+
+        # Detect auto-tuning batch extraction from the batch extractor's config.
+        # Auto-tuning is only meaningful when a Bedrock batch extractor is present.
+        self._batch_config = self._find_batch_config(components)
+        self._auto_tune = bool(self._batch_config and getattr(self._batch_config, 'auto_tune', False))
+        self._explicit_batch_size = explicit_batch_size
+
+        if self._auto_tune:
+            logger.info(
+                f'Auto-tuning batch extraction enabled '
+                f'[num_workers: {self.num_workers}, max_batch_size: {self._batch_config.max_batch_size}]'
+            )
+            if getattr(self._batch_config, 'max_num_concurrent_batches', None):
+                logger.info(
+                    f'Auto-tuning submits num_workers ({self.num_workers}) batch jobs per round '
+                    f'as the unit of concurrency; max_num_concurrent_batches '
+                    f'({self._batch_config.max_num_concurrent_batches}) is not used in this mode'
+                )
+
+    @staticmethod
+    def _unwrap_component(c):
+        """Return the underlying component, unwrapping a CheckpointFilter if present."""
+        return c.inner if isinstance(c, CheckpointFilter) else c
+
+    @classmethod
+    def _find_batch_config(cls, components):
+        """Return the BatchConfig from the first BatchExtractorBase component, if any."""
+        for c in components:
+            inner = cls._unwrap_component(c)
+            if isinstance(inner, BatchExtractorBase):
+                return inner.batch_config
+        return None
     
     def _source_documents_from_base_nodes(self, nodes:Sequence[BaseNode]) -> Generator[SourceDocument, None, None]:
         """
@@ -349,6 +389,27 @@ class ExtractionPipeline():
     def extract(self, inputs: Iterable[SourceType]):
         """
         Extracts data from a given input source using multiple processing stages.
+
+        Dispatches to the auto-tuning path when a batch extractor with
+        ``auto_tune=True`` is present, otherwise runs the fixed-``batch_size``
+        path with unchanged behavior.
+
+        Args:
+            inputs (Iterable[SourceType]): An iterable of input source types
+                to be processed by the extraction pipeline.
+
+        Yields:
+            SourceDocument: Processed and extracted source documents after
+                being handled by the extraction pipeline and decorators.
+        """
+        if self._auto_tune:
+            yield from self._extract_auto_tuned(inputs)
+        else:
+            yield from self._extract_fixed_batch(inputs)
+
+    def _extract_fixed_batch(self, inputs: Iterable[SourceType]):
+        """
+        Extracts data using the fixed-``batch_size`` strategy (default behavior).
 
         This method processes a collection of input source types to extract
         relevant data by applying a series of pre-processing stages and
@@ -423,9 +484,266 @@ class ExtractionPipeline():
             ]
   
             output_source_documents = self._source_documents_from_base_nodes(timestamped_nodes)
-            
+
             for source_document in output_source_documents:
                 yield self.extraction_decorator.handle_output_doc(source_document)
+
+    def _split_transformations(self):
+        """Partition the ingestion transformations into a chunking prefix and an
+        extractor tail.
+
+        The chunking prefix is everything up to (but not including) the first
+        extractor (``BaseExtractor``); the extractor tail is the extractor and
+        everything after it. Components may be wrapped by ``CheckpointFilter``,
+        which is unwrapped only for the isinstance test - the original (possibly
+        wrapped) component is retained so checkpoint filtering is preserved.
+
+        Returns:
+            Tuple[List[TransformComponent], List[TransformComponent]]: The
+            (chunking_transforms, extractor_transforms) partition.
+        """
+        transformations = self.ingestion_pipeline.transformations
+        split_index = None
+        for i, c in enumerate(transformations):
+            if isinstance(self._unwrap_component(c), BaseExtractor):
+                split_index = i
+                break
+
+        if split_index is None:
+            # No extractor found; treat everything as chunking (extractor tail empty).
+            return list(transformations), []
+
+        return list(transformations[:split_index]), list(transformations[split_index:])
+
+    def _chunk_source_document(self, source_document, chunking_transforms, get_source_metadata):
+        """Apply pre-processing, id rewriting, decorator input hook, chunking, and
+        extraction filters to a single source document, returning its filtered chunks.
+
+        Mirrors the per-batch preparation in ``_extract_fixed_batch`` but for one
+        document at a time so chunk counts are known before bucket assignment.
+        """
+        source_documents = [source_document]
+
+        for pre_processor in self.pre_processors:
+            source_documents = pre_processor.parse_source_docs(source_documents)
+
+        source_documents = self.id_rewriter.handle_source_docs(source_documents)
+        source_documents = self.extraction_decorator.handle_input_docs(source_documents)
+
+        input_nodes = [
+            n
+            for sd in source_documents
+            for n in sd.nodes
+        ]
+
+        # Run the chunking prefix (node parsers, checkpoint-wrapped or not) in the
+        # main process so the resulting chunk count is known before assignment.
+        chunked_nodes = run_transformations(
+            input_nodes,
+            transformations=chunking_transforms,
+            in_place=True,
+            cache=None,
+        ) if chunking_transforms else input_nodes
+
+        filtered_nodes = [
+            node
+            for node in chunked_nodes
+            if self.extraction_filters.filter_source_metadata_dictionary(get_source_metadata(node))
+        ]
+
+        return filtered_nodes
+
+    def _run_extractor_round(self, round_buckets, extractor_transforms):
+        """Run the extractor tail over a round's pre-sized job buckets.
+
+        Buckets are processed across at most ``num_workers`` worker processes,
+        preserving the existing parallelism. Each bucket is <= max_batch_size
+        (except a tail-merged final job, which the batch extractor re-splits).
+        """
+        num_workers = min(self.num_workers, len(round_buckets))
+
+        if not extractor_transforms:
+            # No extractor tail; nodes pass through unchanged.
+            for bucket in round_buckets:
+                for node in bucket:
+                    yield node
+            return
+
+        extractor_pipeline = IngestionPipeline(transformations=extractor_transforms, disable_cache=True)
+
+        output_nodes = run_pipeline(
+            extractor_pipeline,
+            round_buckets,
+            num_workers=num_workers,
+            **self.pipeline_kwargs
+        )
+
+        for node in output_nodes:
+            yield node
+
+    def _extract_auto_tuned(self, inputs: Iterable[SourceType]):
+        """
+        Extracts data using auto-tuning batch extraction.
+
+        Streams source documents one at a time, chunks each in the main process,
+        and accumulates the chunks in a :class:`BucketFiller`. When a round fills
+        (``num_workers x max_batch_size`` chunks), it is sliced contiguously into
+        jobs of ``max_batch_size`` and submitted. At input exhaustion the
+        remainder is submitted as a final round, or merged into the previous
+        round if it is below the Bedrock minimum. The user-supplied ``batch_size``
+        (if any) acts only as an upper bound on documents consumed per round.
+
+        Args:
+            inputs (Iterable[SourceType]): An iterable of input source types.
+
+        Yields:
+            SourceDocument: Processed and extracted source documents.
+        """
+        def get_source_metadata(node):
+            if isinstance(node, Document):
+                return node.metadata
+            else:
+                return node.relationships[NodeRelationship.SOURCE].metadata
+
+        max_batch_size = self._batch_config.max_batch_size
+
+        if self._explicit_batch_size is not None:
+            logger.info(
+                f'Auto-tuning enabled; interpreting batch_size ({self._explicit_batch_size}) as a '
+                f'cap on source documents consumed per round'
+            )
+        docs_per_round_cap = self._explicit_batch_size
+
+        chunking_transforms, extractor_transforms = self._split_transformations()
+
+        # Under auto-tuning, num_workers is the number of batch jobs per full
+        # round (each up to max_batch_size) and the unit of job concurrency. It
+        # supersedes max_num_concurrent_batches, which is the per-worker job
+        # concurrency of the fixed-batch path.
+        filler = BucketFiller(num_workers=self.num_workers, max_batch_size=max_batch_size)
+
+        # round_state is mutable so the nested closures see updates.
+        round_state = {'num': 0, 'docs': 0}
+
+        # Submission is deferred by one round (`held`) so a final remainder below
+        # BEDROCK_MIN_BATCH_SIZE can be merged into the previous round's last job
+        # rather than emitted as an undersized round that falls back to slow
+        # synchronous extraction - mirroring split_nodes' tail-merge.
+        held = {'jobs': None, 'docs': 0}
+
+        def emit_jobs(round_jobs, trigger, docs_consumed):
+            round_state['num'] += 1
+            job_sizes = [len(j) for j in round_jobs]
+            logger.info(
+                f'Submitting auto-tuned extraction round '
+                f'[round: {round_state["num"]}, trigger: {trigger}, jobs: {len(round_jobs)}, '
+                f'job_sizes: {job_sizes}, documents_consumed: {docs_consumed}]'
+            )
+            if len(round_jobs) < self.num_workers:
+                logger.info(
+                    f'Round holds {len(round_jobs)} job(s) '
+                    f'(num_workers={self.num_workers}) - fewer jobs than workers minimises per-job overhead'
+                )
+            logger.debug(f'Auto-tuned round job sizes: {job_sizes}')
+            yield from self._emit_extracted(
+                self._run_extractor_round(round_jobs, extractor_transforms)
+            )
+
+        def flush(trigger):
+            # Drain the current buffer into a round, submit the previously-held
+            # round, and hold the newly-drained one for possible tail-merge.
+            round_jobs = filler.drain_round()
+            if not round_jobs:
+                return
+            if held['jobs'] is not None:
+                yield from emit_jobs(held['jobs'], 'full', held['docs'])
+            held['jobs'] = round_jobs
+            held['docs'] = round_state['docs']
+            round_state['docs'] = 0
+
+        input_source_documents = source_documents_from_source_types(inputs)
+
+        for source_document in input_source_documents:
+
+            chunks = self._chunk_source_document(
+                source_document, chunking_transforms, get_source_metadata
+            )
+
+            if not chunks:
+                continue
+
+            # Flush the current round before appending a document that would
+            # overshoot round capacity, so the document is not split across
+            # rounds while the flushed round stays near-full. Also honour an
+            # explicit batch_size as a cap on documents consumed per round.
+            over_doc_cap = docs_per_round_cap is not None and round_state['docs'] >= docs_per_round_cap
+            if over_doc_cap:
+                yield from flush(trigger='batch_size_cap')
+            elif filler.would_overshoot(len(chunks)):
+                yield from flush(trigger='full')
+
+            if len(chunks) > filler.round_capacity:
+                logger.warning(
+                    f'Document produced {len(chunks)} chunks, exceeding a full round capacity '
+                    f'({filler.round_capacity} = num_workers {self.num_workers} x max_batch_size '
+                    f'{max_batch_size}). Its chunks will be split across multiple rounds and may be '
+                    f'emitted as more than one SourceDocument. Increase max_batch_size or num_workers '
+                    f'to keep large documents whole.'
+                )
+
+            filler.add_document_chunks(chunks)
+            round_state['docs'] += 1
+
+            # A single document larger than a whole round's capacity is drained
+            # in full rounds off the front; the remainder carries forward.
+            while filler.pending() >= filler.round_capacity:
+                yield from flush(trigger='full')
+
+        # Drain the final remainder and reconcile with the held round.
+        final_jobs = filler.drain_round()
+        final_docs = round_state['docs']
+        final_total = sum(len(j) for j in final_jobs)
+
+        merged_size = (len(held['jobs'][-1]) + final_total) if held['jobs'] is not None else 0
+        if (held['jobs'] is not None
+                and 0 < final_total < BEDROCK_MIN_BATCH_SIZE
+                and merged_size <= BEDROCK_MAX_BATCH_SIZE):
+            # Merge the undersized tail into the held round's last job (which may
+            # then exceed max_batch_size, as split_nodes' tail-merge does) so it
+            # is batched rather than routed to synchronous extraction. Guarded so
+            # the merged job never exceeds Bedrock's hard per-job record limit;
+            # if it would, the tail is left as its own (sync-fallback) round.
+            held['jobs'][-1].extend(node for job in final_jobs for node in job)
+            held['docs'] += final_docs
+            final_jobs = []
+
+        if held['jobs'] is not None:
+            yield from emit_jobs(held['jobs'], 'full', held['docs'])
+        if final_jobs:
+            yield from emit_jobs(final_jobs, 'exhausted', final_docs)
+
+    def _emit_extracted(self, output_nodes):
+        """Apply extract-timestamp and decorator output hook to extracted nodes,
+        reconstruct source documents, and yield them - shared post-processing that
+        matches the fixed-batch path.
+        """
+        extract_timestamp = self.extract_timestamp or int(time.time() * 1000)
+
+        def add_timestamp(node):
+            if EXTRACT_TIMESTAMP in node.metadata:
+                return node
+            node.metadata[EXTRACT_TIMESTAMP] = extract_timestamp
+            return node
+
+        timestamped_nodes = [
+            add_timestamp(node)
+            for node in output_nodes
+        ]
+
+        output_source_documents = self._source_documents_from_base_nodes(timestamped_nodes)
+
+        for source_document in output_source_documents:
+            yield self.extraction_decorator.handle_output_doc(source_document)
 
     
    

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -620,7 +620,11 @@ class ExtractionPipeline():
         # round (each up to max_batch_size) and the unit of job concurrency. It
         # supersedes max_num_concurrent_batches, which is the per-worker job
         # concurrency of the fixed-batch path.
-        filler = BucketFiller(num_workers=self.num_workers, max_batch_size=max_batch_size)
+        filler = BucketFiller(
+            num_workers=self.num_workers,
+            max_batch_size=max_batch_size,
+            min_batch_size=BEDROCK_MIN_BATCH_SIZE,
+        )
 
         # round_state is mutable so the nested closures see updates.
         round_state = {'num': 0, 'docs': 0}
@@ -672,14 +676,15 @@ class ExtractionPipeline():
             if not chunks:
                 continue
 
-            # Flush the current round before appending a document that would
-            # overshoot round capacity, so the document is not split across
-            # rounds while the flushed round stays near-full. Also honour an
-            # explicit batch_size as a cap on documents consumed per round.
+            # Flush before a document that would overshoot round capacity, so it
+            # isn't split across rounds, or when an explicit batch_size caps the
+            # documents per round. Don't flush a buffer below the Bedrock minimum:
+            # that would strand a sub-minimum round on synchronous extraction, so
+            # carry it forward to fill the round instead.
             over_doc_cap = docs_per_round_cap is not None and round_state['docs'] >= docs_per_round_cap
             if over_doc_cap:
                 yield from flush(trigger='batch_size_cap')
-            elif filler.would_overshoot(len(chunks)):
+            elif filler.would_overshoot(len(chunks)) and filler.pending() >= BEDROCK_MIN_BATCH_SIZE:
                 yield from flush(trigger='full')
 
             if len(chunks) > filler.round_capacity:

--- a/lexical-graph/tests/unit/indexing/extract/test_batch_config.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_batch_config.py
@@ -114,6 +114,83 @@ class TestBatchConfigDefaults:
         assert config.security_group_ids == []
 
 
+class TestBatchConfigAutoTune:
+    """Tests for the auto_tune flag and max_batch_size validation."""
+
+    def test_default_auto_tune_is_false(self):
+        """Verify auto_tune defaults to False so existing constructions are unaffected."""
+        config = BatchConfig(
+            role_arn="arn:aws:iam::123456789012:role/test-role",
+            region="us-east-1",
+            bucket_name="test-bucket"
+        )
+
+        assert config.auto_tune is False
+
+    def test_auto_tune_can_be_enabled(self):
+        """Verify auto_tune can be set to True."""
+        config = BatchConfig(
+            role_arn="arn:aws:iam::123456789012:role/test-role",
+            region="us-east-1",
+            bucket_name="test-bucket",
+            auto_tune=True
+        )
+
+        assert config.auto_tune is True
+
+    def test_construction_without_auto_tune_field_still_works(self):
+        """Verify omitting auto_tune keeps prior behavior (backward compatibility)."""
+        config = BatchConfig(
+            role_arn="arn:aws:iam::123456789012:role/test-role",
+            region="us-east-1",
+            bucket_name="test-bucket",
+            max_batch_size=10000,
+            max_num_concurrent_batches=5,
+            delete_on_success=False
+        )
+
+        assert config.auto_tune is False
+        assert config.max_batch_size == 10000
+
+    def test_max_batch_size_below_minimum_raises(self):
+        """Verify max_batch_size below BEDROCK_MIN_BATCH_SIZE (100) raises ValueError."""
+        with pytest.raises(ValueError):
+            BatchConfig(
+                role_arn="arn:aws:iam::123456789012:role/test-role",
+                region="us-east-1",
+                bucket_name="test-bucket",
+                max_batch_size=99
+            )
+
+    def test_max_batch_size_above_maximum_raises(self):
+        """Verify max_batch_size above BEDROCK_MAX_BATCH_SIZE (50000) raises ValueError."""
+        with pytest.raises(ValueError):
+            BatchConfig(
+                role_arn="arn:aws:iam::123456789012:role/test-role",
+                region="us-east-1",
+                bucket_name="test-bucket",
+                max_batch_size=50001
+            )
+
+    def test_max_batch_size_at_bounds_is_valid(self):
+        """Verify max_batch_size exactly at the Bedrock bounds is accepted."""
+        min_config = BatchConfig(
+            role_arn="arn:aws:iam::123456789012:role/test-role",
+            region="us-east-1",
+            bucket_name="test-bucket",
+            max_batch_size=100
+        )
+        max_config = BatchConfig(
+            role_arn="arn:aws:iam::123456789012:role/test-role",
+            region="us-east-1",
+            bucket_name="test-bucket",
+            max_batch_size=50000
+        )
+
+        assert min_config.max_batch_size == 100
+        assert max_config.max_batch_size == 50000
+
+
 class TestBatchConfigNetworkSettings:
     """Tests for BatchConfig network configuration."""
     

--- a/lexical-graph/tests/unit/indexing/extract/test_bucket_filler.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_bucket_filler.py
@@ -1,0 +1,128 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from llama_index.core.schema import TextNode
+
+from graphrag_toolkit.lexical_graph.indexing.extract.bucket_filler import BucketFiller
+
+
+def make_chunks(n, prefix="c"):
+    """Create n TextNodes with deterministic ids for order/identity comparisons."""
+    return [TextNode(text=f"{prefix}-{i}", id_=f"{prefix}-{i}") for i in range(n)]
+
+
+def flat_ids(jobs):
+    """Flatten job node ids preserving order."""
+    return [node.node_id for job in jobs for node in job]
+
+
+class TestConstruction:
+    def test_invalid_num_workers_raises(self):
+        with pytest.raises(ValueError):
+            BucketFiller(num_workers=0, max_batch_size=100)
+
+    def test_invalid_max_batch_size_raises(self):
+        with pytest.raises(ValueError):
+            BucketFiller(num_workers=2, max_batch_size=0)
+
+    def test_round_capacity_and_empty_state(self):
+        filler = BucketFiller(num_workers=3, max_batch_size=100)
+        assert filler.round_capacity == 300
+        assert filler.pending() == 0
+        assert filler.drain_round() == []
+
+
+class TestOvershoot:
+    def test_empty_buffer_never_overshoots(self):
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        assert filler.would_overshoot(500) is False  # oversized doc still accepted
+
+    def test_overshoot_true_when_would_exceed_capacity(self):
+        filler = BucketFiller(num_workers=2, max_batch_size=100)  # capacity 200
+        filler.add_document_chunks(make_chunks(180))
+        assert filler.would_overshoot(30) is True   # 180 + 30 > 200
+        assert filler.would_overshoot(20) is False  # 180 + 20 == 200, fits
+
+
+class TestContiguousPacking:
+    def test_full_round_fills_every_job_to_max(self):
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        filler.add_document_chunks(make_chunks(200))
+        jobs = filler.drain_round()
+        assert [len(j) for j in jobs] == [100, 100]  # exactly num_workers full jobs
+        assert filler.pending() == 0
+
+    def test_remainder_only_in_last_job(self):
+        filler = BucketFiller(num_workers=3, max_batch_size=100)
+        filler.add_document_chunks(make_chunks(250))
+        jobs = filler.drain_round()
+        assert [len(j) for j in jobs] == [100, 100, 50]  # full, full, remainder
+
+    def test_never_more_than_num_workers_jobs_per_round(self):
+        # 250 chunks with capacity 200 -> one round takes 200 (2 jobs), 50 remains.
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        filler.add_document_chunks(make_chunks(250))
+        jobs = filler.drain_round()
+        assert len(jobs) == 2
+        assert [len(j) for j in jobs] == [100, 100]
+        assert filler.pending() == 50  # remainder carried forward
+        # next drain takes the remainder
+        jobs2 = filler.drain_round()
+        assert [len(j) for j in jobs2] == [50]
+        assert filler.pending() == 0
+
+    def test_order_and_count_preserved(self):
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        added = make_chunks(200)
+        filler.add_document_chunks(added)
+        jobs = filler.drain_round()
+        assert flat_ids(jobs) == [n.node_id for n in added]  # exact order preserved
+
+    def test_add_ignores_empty(self):
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        filler.add_document_chunks([])
+        assert filler.pending() == 0
+
+
+class TestConsolidation:
+    def test_small_total_single_job(self):
+        filler = BucketFiller(num_workers=4, max_batch_size=25000)
+        filler.add_document_chunks(make_chunks(30))
+        jobs = filler.drain_round()
+        assert len(jobs) == 1
+        assert len(jobs[0]) == 30
+
+    def test_final_round_minimum_jobs(self):
+        # 230 chunks, capacity 500 -> ceil(230/100)=3 jobs [100,100,30], <= num_workers(5)
+        filler = BucketFiller(num_workers=5, max_batch_size=100)
+        filler.add_document_chunks(make_chunks(230))
+        jobs = filler.drain_round()
+        assert [len(j) for j in jobs] == [100, 100, 30]
+
+    def test_multiple_documents_accumulate_in_order(self):
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        a = make_chunks(60, "a")
+        b = make_chunks(60, "b")
+        c = make_chunks(60, "c")
+        filler.add_document_chunks(a)
+        filler.add_document_chunks(b)
+        filler.add_document_chunks(c)  # 180 total, under capacity 200
+        jobs = filler.drain_round()
+        # contiguous slice: [100, 80], documents split across the job boundary
+        assert [len(j) for j in jobs] == [100, 80]
+        assert flat_ids(jobs) == [n.node_id for n in (a + b + c)]
+
+
+class TestOversizedDocument:
+    def test_document_larger_than_round_drains_in_full_rounds(self):
+        # Single 450-chunk doc, capacity 200. Caller drains while pending>=capacity.
+        filler = BucketFiller(num_workers=2, max_batch_size=100)
+        filler.add_document_chunks(make_chunks(450))
+        rounds = []
+        while filler.pending() >= filler.round_capacity:
+            rounds.append(filler.drain_round())
+        final = filler.drain_round()  # remainder
+        # Two full rounds of [100,100] then a final [50]
+        assert [[len(j) for j in r] for r in rounds] == [[100, 100], [100, 100]]
+        assert [len(j) for j in final] == [50]

--- a/lexical-graph/tests/unit/indexing/extract/test_bucket_filler.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_bucket_filler.py
@@ -126,3 +126,65 @@ class TestOversizedDocument:
         # Two full rounds of [100,100] then a final [50]
         assert [[len(j) for j in r] for r in rounds] == [[100, 100], [100, 100]]
         assert [len(j) for j in final] == [50]
+
+
+class TestSubMinimumTailMerge:
+    """drain_round must fold a trailing sub-minimum job into the previous job
+    (as split_nodes does), so a round with >= min_batch_size chunks never emits
+    an under-minimum job that would fall back to synchronous extraction."""
+
+    def test_min_batch_size_defaults_to_one_and_does_not_merge(self):
+        # Backwards-compatible default: no minimum, so plain slicing is retained.
+        filler = BucketFiller(num_workers=3, max_batch_size=100)
+        filler.add_document_chunks(make_chunks(210))
+        assert [len(j) for j in filler.drain_round()] == [100, 100, 10]
+
+    def test_invalid_min_batch_size_raises(self):
+        with pytest.raises(ValueError):
+            BucketFiller(num_workers=2, max_batch_size=100, min_batch_size=0)
+
+    def test_trailing_sub_min_job_folds_into_previous(self):
+        # 210 chunks, max 100, min 100 -> [100, 110] (the 10-tail merges), matching
+        # split_nodes rather than [100, 100, 10].
+        filler = BucketFiller(num_workers=3, max_batch_size=100, min_batch_size=100)
+        filler.add_document_chunks(make_chunks(210))
+        jobs = filler.drain_round()
+        assert [len(j) for j in jobs] == [100, 110]
+        assert all(len(j) >= 100 for j in jobs)
+
+    def test_two_job_round_with_sub_min_tail_folds_to_one_job(self):
+        # 180 chunks, max 100, min 100 -> [100, 80] would leave an 80-tail; merges
+        # into a single 180 job.
+        filler = BucketFiller(num_workers=2, max_batch_size=100, min_batch_size=100)
+        filler.add_document_chunks(make_chunks(180))
+        assert [len(j) for j in filler.drain_round()] == [180]
+
+    def test_exact_multiple_is_unaffected(self):
+        filler = BucketFiller(num_workers=3, max_batch_size=100, min_batch_size=100)
+        filler.add_document_chunks(make_chunks(300))
+        assert [len(j) for j in filler.drain_round()] == [100, 100, 100]
+
+    def test_tail_just_below_minimum_merges_at_minimum_stays(self):
+        # min < max makes the boundary explicit: a 49-tail (< min 50) merges,
+        # a 50-tail (== min 50) is a valid job and stays.
+        below = BucketFiller(num_workers=2, max_batch_size=100, min_batch_size=50)
+        below.add_document_chunks(make_chunks(149))
+        assert [len(j) for j in below.drain_round()] == [149]
+
+        at_min = BucketFiller(num_workers=2, max_batch_size=100, min_batch_size=50)
+        at_min.add_document_chunks(make_chunks(150))
+        assert [len(j) for j in at_min.drain_round()] == [100, 50]
+
+    def test_whole_round_below_minimum_stays_single_small_job(self):
+        # No previous job to merge into: a genuinely sub-min round is returned as
+        # one small job for the driver / sync fallback to handle.
+        filler = BucketFiller(num_workers=3, max_batch_size=100, min_batch_size=100)
+        filler.add_document_chunks(make_chunks(60))
+        assert [len(j) for j in filler.drain_round()] == [60]
+
+    def test_order_preserved_after_merge(self):
+        filler = BucketFiller(num_workers=3, max_batch_size=100, min_batch_size=100)
+        added = make_chunks(210)
+        filler.add_document_chunks(added)
+        jobs = filler.drain_round()
+        assert flat_ids(jobs) == [n.node_id for n in added]

--- a/lexical-graph/tests/unit/indexing/extract/test_extraction_pipeline_auto_tune.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_extraction_pipeline_auto_tune.py
@@ -228,11 +228,11 @@ class TestAutoTunedRounds:
         assert sum(len(b) for r in rounds for b in r) == 5
 
     def test_sub_min_tail_merges_into_previous_round(self):
-        # num_workers=1, max_batch_size=100. Doc A (60) flushes when doc B (60)
-        # would overshoot; the held round is [60]. Doc B's 60-chunk tail is
-        # < BEDROCK_MIN(100), so it merges into the held round's last job -> a
-        # single 120-chunk job, which is batched rather than two sub-min rounds
-        # that would both fall back to synchronous extraction.
+        # num_workers=1, max_batch_size=100. Doc A (60) is below the Bedrock
+        # minimum, so doc B (60) overshooting does NOT flush it as a sub-min
+        # round; both accumulate, the round drains 100, and the 20-chunk tail
+        # merges back into it -> a single 120-chunk job, batched rather than two
+        # sub-min rounds that would both fall back to synchronous extraction.
         pipeline = ExtractionPipeline(
             components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
             num_workers=1,
@@ -310,6 +310,40 @@ class TestAutoTunedRounds:
         assert [len(b) for b in rounds[1]] == [100]
         assert len(output) == 300
 
+    def test_consolidation_round_never_emits_sub_min_job(self):
+        # num_workers=3, max_batch_size=100 -> capacity 300. 210 chunks fill no
+        # round, so they all drain in one consolidation round. Naive slicing
+        # would give [100, 100, 10] (the 10 falls back to sync extraction);
+        # split_nodes-style tail-merge gives [100, 110] instead - no sub-min job
+        # even though the round total (210) is well above the minimum.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=3,
+        )
+        docs = make_source_documents(210)
+        _, rounds = self._run(pipeline, docs)
+
+        submitted = [len(b) for r in rounds for b in r]
+        assert sum(submitted) == 210
+        assert all(size >= 100 for size in submitted), rounds
+        assert [len(b) for b in rounds[0]] == [100, 110]
+
+    def test_overshoot_flush_never_emits_sub_min_job(self):
+        # num_workers=3, max_batch_size=100 -> capacity 300. A 80-chunk doc then
+        # a 250-chunk doc. The 80-chunk buffer is below the minimum, so the
+        # 250-chunk doc overshooting does not strand it as an [80] round; the
+        # docs are packed together into full rounds with the tail merged.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=3,
+        )
+        docs = make_multichunk_documents([80, 250])
+        _, rounds = self._run(pipeline, docs)
+
+        submitted = [len(b) for r in rounds for b in r]
+        assert sum(submitted) == 330
+        assert all(size >= 100 for size in submitted), rounds
+
     def test_multichunk_documents_all_chunks_processed(self):
         pipeline = ExtractionPipeline(
             components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
@@ -336,7 +370,11 @@ class TestAutoTunedRounds:
             # Every job except the last in the round is exactly max_batch_size.
             for job in r[:-1]:
                 assert len(job) == 100
-            assert 0 < len(r[-1]) <= 100
+            # The last job of a round holds the remainder and, when that would be
+            # below the Bedrock minimum, absorbs it (as split_nodes' tail-merge
+            # does), so it can exceed max_batch_size but never by more than the
+            # minimum. It is never itself sub-minimum.
+            assert 100 <= len(r[-1]) <= 100 + 100
         # Total jobs should be close to the theoretical minimum (1400/100 = 14),
         # not inflated by under-filling. Allow a small slack for round tails.
         total_jobs = sum(len(r) for r in rounds)

--- a/lexical-graph/tests/unit/indexing/extract/test_extraction_pipeline_auto_tune.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_extraction_pipeline_auto_tune.py
@@ -1,0 +1,421 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for auto-tuning batch extraction in ExtractionPipeline.
+
+These tests avoid launching the real ProcessPoolExecutor by stubbing
+``_run_extractor_round`` (which is the boundary where worker processes would be
+spawned). The focus is on the auto-tuning orchestration: detection/dispatch,
+incremental chunking, bucket filling, round submission, and consolidation.
+"""
+
+import pytest
+from unittest.mock import patch
+from llama_index.core.llms import MockLLM
+from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.schema import Document, TextNode, NodeRelationship, RelatedNodeInfo
+
+from graphrag_toolkit.lexical_graph.utils import LLMCache
+from graphrag_toolkit.lexical_graph.indexing.extract.batch_config import BatchConfig
+from graphrag_toolkit.lexical_graph.indexing.extract.batch_extractor_base import BatchExtractorBase
+from graphrag_toolkit.lexical_graph.indexing.extract.extraction_pipeline import ExtractionPipeline
+
+
+class _StubBatchExtractor(BatchExtractorBase):
+    """Minimal concrete batch extractor for detection/dispatch tests."""
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "_StubBatchExtractor"
+
+    def _get_json(self, node, llm, inference_parameters):
+        return {}
+
+    def _run_non_batch_extractor(self, nodes):
+        return list(nodes)
+
+    def _update_node(self, node, node_metadata_map):
+        return node
+
+
+def make_batch_extractor(auto_tune=False, max_batch_size=100):
+    config = BatchConfig(
+        role_arn="arn:aws:iam::123456789012:role/test-role",
+        region="us-east-1",
+        bucket_name="test-bucket",
+        max_batch_size=max_batch_size,
+        auto_tune=auto_tune,
+    )
+    llm = LLMCache(llm=MockLLM(), enable_cache=False)
+    return _StubBatchExtractor(
+        batch_config=config,
+        llm=llm,
+        prompt_template="prompt",
+        description="Test",
+    )
+
+
+def make_source_documents(num_docs):
+    """Build source documents, each already carrying one chunk TextNode with a
+    SOURCE relationship (so no node parser is required)."""
+    docs = []
+    for d in range(num_docs):
+        source = Document(text=f"source-{d}", id_=f"src-{d}")
+        node = TextNode(text=f"chunk-{d}", id_=f"chunk-{d}")
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+            node_id=f"src-{d}", metadata={}
+        )
+        docs.append(node)
+    return docs
+
+
+def make_multichunk_documents(chunk_counts):
+    """Build pre-chunked inputs where document i already has ``chunk_counts[i]``
+    chunk TextNodes sharing one SOURCE id. No node parser runs, so the chunk
+    count per document is exactly as specified."""
+    nodes = []
+    for d, count in enumerate(chunk_counts):
+        for c in range(count):
+            node = TextNode(text=f"doc{d}-chunk{c}", id_=f"doc{d}-chunk{c}")
+            node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+                node_id=f"src-{d}", metadata={}
+            )
+            nodes.append(node)
+    return nodes
+
+
+class TestAutoTuneDetection:
+    def test_auto_tune_disabled_by_default(self):
+        pipeline = ExtractionPipeline(components=[make_batch_extractor(auto_tune=False)])
+        assert pipeline._auto_tune is False
+
+    def test_auto_tune_enabled_from_batch_config(self):
+        pipeline = ExtractionPipeline(components=[make_batch_extractor(auto_tune=True)])
+        assert pipeline._auto_tune is True
+
+    def test_no_batch_extractor_means_no_auto_tune(self):
+        pipeline = ExtractionPipeline(components=[])
+        assert pipeline._auto_tune is False
+        assert pipeline._batch_config is None
+
+
+class TestDispatch:
+    def test_disabled_uses_fixed_batch_path(self):
+        pipeline = ExtractionPipeline(components=[make_batch_extractor(auto_tune=False)])
+        with patch.object(pipeline, "_extract_fixed_batch", return_value=iter([])) as fixed, \
+             patch.object(pipeline, "_extract_auto_tuned", return_value=iter([])) as auto:
+            list(pipeline.extract([Document(text="d")]))
+            fixed.assert_called_once()
+            auto.assert_not_called()
+
+    def test_enabled_uses_auto_tuned_path(self):
+        pipeline = ExtractionPipeline(components=[make_batch_extractor(auto_tune=True)])
+        with patch.object(pipeline, "_extract_fixed_batch", return_value=iter([])) as fixed, \
+             patch.object(pipeline, "_extract_auto_tuned", return_value=iter([])) as auto:
+            list(pipeline.extract([Document(text="d")]))
+            auto.assert_called_once()
+            fixed.assert_not_called()
+
+
+class TestAutoTunedRounds:
+    """Exercise the streaming/bucket/round orchestration with the extractor tail
+    stubbed so no worker processes are spawned. The stub returns its input nodes
+    unchanged, so output chunk identity can be compared to input."""
+
+    def _run(self, pipeline, docs):
+        captured_rounds = []
+
+        def fake_round(round_buckets, extractor_transforms):
+            captured_rounds.append([[n.node_id for n in b] for b in round_buckets])
+            for bucket in round_buckets:
+                for node in bucket:
+                    yield node
+
+        with patch.object(pipeline, "_run_extractor_round", side_effect=fake_round):
+            output = list(pipeline.extract(docs))
+        return output, captured_rounds
+
+    def test_small_input_consolidates_to_single_round(self):
+        # max_batch_size large, few docs -> one consolidated job at exhaustion.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=25000)],
+            num_workers=4,
+        )
+        docs = make_source_documents(5)
+        output, rounds = self._run(pipeline, docs)
+
+        assert len(rounds) == 1          # single submission round
+        assert len(rounds[0]) == 1       # consolidated into one job
+        assert len(rounds[0][0]) == 5    # all 5 chunks
+        assert len(output) == 5
+
+    def test_full_buckets_trigger_round(self):
+        # max_batch_size=100, num_workers=2, capacity 200. 250 chunks => one full
+        # round of 200, then a 50-chunk tail. 50 < BEDROCK_MIN(100), so the tail
+        # merges into the round's last job (150) rather than a sub-min round.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        docs = make_source_documents(250)
+        output, rounds = self._run(pipeline, docs)
+
+        assert len(rounds) == 1
+        assert sorted(len(b) for b in rounds[0]) == [100, 150]  # tail merged into last job
+        assert sum(len(b) for r in rounds for b in r) == 250
+        assert len(output) == 250
+
+    def test_chunk_equivalence_all_nodes_processed(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        docs = make_source_documents(300)
+        output, rounds = self._run(pipeline, docs)
+
+        # Every input chunk is submitted exactly once (ids are rewritten by the
+        # IdRewriter, so compare counts and uniqueness rather than raw ids).
+        submitted = [nid for r in rounds for bucket in r for nid in bucket]
+        assert len(submitted) == 300
+        assert len(set(submitted)) == 300
+        assert len(output) == 300
+
+    def test_no_bucket_exceeds_max_batch_size(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=3,
+        )
+        docs = make_source_documents(500)
+        _, rounds = self._run(pipeline, docs)
+
+        for r in rounds:
+            for bucket in r:
+                assert len(bucket) <= 100
+
+    def test_never_more_jobs_than_num_workers(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        docs = make_source_documents(500)
+        _, rounds = self._run(pipeline, docs)
+
+        for r in rounds:
+            assert len(r) <= 2
+
+    def test_empty_input_yields_nothing(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        output, rounds = self._run(pipeline, [])
+        assert output == []
+        assert rounds == []
+
+    def test_batch_size_acts_as_document_cap(self):
+        # Explicit batch_size=2 caps documents per round. 5 single-chunk docs
+        # would flush after docs 2 and 4; the final 1-chunk tail (< BEDROCK_MIN)
+        # merges into the previous round, yielding 2 emitted rounds.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=25000)],
+            num_workers=2,
+            batch_size=2,
+        )
+        assert pipeline._explicit_batch_size == 2
+        docs = make_source_documents(5)
+        _, rounds = self._run(pipeline, docs)
+        # Rounds: [2] then [2 + merged 1 = 3]. All 5 chunks submitted.
+        assert len(rounds) == 2
+        assert sum(len(b) for r in rounds for b in r) == 5
+
+    def test_sub_min_tail_merges_into_previous_round(self):
+        # num_workers=1, max_batch_size=100. Doc A (60) flushes when doc B (60)
+        # would overshoot; the held round is [60]. Doc B's 60-chunk tail is
+        # < BEDROCK_MIN(100), so it merges into the held round's last job -> a
+        # single 120-chunk job, which is batched rather than two sub-min rounds
+        # that would both fall back to synchronous extraction.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=1,
+        )
+        docs = make_multichunk_documents([60, 60])
+        output, rounds = self._run(pipeline, docs)
+
+        assert [[len(j) for j in r] for r in rounds] == [[120]]
+        assert sum(len(b) for r in rounds for b in r) == 120
+
+    def test_tail_not_merged_when_it_would_exceed_bedrock_max(self):
+        # The tail-merge must never grow a job past Bedrock's hard per-job limit.
+        # BEDROCK_MAX_BATCH_SIZE is patched low so the guard fires with small data:
+        # held last job (250) + tail (60) = 310 > patched max (260), so the tail
+        # is left as its own round instead of being merged.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=250)],
+            num_workers=1,
+        )
+        docs = make_multichunk_documents([250, 60])
+        with patch(
+            "graphrag_toolkit.lexical_graph.indexing.extract.extraction_pipeline.BEDROCK_MAX_BATCH_SIZE",
+            260,
+        ):
+            output, rounds = self._run(pipeline, docs)
+
+        assert [[len(j) for j in r] for r in rounds] == [[250], [60]]  # not merged
+        assert sum(len(b) for r in rounds for b in r) == 310
+
+    def test_oversized_document_split_across_rounds(self):
+        # A single document with more chunks than a whole round's capacity
+        # (num_workers=2 x max_batch_size=100 = 200) must still be fully
+        # processed, split across successive full rounds.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        docs = make_multichunk_documents([250])
+        output, rounds = self._run(pipeline, docs)
+
+        total_submitted = sum(len(b) for r in rounds for b in r)
+        assert total_submitted == 250
+        # A single 250-chunk doc drains a full round of 200 ([100,100]); the
+        # 50-chunk tail (< BEDROCK_MIN) merges into the last job -> [100,150].
+        # A merged tail may exceed max_batch_size (as split_nodes' tail-merge
+        # does), but never by more than BEDROCK_MIN.
+        for r in rounds:
+            for bucket in r:
+                assert len(bucket) <= 100 + 100  # max_batch_size + BEDROCK_MIN bound
+
+    def test_sub_min_tail_not_merged_when_no_prior_round(self):
+        # A tiny corpus that never fills a round has no prior round to merge
+        # into, so its single sub-min round is emitted as-is (the extractor
+        # routes it to the synchronous fallback downstream).
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=25000)],
+            num_workers=2,
+        )
+        docs = make_source_documents(30)  # 30 chunks, well below BEDROCK_MIN
+        output, rounds = self._run(pipeline, docs)
+        assert [[len(j) for j in r] for r in rounds] == [[30]]
+        assert len(output) == 30
+
+    def test_above_min_tail_is_its_own_round(self):
+        # A final remainder >= BEDROCK_MIN is submitted as its own round (not
+        # merged), since it is a valid standalone batch job.
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        docs = make_source_documents(300)  # 200 + 100; tail of 100 is >= BEDROCK_MIN
+        output, rounds = self._run(pipeline, docs)
+        assert len(rounds) == 2
+        assert sorted(len(b) for b in rounds[0]) == [100, 100]
+        assert [len(b) for b in rounds[1]] == [100]
+        assert len(output) == 300
+
+    def test_multichunk_documents_all_chunks_processed(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=2,
+        )
+        docs = make_multichunk_documents([30, 45, 55, 40, 60])  # 230 chunks total
+        output, rounds = self._run(pipeline, docs)
+
+        total_submitted = sum(len(b) for r in rounds for b in r)
+        assert total_submitted == 230
+
+    def test_jobs_filled_to_max_batch_size(self):
+        # Regression guard: the contiguous packing must fill every job to
+        # max_batch_size except the last job of each round. (The prior
+        # least-filled+keep-whole design under-filled every job.)
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
+            num_workers=3,
+        )
+        docs = make_multichunk_documents([70] * 20)  # 1400 chunks
+        _, rounds = self._run(pipeline, docs)
+
+        for r in rounds:
+            # Every job except the last in the round is exactly max_batch_size.
+            for job in r[:-1]:
+                assert len(job) == 100
+            assert 0 < len(r[-1]) <= 100
+        # Total jobs should be close to the theoretical minimum (1400/100 = 14),
+        # not inflated by under-filling. Allow a small slack for round tails.
+        total_jobs = sum(len(r) for r in rounds)
+        assert total_jobs <= 16
+
+
+class TestDocumentContiguity:
+    """Verify that a document's chunks stay contiguous through extraction and
+    output reconstruction, using the real chunking prefix, the real
+    _emit_extracted / _source_documents_from_base_nodes reconstruction, and an
+    extractor stub that reproduces BatchExtractorBase's sort-by-node-id."""
+
+    def _run_with_realistic_extractor(self, pipeline, docs):
+        captured_rounds = []
+
+        def realistic_round(round_buckets, extractor_transforms):
+            captured_rounds.append([len(b) for b in round_buckets])
+            # BatchExtractorBase sorts nodes by id within a worker and recombines
+            # results across workers; emulate that ordering hazard here.
+            all_nodes = [n for bucket in round_buckets for n in bucket]
+            all_nodes.sort(key=lambda n: n.node_id)
+            for node in all_nodes:
+                yield node
+
+        with patch.object(pipeline, "_run_extractor_round", side_effect=realistic_round):
+            output = list(pipeline.extract(docs))
+        return output, captured_rounds
+
+    def test_one_source_document_per_input_document(self):
+        # Multi-chunk docs + a small max_batch_size so several rounds occur. Even
+        # with the extractor reordering nodes by id, each input document must
+        # reconstruct into exactly one output SourceDocument (no fragmentation).
+        pipeline = ExtractionPipeline(
+            components=[
+                SentenceSplitter(chunk_size=60, chunk_overlap=10),
+                make_batch_extractor(auto_tune=True, max_batch_size=100),
+            ],
+            num_workers=2,
+        )
+        docs = [
+            Document(text=(f"Document {d}. " + "sentence text here. " * 40), id_=f"doc-{d}")
+            for d in range(8)
+        ]
+
+        output, rounds = self._run_with_realistic_extractor(pipeline, docs)
+
+        from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+        assert all(isinstance(sd, SourceDocument) for sd in output)
+        # Exactly one output SourceDocument per input document.
+        source_ids = set()
+        for sd in output:
+            ids_in_doc = {
+                n.relationships[NodeRelationship.SOURCE].node_id for n in sd.nodes
+            }
+            assert len(ids_in_doc) == 1  # every chunk in the SourceDocument shares one source
+            source_ids |= ids_in_doc
+        assert len(output) == len(source_ids)  # no source split across two SourceDocuments
+        assert len(output) == 8
+
+
+class TestFixedBatchPathUnaffected:
+    """auto_tune=False must retain the fixed-batch_size document-pull behavior."""
+
+    def test_disabled_pipeline_reports_explicit_batch_size(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=False, max_batch_size=100)],
+            num_workers=2,
+            batch_size=8,
+        )
+        assert pipeline._auto_tune is False
+        assert pipeline.batch_size == 8
+
+    def test_disabled_dispatches_to_fixed_batch(self):
+        pipeline = ExtractionPipeline(
+            components=[make_batch_extractor(auto_tune=False, max_batch_size=100)],
+            num_workers=2,
+            batch_size=4,
+        )
+        with patch.object(pipeline, "_extract_fixed_batch", return_value=iter([])) as fixed:
+            list(pipeline.extract([Document(text="d")]))
+            fixed.assert_called_once()

--- a/lexical-graph/tests/unit/indexing/extract/test_extraction_pipeline_auto_tune.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_extraction_pipeline_auto_tune.py
@@ -12,7 +12,6 @@ incremental chunking, bucket filling, round submission, and consolidation.
 import pytest
 from unittest.mock import patch
 from llama_index.core.llms import MockLLM
-from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.schema import Document, TextNode, NodeRelationship, RelatedNodeInfo
 
 from graphrag_toolkit.lexical_graph.utils import LLMCache
@@ -345,10 +344,10 @@ class TestAutoTunedRounds:
 
 
 class TestDocumentContiguity:
-    """Verify that a document's chunks stay contiguous through extraction and
-    output reconstruction, using the real chunking prefix, the real
-    _emit_extracted / _source_documents_from_base_nodes reconstruction, and an
-    extractor stub that reproduces BatchExtractorBase's sort-by-node-id."""
+    """Verify a document's chunks reconstruct into a single output SourceDocument,
+    even when the extractor reorders nodes by id. Uses the real _emit_extracted /
+    _source_documents_from_base_nodes reconstruction and an extractor stub that
+    reproduces BatchExtractorBase's sort-by-node-id."""
 
     def _run_with_realistic_extractor(self, pipeline, docs):
         captured_rounds = []
@@ -371,16 +370,10 @@ class TestDocumentContiguity:
         # with the extractor reordering nodes by id, each input document must
         # reconstruct into exactly one output SourceDocument (no fragmentation).
         pipeline = ExtractionPipeline(
-            components=[
-                SentenceSplitter(chunk_size=60, chunk_overlap=10),
-                make_batch_extractor(auto_tune=True, max_batch_size=100),
-            ],
+            components=[make_batch_extractor(auto_tune=True, max_batch_size=100)],
             num_workers=2,
         )
-        docs = [
-            Document(text=(f"Document {d}. " + "sentence text here. " * 40), id_=f"doc-{d}")
-            for d in range(8)
-        ]
+        docs = make_multichunk_documents([40] * 8)  # 8 sources, 320 chunks, >1 round
 
         output, rounds = self._run_with_realistic_extractor(pipeline, docs)
 


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Adds an opt-in `auto_tune` mode to batch extraction that removes `batch_size` from the set of knobs a user must hand-tune. Instead of pulling a fixed number of documents per iteration and hoping the resulting chunk count fills Bedrock jobs well, the pipeline streams and chunks documents incrementally, packs the chunks contiguously into jobs of `max_batch_size`, and submits a round of up to `num_workers` jobs once a round fills. Under auto-tuning the user specifies only `num_workers` and `max_batch_size`; `batch_size` becomes derived.

Enable with `BatchConfig(..., auto_tune=True)`. Default is `False` — no behavior change for existing configurations.

## Changes

<!-- List the key changes made -->
- `BatchConfig`: new `auto_tune` flag + `__post_init__` validation of `max_batch_size` against the Bedrock bounds.
- `BucketFiller` (new): contiguous, count-based chunk accumulator — mirrors the fixed path's `node_batcher`/`split_nodes` packing (fill to `max_batch_size`, remainder in the last job).
- `ExtractionPipeline`: detects `auto_tune` from the batch extractor's config and branches to `_extract_auto_tuned`; the existing fixed-`batch_size` path is unchanged. Chunking moves to the main process so chunk counts are known before job assignment; the extractor tail still runs across `num_workers` worker processes.
- Docs + integration tests (`BatchExtractAutoTuneToS3`, and an on-demand `BatchExtractSmallBatchToS3` baseline for the fixed-vs-auto-tune comparison).

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->
Today, keeping Bedrock batch jobs well-utilized requires reasoning about `batch_size` × avg-chunks-per-doc ÷ `num_workers` vs `max_batch_size`. Get it wrong and you either get many small, under-utilized jobs (slow: each job carries
~10 min of fixed Bedrock overhead, and sub-100-record jobs fall back to synchronous extraction) or jobs that need re-splitting. Auto-tuning derives the document volume so jobs fill to `max_batch_size` automatically.

Related issue (if any): closes #257 

## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
