### PR TITLE
[CHORE] Bump nanoid version

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -6652,9 +6652,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Description

Bumping the transitive nanoid dependency in docs-site from 3.3.16 → 3.3.18, the first patched version on the 3.3.x line. 

## Changes

  - docs-site/package-lock.json only — 3 lines (version, resolved URL, integrity hash).
  - No package.json change required: postcss's ^3.3.16 range already permits 3.3.18, so this is an in-range minor bump with no dependent updates.

## Problem

  - Lockfile-only change (npm update nanoid --package-lock-only); no runtime or source code affected.

Related issue (if any): #

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
