### PR TITLE
[FIX]: Validate region and format in Neptune Analytics load Cypher

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -291,7 +291,8 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
                 return
 
     def __attach_existing_neptune_graph(self, neptune_graph_id):
-        assert neptune_graph_id is not None, "graph_identifier is required"
+        if neptune_graph_id is None:
+            raise ValueError("graph_identifier is required")
         response = self.neptune_client.get_graph(graphIdentifier=neptune_graph_id)
         return response['id']
 
@@ -312,7 +313,8 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
         _validate_s3_path(s3_path)
 
         if csv_file is not None:
-            assert s3_path is not None, "s3 path should be passed with local csv path for data import"
+            if s3_path is None:
+                raise ValueError("s3_path must be provided with a local csv_file for data import")
             self._upload_to_s3(s3_path, csv_file)
 
         logger.info(f'Loading data from source : {s3_path} into graph: {self.neptune_graph_id}')
@@ -401,8 +403,10 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
         """
 
         if node_embedding_text_props is None:
-            assert self.node_type_to_property_mapping,\
-            "Node properties to as text input for node embedding must be provided or use `assign_text_repr_prop_for_nodes` to set a default representation for each node"
+            if not self.node_type_to_property_mapping:
+                raise ValueError(
+                    "Node properties to as text input for node embedding must be provided or use `assign_text_repr_prop_for_nodes` to set a default representation for each node"
+                )
             logger.info(f'Using text representation property: {self.node_type_to_property_mapping} for as text input for node embedding')
             node_embedding_text_props = {k: [v] for k, v in self.node_type_to_property_mapping.items if v is not None}
 
@@ -474,7 +478,8 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         _validate_s3_path(s3_path)
 
         if csv_file is not None:
-            assert s3_path is not None, "s3 path should be passed with local csv path for data import"
+            if s3_path is None:
+                raise ValueError("s3_path must be provided with a local csv_file for data import")
             self._upload_to_s3(s3_path, csv_file)
 
         logger.info(f'Loading data from source : {s3_path} into graph: {self.endpoint_url}')

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -33,6 +33,15 @@ def _validate_s3_path(s3_path):
         )
 
 
+# region is interpolated into the CALL neptune.load() Cypher too, so allowlist it.
+_REGION_PATTERN = re.compile(r'^[a-z0-9-]+$')
+
+
+def _validate_region(region):
+    if region is None or not _REGION_PATTERN.match(region):
+        raise ValueError(f"Invalid AWS region: '{region}'. Must match [a-z0-9-].")
+
+
 # Escape backticks before a label is interpolated into a backtick-quoted Cypher
 # identifier. Doubling is Cypher's escape rule; without it a label containing a
 # backtick could break out of the identifier and inject Cypher.
@@ -251,10 +260,13 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
 
 
         if region is None:
+            self.region = None
             self.__detect_region()
         else:
             self.region = region
-        assert self.region is not None, "region needs to be passed in or inferrable from current environment"
+        if self.region is None:
+            raise ValueError("region needs to be passed in or inferrable from current environment")
+        _validate_region(self.region)
         self.session = boto3.Session(region_name=self.region)
         self.neptune_client = self.session.client('neptune-graph', region_name=self.region)
         self.s3_client = self.session.client('s3', region_name=self.region)
@@ -291,7 +303,8 @@ class NeptuneAnalyticsGraphStore(BaseNeptuneGraphStore):
 
         """
 
-        assert format in ['NTRIPLES', 'CSV', 'OPEN_CYPHER'], "format must be either 'NTRIPLES' or 'CSV' or 'OPEN_CYPHER'"
+        if format not in ('NTRIPLES', 'CSV', 'OPEN_CYPHER'):
+            raise ValueError("format must be one of 'NTRIPLES', 'CSV', 'OPEN_CYPHER'")
         _validate_s3_path(s3_path)
 
         if csv_file is not None:

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -26,19 +26,23 @@ _S3_PATH_PATTERN = re.compile(r'^s3://[a-zA-Z0-9.\-_/+=!@()*]+$')
 def _validate_s3_path(s3_path):
     if s3_path is None:
         return
-    if not _S3_PATH_PATTERN.match(s3_path):
+    # fullmatch, not match: '$' matches before a trailing newline, so match()
+    # would let 's3://b/k\n' through.
+    if not _S3_PATH_PATTERN.fullmatch(s3_path):
         raise ValueError(
             f"Invalid s3_path format: '{s3_path}'. "
             "Must be a valid S3 URI (s3://bucket/key)."
         )
 
 
-# region is interpolated into the CALL neptune.load() Cypher too, so allowlist it.
-_REGION_PATTERN = re.compile(r'^[a-z0-9-]+$')
+# region is interpolated into the CALL neptune.load() Cypher, so check its format.
+_REGION_PATTERN = re.compile(r'[a-z0-9-]+')
 
 
 def _validate_region(region):
