### PR TITLE
fix: stop FMObservabilityPublisher.close() from leaking its poller th…

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/utils/fm_observability.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/utils/fm_observability.py
@@ -525,6 +525,7 @@ class FMObservabilityPublisher():
         self.subscribers = subscribers
         self.interval_seconds = interval_seconds
         self.allow_continue = True
+        self._lock = threading.Lock()
         self.poller = FMObservabilityQueuePoller()
         self.poller.start()
 
@@ -534,17 +535,19 @@ class FMObservabilityPublisher():
 
     def close(self):
         """
-        Disables the continuation functionality by updating the internal flag.
+        Disables the continuation functionality and stops the current poller.
 
         This method prevents further continuation of a process by setting the
-        `allow_continue` attribute to `False`. Once invoked, the attribute will
-        indicate that continuation should not occur.
+        `allow_continue` attribute to `False` and synchronously stopping the
+        currently running poller thread, so no poller is left running past close().
 
         Attributes:
             allow_continue (bool): Indicates whether continuation is permitted or not.
                 Set to `False` to disable continuation.
         """
-        self.allow_continue = False
+        with self._lock:
+            self.allow_continue = False
+            self.poller.stop()
 
     def __enter__(self):
         """
@@ -578,16 +581,17 @@ class FMObservabilityPublisher():
         Returns:
             None
         """
-        stats = self.poller.stop()
-        self.poller = FMObservabilityQueuePoller()
-        self.poller.start()
-        if self.allow_continue:
-            logging.debug('Scheduling new poller')
-            t = threading.Timer(self.interval_seconds, self.publish_stats)
-            t.daemon = True
-            t.start()
-        else:
-            logging.debug('Shutting down publisher')
+        with self._lock:
+            stats = self.poller.stop()
+            if self.allow_continue:
+                self.poller = FMObservabilityQueuePoller()
+                self.poller.start()
+                logging.debug('Scheduling new poller')
+                t = threading.Timer(self.interval_seconds, self.publish_stats)
+                t.daemon = True
+                t.start()
+            else:
+                logging.debug('Shutting down publisher')
         for subscriber in self.subscribers:
             subscriber.on_new_stats(stats)
 

--- a/lexical-graph/tests/unit/utils/test_fm_observability.py
+++ b/lexical-graph/tests/unit/utils/test_fm_observability.py
@@ -445,6 +445,7 @@ class TestObservabilityIntegration:
     def test_publisher_initialization_sets_up_handlers(self, mock_settings, mock_queue_class):
         """Verify FMObservabilityPublisher sets up handlers on initialization."""
         mock_queue_instance = Mock()
+        mock_queue_instance.get = Mock(side_effect=queue.Empty)
         mock_queue_class.return_value = mock_queue_instance
         mock_callback_manager = Mock()
         mock_settings.callback_manager = mock_callback_manager
@@ -466,6 +467,7 @@ class TestObservabilityIntegration:
     def test_publisher_context_manager(self, mock_settings, mock_queue_class):
         """Verify FMObservabilityPublisher works as context manager."""
         mock_queue_instance = Mock()
+        mock_queue_instance.get = Mock(side_effect=queue.Empty)
         mock_queue_class.return_value = mock_queue_instance
         mock_callback_manager = Mock()
         mock_settings.callback_manager = mock_callback_manager
@@ -478,7 +480,35 @@ class TestObservabilityIntegration:
         # After exiting context, should be closed
         assert publisher.allow_continue is False
 
-    
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_close_stops_the_current_poller(self, mock_settings):
+        """close() must synchronously stop the running poller, not just flip allow_continue."""
+        mock_settings.callback_manager = Mock()
+
+        publisher = FMObservabilityPublisher(subscribers=[], interval_seconds=30.0)
+        live_poller = publisher.poller
+
+        publisher.close()
+
+        assert live_poller._discontinue.is_set()
+        live_poller.join(timeout=5)
+        assert not live_poller.is_alive()
+
+    @patch('graphrag_toolkit.lexical_graph.utils.fm_observability.Settings')
+    def test_publish_stats_does_not_replace_poller_after_close(self, mock_settings):
+        """A publish_stats() tick firing after close() must not leave a fresh, unstopped poller."""
+        mock_settings.callback_manager = Mock()
+
+        publisher = FMObservabilityPublisher(subscribers=[], interval_seconds=30.0)
+        original_poller = publisher.poller
+
+        publisher.close()
+        # Simulate the in-flight Timer (scheduled before close()) firing afterwards.
+        publisher.publish_stats()
+
+        assert publisher.poller is original_poller
+        assert publisher.poller._discontinue.is_set()
+
     @patch('graphrag_toolkit.lexical_graph.utils.fm_observability._fm_observability_queue')
     def test_handler_event_end_puts_event_in_queue(self, mock_queue):
         """Verify FMObservabilityHandler puts completed events in queue."""


### PR DESCRIPTION
Duplicate of #451
with rebase off of main for CI testing