### PR TITLE
Revert "Read coverage values via env"

### DIFF
--- a/.github/workflows/lexical-graph-tests.yml
+++ b/.github/workflows/lexical-graph-tests.yml
@@ -157,16 +157,11 @@ jobs:
 
       - name: Comment on PR with coverage report link
         uses: actions/github-script@v9
-        env:
-          # Pass via env, not inline ${{ }}, so the values can't break out of the
-          # script into executable JS.
-          COVERAGE: ${{ steps.coverage.outputs.percentage }}
-          TARGET: ${{ steps.coverage.outputs.target }}
         with:
           script: |
             const artifactUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const coverage = process.env.COVERAGE;
-            const target = process.env.TARGET;
+            const coverage = `${{ steps.coverage.outputs.percentage }}`;
+            const target = `${{ steps.coverage.outputs.target }}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
This reverts commit 3c40c7ef349b318b2b9385e3a82bb9f50fd63843.

## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->

## Changes

<!-- List the key changes made -->

-

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
