### PR TITLE
[FIX]: Widen secret scanning to release branches

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,9 +6,9 @@ name: Secret Scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'v*.*.x']
   push:
-    branches: [main]
+    branches: [main, 'v*.*.x']
   schedule:
     - cron: '17 9 * * 1'
   workflow_dispatch:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,6 +5,8 @@
 name: Secret Scan
 
 on:
+  # Scan main and vX.Y.x release branches. New release branches are cut from
+  # main and inherit it from there.
   pull_request:
     branches: [main, 'v*.*.x']
   push:


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
- The gitleaks workflow only ran on main, so PRs/pushes to release branches were never scanned per-commit

## Changes

<!-- List the key changes made -->

- Widen secret scanning to vX.Y.x release branches

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