-    if region is None or not _REGION_PATTERN.match(region):
+    # fullmatch, not match: '$' matches before a trailing newline, so 'us-east-1\n'
+    # would otherwise pass.
+    if region is None or not _REGION_PATTERN.fullmatch(region):
         raise ValueError(f"Invalid AWS region: '{region}'. Must match [a-z0-9-].")
 
 
@@ -440,7 +444,8 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         :param region: Str AWS region
         """
         self.region = region
-        assert self.region is not None, "region needs to be passed in or inferrable from current environment"
+        if self.region is None:
+            raise ValueError("region needs to be passed in or inferrable from current environment")
         self.session = boto3.Session(region_name=self.region)
         self.endpoint_url = endpoint_url
         self.neptune_data_client = self.session.client('neptunedata', region_name=self.region, endpoint_url = self.endpoint_url)
@@ -464,7 +469,8 @@ class NeptuneDBGraphStore(BaseNeptuneGraphStore):
         Returns:
         """
 
-        assert format in ['CSV', 'OPEN_CYPHER'], "format must be either or 'CSV' or 'OPEN_CYPHER'"
+        if format not in ('CSV', 'OPEN_CYPHER'):
+            raise ValueError("format must be one of 'CSV', 'OPEN_CYPHER'")
         _validate_s3_path(s3_path)
 
         if csv_file is not None:

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -311,7 +311,22 @@ class TestNeptuneAnalyticsGraphStore:
         
         with pytest.raises(ValueError, match="format must be"):
             store.read_from_csv(s3_path='s3://test-bucket/data.csv', format='INVALID')
-    
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_store_read_from_csv_local_file_without_s3_path_raises(self, mock_session, mock_neptune_client, mock_s3_client):
+        """A local csv_file with no s3_path raises (a stripped assert would upload a None key under -O)."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client
+        }[service]
+
+        store = NeptuneAnalyticsGraphStore(graph_identifier='test-graph-id', region='us-west-2')
+
+        with pytest.raises(ValueError, match="s3_path must be provided"):
+            store.read_from_csv(csv_file='/tmp/test.csv')
+
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
     def test_neptune_store_execute_query_with_parameters(self, mock_session, mock_neptune_client, mock_s3_client):
         """Verify execute_query passes parameters correctly."""
@@ -537,6 +552,24 @@ class TestNeptuneDBGraphStore:
         assert 'edgeLabelDetails' in result
         assert 'labelTriples' in result
     
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_neptune_db_store_read_from_csv_local_file_without_s3_path_raises(self, mock_session, mock_neptune_data_client, mock_s3_client):
+        """A local csv_file with no s3_path raises (stripped assert would upload a None key under -O)."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptunedata': mock_neptune_data_client,
+            's3': mock_s3_client
+        }[service]
+
+        store = NeptuneDBGraphStore(
+            endpoint_url='https://test-cluster.us-west-2.neptune.amazonaws.com:8182',
+            region='us-west-2'
+        )
+
+        with pytest.raises(ValueError, match="s3_path must be provided"):
+            store.read_from_csv(csv_file='/tmp/test.csv')
+
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
     def test_neptune_db_store_read_from_csv(self, mock_session, mock_neptune_data_client, mock_s3_client):
         """Verify Neptune DB read_from_csv starts bulk loader."""

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -587,13 +587,18 @@ class TestNeptuneDBGraphStore:
             region='us-west-2'
         )
         
-        with pytest.raises(AssertionError, match="format must be either"):
+        with pytest.raises(ValueError, match="format must be"):
             store.read_from_csv(
                 s3_path='s3://test-bucket/data.csv',
                 format='NTRIPLES',
                 iam_role='arn:aws:iam::123456789012:role/NeptuneLoadRole'
             )
     
+    def test_neptune_db_store_missing_region_raises_value_error(self):
+        """A missing region raises ValueError, not a stripped assert."""
+        with pytest.raises(ValueError, match="region needs to be"):
+            NeptuneDBGraphStore(endpoint_url='https://x.neptune.amazonaws.com:8182')
+
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
     def test_neptune_db_store_get_node_properties(self, mock_session, mock_neptune_data_client, mock_s3_client):
         """Verify _get_node_properties enriches schema with node details."""
@@ -1312,6 +1317,8 @@ class TestValidateRegion:
         pytest.param('US-EAST-1', id='uppercase'),
         pytest.param("us-east-1', format:'CSV'}) DETACH DELETE n //", id='cypher-breakout'),
         pytest.param('us east 1', id='space'),
