### PR TITLE
[FIX] (lexical-graph): fix KeyError 'params' in domain-entity batch insert

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
@@ -124,8 +124,8 @@ class EntityGraphBuilder(GraphBuilder):
                     e_id = entity.entityId
                     e_label = escape_cypher_label(label_from(entity.classification or DEFAULT_CLASSIFICATION))
                     e_comment = f'// awsqid:{e_id}-{e_label}'.replace('\r', ' ').replace('\n', ' ')
-                    query_e = f"MERGE ({e_var}:`__Entity__`{{{graph_client.node_id('entityId')}: $entityId}}) SET {e_var} :`{e_label}` {e_comment}"
-                    graph_client.execute_query_with_retry(query_e, {'entityId': e_id}, max_attempts=5, max_wait=7)
+                    query_e = f"UNWIND $params AS params MERGE ({e_var}:`__Entity__`{{{graph_client.node_id('entityId')}: params.entityId}}) SET {e_var} :`{e_label}` {e_comment}"
+                    graph_client.execute_query_with_retry(query_e, self._to_params({'entityId': e_id}), max_attempts=5, max_wait=7)
 
                 insert_domain_entity(fact.subject)
 

--- a/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_domain_label_batch.py
+++ b/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_domain_label_batch.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for the domain-entity insert aborting batch build with
+KeyError: 'params'.
+
+When batch writes are enabled, GraphBatchClient.execute_query_with_retry reads
+``properties['params']``. Every graph builder therefore wraps its params via
+``_to_params`` and uses an ``UNWIND $params AS params`` query. The domain-entity
+insert in EntityGraphBuilder used to break this contract - it passed a flat
+``{'entityId': e_id}`` dict and a scalar ``$entityId`` query - so the first
+domain-label insert raised ``KeyError: 'params'`` and took down the whole build
+whenever ``include_domain_labels=True``.
+
+This test drives the real builder through a real GraphBatchClient with batch
+writes enabled: under the bug it raises KeyError; with the fix it queues the id
+as a ``params`` row.
+"""
+
+from llama_index.core.schema import TextNode
+
+from graphrag_toolkit.lexical_graph.indexing.build.entity_graph_builder import (
+    EntityGraphBuilder,
+)
+from graphrag_toolkit.lexical_graph.indexing.build.graph_batch_client import (
+    GraphBatchClient,
+)
+
+ENTITY_ID = 'ent-cafebabe'
+
+
+class _MockStore:
+    """Minimal graph store for GraphBatchClient to wrap. Batch inserts only
+    queue into the client's ``batches`` dict, so the store itself is never
+    queried during build()."""
+
+    def node_id(self, name):
+        return name
+
+
+def _fact_node():
+    return TextNode(
+        text='x',
+        metadata={
+            'fact': {
+                'factId': 'fact-1',
+                'subject': {
+                    'entityId': ENTITY_ID,
+                    'value': 'Acme',
+                    'classification': 'Company',
+                },
+                'predicate': {'value': 'operates'},
+                'object': None,
+            }
+        },
+    )
+
+
+def test_domain_entity_insert_uses_batch_params_shape():
+    """The real builder, driven through a real GraphBatchClient with batch
+    writes enabled, must not raise KeyError: 'params' and must queue the
+    domain-entity id in the ``{'params': [...]}`` shape the client requires."""
+    batch_client = GraphBatchClient(
+        graph_client=_MockStore(),
+        batch_writes_enabled=True,
+        batch_write_size=100,
+    )
+
+    # Under the bug this call raised KeyError: 'params'.
+    EntityGraphBuilder().build(
+        _fact_node(),
+        batch_client,
+        include_domain_labels=True,
+        include_local_entities=False,
+    )
+
+    # The domain-entity query is the one carrying the awsqid comment.
+    domain_batches = {q: p for q, p in batch_client.batches.items() if 'awsqid' in q}
+    assert domain_batches, 'expected a domain-entity query to be queued'
+
+    query, params = next(iter(domain_batches.items()))
+    assert 'UNWIND $params AS params' in query
+    assert 'params.entityId' in query
+    assert '$entityId' not in query
+    assert params == [{'entityId': ENTITY_ID}]

--- a/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_label_injection.py
+++ b/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_label_injection.py
@@ -61,7 +61,10 @@ def _domain_query(client):
 
 def test_domain_entity_query_is_escaped_and_parameterised():
     """The real builder emits the escaped label (not the raw label-wrap) and binds
-    entityId as a parameter instead of inlining it as a string literal."""
+    entityId as a parameter instead of inlining it as a string literal.
+
+    The id is bound through the batch client's ``UNWIND $params AS params`` form
+    (``params.entityId``), not inlined, so a crafted id cannot break out either."""
     client = _CapturingClient()
     EntityGraphBuilder().build(
         _fact_node(),
@@ -76,7 +79,8 @@ def test_domain_entity_query_is_escaped_and_parameterised():
     raw = label_from(MALICIOUS_CLASSIFICATION)
     assert f':`{safe}`' in query
     assert f':`{raw}`' not in query
-    assert '$entityId' in query
+    assert 'UNWIND $params AS params' in query
+    assert 'params.entityId' in query
     assert f"'{ENTITY_ID}'" not in query
 
 


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
- insert_domain_entity passed a flat {'entityId': e_id} dict and a scalar
$entityId query to the batch graph client. When batch writes are enabled,
GraphBatchClient.execute_query_with_retry reads properties['params'], so the
missing key raised KeyError: 'params' and aborted the entire build whenever
include_domain_labels=True.

## Changes

<!-- List the key changes made -->

- Align this call site with every other graph builder: use the
UNWIND $params AS params form (binding params.entityId) and wrap the params
via _to_params so they carry the {'params': [...]} shape the batch client
requires. Label escaping and id-as-bound-parameter behaviour are unchanged.

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->
_to_params(p) wraps params into the {'params': [p]} shape the batch client requires, and every graph-builder call site uses it — except insert_domain_entity at entity_graph_builder.py:128, which passes a raw {'entityId': e_id} and a scalar $entityId query instead of the UNWIND $params pattern.
Under batch writes, the client does properties['params'] (graph_batch_client.py:141) → no 'params' key → KeyError: 'params', which aborts the entire build. The two queries then time out because there's no graph.

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
