### PR TITLE
[FIX]: Read coverage values via env

### DIFF
--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -157,11 +157,16 @@ jobs:
 
       - name: Comment on PR with coverage report link
         uses: actions/github-script@v9
+        env:
+          # Pass via env, not inline ${{ }}, so the values can't break out of the
+          # script into executable JS.
+          COVERAGE: ${{ steps.coverage.outputs.percentage }}
+          TARGET: ${{ steps.coverage.outputs.target }}
         with:
           script: |
             const artifactUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const coverage = `${{ steps.coverage.outputs.percentage }}`;
-            const target = `${{ steps.coverage.outputs.target }}`;
+            const coverage = process.env.COVERAGE;
+            const target = process.env.TARGET;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
- coverage-percentage.txt is produced by the test job (which runs PR code) and was interpolated as ${{ steps.coverage.outputs.* }} inside a JS template literal in a job with pull-requests: write. Pass the values via env: and reference them as process.env.COVERAGE / process.env.TARGET so they can't break out of the script into executable JS

## Changes

<!-- List the key changes made -->

- Read coverage values via env in the PR-comment github-script step

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