+        pytest.param('us-east-1\n', id='trailing-newline'),
+        pytest.param('us-east-1\nDETACH DELETE n', id='newline-injection'),
     ])
     def test_rejects_invalid_regions(self, region):
         with pytest.raises(ValueError, match='Invalid AWS region'):

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -15,6 +15,7 @@ from graphrag_toolkit.byokg_rag.graphstore.neptune import (
     NeptuneDBGraphStore,
     BaseNeptuneGraphStore,
     _validate_s3_path,
+    _validate_region,
     _escape_cypher_label,
 )
 
@@ -308,7 +309,7 @@ class TestNeptuneAnalyticsGraphStore:
             region='us-west-2'
         )
         
-        with pytest.raises(AssertionError, match="format must be either"):
+        with pytest.raises(ValueError, match="format must be"):
             store.read_from_csv(s3_path='s3://test-bucket/data.csv', format='INVALID')
     
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
@@ -1281,6 +1282,73 @@ class TestValidateS3Path:
     def test_rejects_empty_string(self):
         with pytest.raises(ValueError, match='Invalid s3_path'):
             _validate_s3_path('')
+
+
+class TestValidateRegion:
+    """region is interpolated into the CALL neptune.load() Cypher alongside
+    s3_path, so it must be allowlisted too."""
+
+    @pytest.mark.parametrize('region', ['us-east-1', 'eu-west-2', 'us-gov-west-1'])
+    def test_accepts_valid_regions(self, region):
+        _validate_region(region)
+
+    def test_accepts_every_region_botocore_knows(self):
+        import botocore.session
+
+        sess = botocore.session.get_session()
+        regions = {
+            r
+            for partition in sess.get_available_partitions()
+            for svc in sess.get_available_services()
+            for r in sess.get_available_regions(svc, partition_name=partition)
+        }
+        assert regions  # sanity: botocore returned something
+        for region in regions:
+            _validate_region(region)
+
+    @pytest.mark.parametrize('region', [
+        pytest.param(None, id='none'),
+        pytest.param('', id='empty'),
+        pytest.param('US-EAST-1', id='uppercase'),
+        pytest.param("us-east-1', format:'CSV'}) DETACH DELETE n //", id='cypher-breakout'),
+        pytest.param('us east 1', id='space'),
+    ])
+    def test_rejects_invalid_regions(self, region):
+        with pytest.raises(ValueError, match='Invalid AWS region'):
+            _validate_region(region)
+
+
+class TestNeptuneAnalyticsRegionValidation:
+    """The store must reject a malicious region at construction, before it can
+    reach the load Cypher."""
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_constructor_rejects_malicious_region(self, mock_session, mock_neptune_client, mock_s3_client):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client,
+        }[service]
+
+        with pytest.raises(ValueError, match='Invalid AWS region'):
+            NeptuneAnalyticsGraphStore(
+                graph_identifier='test-graph-id',
+                region="us-east-1', format:'CSV'}) DETACH DELETE n //",
+            )
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    @patch.dict('os.environ', {'AWS_REGION': "us-east-1'}) DETACH DELETE n //"})
+    def test_constructor_rejects_malicious_region_from_env(self, mock_session, mock_neptune_client, mock_s3_client):
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client,
+        }[service]
+
+        with pytest.raises(ValueError, match='Invalid AWS region'):
+            NeptuneAnalyticsGraphStore(graph_identifier='test-graph-id')
 
 
 class TestReadFromCsvValidatesS3Path:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
@@ -124,8 +124,8 @@ class EntityGraphBuilder(GraphBuilder):
                     e_id = entity.entityId
                     e_label = escape_cypher_label(label_from(entity.classification or DEFAULT_CLASSIFICATION))
                     e_comment = f'// awsqid:{e_id}-{e_label}'.replace('\r', ' ').replace('\n', ' ')
-                    query_e = f"MERGE ({e_var}:`__Entity__`{{{graph_client.node_id('entityId')}: $entityId}}) SET {e_var} :`{e_label}` {e_comment}"
-                    graph_client.execute_query_with_retry(query_e, {'entityId': e_id}, max_attempts=5, max_wait=7)
+                    query_e = f"UNWIND $params AS params MERGE ({e_var}:`__Entity__`{{{graph_client.node_id('entityId')}: params.entityId}}) SET {e_var} :`{e_label}` {e_comment}"
+                    graph_client.execute_query_with_retry(query_e, self._to_params({'entityId': e_id}), max_attempts=5, max_wait=7)
 
                 insert_domain_entity(fact.subject)
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/entity_graph_builder.py
@@ -120,6 +120,9 @@ class EntityGraphBuilder(GraphBuilder):
                     if entity.classification and entity.classification == LOCAL_ENTITY_CLASSIFICATION:
                         return
 
+                    # new_query_var() makes each query string unique, so this
+                    # UNWIND runs one row per call. Correct, but batching these
+                    # into a single multi-row UNWIND is a future optimization.
                     e_var = new_query_var()
                     e_id = entity.entityId
                     e_label = escape_cypher_label(label_from(entity.classification or DEFAULT_CLASSIFICATION))

--- a/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_domain_label_batch.py
+++ b/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_domain_label_batch.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for the domain-entity insert aborting batch build with
+KeyError: 'params'.
+
+When batch writes are enabled, GraphBatchClient.execute_query_with_retry reads
+``properties['params']``. Every graph builder therefore wraps its params via
+``_to_params`` and uses an ``UNWIND $params AS params`` query. The domain-entity
+insert in EntityGraphBuilder used to break this contract - it passed a flat
+``{'entityId': e_id}`` dict and a scalar ``$entityId`` query - so the first
+domain-label insert raised ``KeyError: 'params'`` and took down the whole build
+whenever ``include_domain_labels=True``.
+
+This test drives the real builder through a real GraphBatchClient with batch
+writes enabled: under the bug it raises KeyError; with the fix it queues the id
+as a ``params`` row.
+"""
+
+from llama_index.core.schema import TextNode
+
+from graphrag_toolkit.lexical_graph.indexing.build.entity_graph_builder import (
+    EntityGraphBuilder,
+)
+from graphrag_toolkit.lexical_graph.indexing.build.graph_batch_client import (
+    GraphBatchClient,
+)
+
+ENTITY_ID = 'ent-cafebabe'
+
+
+class _MockStore:
+    """Minimal graph store for GraphBatchClient to wrap. Batch inserts only
+    queue into the client's ``batches`` dict, so the store itself is never
+    queried during build()."""
+
+    def node_id(self, name):
+        return name
+
+
+def _fact_node():
+    return TextNode(
+        text='x',
+        metadata={
+            'fact': {
+                'factId': 'fact-1',
+                'subject': {
+                    'entityId': ENTITY_ID,
+                    'value': 'Acme',
+                    'classification': 'Company',
+                },
+                'predicate': {'value': 'operates'},
+                'object': None,
+            }
+        },
+    )
+
+
+def test_domain_entity_insert_uses_batch_params_shape():
+    """The real builder, driven through a real GraphBatchClient with batch
+    writes enabled, must not raise KeyError: 'params' and must queue the
+    domain-entity id in the ``{'params': [...]}`` shape the client requires."""
+    batch_client = GraphBatchClient(
+        graph_client=_MockStore(),
+        batch_writes_enabled=True,
+        batch_write_size=100,
+    )
+
+    # Under the bug this call raised KeyError: 'params'.
+    EntityGraphBuilder().build(
+        _fact_node(),
+        batch_client,
+        include_domain_labels=True,
+        include_local_entities=False,
+    )
+
+    # The domain-entity query is the one carrying the awsqid comment.
+    domain_batches = {q: p for q, p in batch_client.batches.items() if 'awsqid' in q}
+    assert domain_batches, 'expected a domain-entity query to be queued'
+
+    query, params = next(iter(domain_batches.items()))
+    assert 'UNWIND $params AS params' in query
+    assert 'params.entityId' in query
+    assert '$entityId' not in query
+    assert params == [{'entityId': ENTITY_ID}]

--- a/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_label_injection.py
+++ b/lexical-graph/tests/unit/indexing/build/test_entity_graph_builder_label_injection.py
@@ -61,7 +61,10 @@ def _domain_query(client):
 
 def test_domain_entity_query_is_escaped_and_parameterised():
     """The real builder emits the escaped label (not the raw label-wrap) and binds
-    entityId as a parameter instead of inlining it as a string literal."""
+    entityId as a parameter instead of inlining it as a string literal.
+
+    The id is bound through the batch client's ``UNWIND $params AS params`` form
+    (``params.entityId``), not inlined, so a crafted id cannot break out either."""
     client = _CapturingClient()
     EntityGraphBuilder().build(
         _fact_node(),
@@ -76,7 +79,8 @@ def test_domain_entity_query_is_escaped_and_parameterised():
     raw = label_from(MALICIOUS_CLASSIFICATION)
     assert f':`{safe}`' in query
     assert f':`{raw}`' not in query
-    assert '$entityId' in query
+    assert 'UNWIND $params AS params' in query
+    assert 'params.entityId' in query
     assert f"'{ENTITY_ID}'" not in query
 
 


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
`CALL neptune.load()` does not accept bound parameters, so `NeptuneAnalyticsGraphStore.read_from_csv` interpolates its inputs directly into the Cypher string. A previous change allowlisted `s3_path`, but two interpolations were left unhardened

## Changes

<!-- List the key changes made -->

- Added `_validate_region`
- Bad region is rejected at construction, before it can reach the load Cypher.

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
