### PR TITLE
[FIX] Propagate GraphRAGConfig to spawn extraction and build workers

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -3,6 +3,7 @@
 
 import os
 import json
+import pickle
 import time
 import subprocess
 import boto3
@@ -16,7 +17,7 @@ import threading
 import logging
 from enum import Enum
 from dataclasses import dataclass, field
-from typing import Optional, Union, Dict, Set, List
+from typing import Optional, Union, Dict, Set, List, Any
 from boto3 import Session as Boto3Session
 from botocore.config import Config
 
@@ -351,6 +352,62 @@ class _GraphRAGConfig:
     _s3_chunk_store: Optional[str] = None
     _local_output_dir: Optional[str] = None
     _log_output_dir: Optional[str] = None
+
+    # Fields that must NOT cross into a 'spawn'-started worker: sessions, boto3
+    # clients, and LLM/embedding objects. They aren't picklable and are rebuilt
+    # in the worker from the propagated scalars. Everything else backing a
+    # setting is a picklable scalar and propagates automatically - so a NEW
+    # setting can't silently fail to reach workers (the bug this guards against).
+    _NON_PROPAGATABLE_FIELDS = frozenset({
+        '_boto3_session', '_session', '_aws_clients', '_aws_valid_services',
+        '_extraction_llm', '_response_llm', '_embed_model',
+    })
+
+    def _is_propagatable_field(self, name: str) -> bool:
+        return name.startswith('_') and name not in self._NON_PROPAGATABLE_FIELDS
+
+    def get_config_snapshot(self) -> Dict[str, Any]:
+        """Return a picklable snapshot of explicitly-set scalar settings.
+
+        Used to propagate config to 'spawn'-started worker processes: spawn
+        re-imports this module in a clean interpreter, so the singleton loses any
+        value set programmatically (those were only inherited under fork). Env-
+        derived values still resolve in the worker (children inherit os.environ),
+        so only explicitly-set overrides (non-None backing fields) are captured.
+
+        Every scalar setting field is included automatically; session/clients and
+        LLM/embedding objects are excluded (_NON_PROPAGATABLE_FIELDS). A field
+        holding an unexpectedly non-picklable value is skipped with a warning
+        rather than crashing worker startup.
+        """
+        snapshot: Dict[str, Any] = {}
+        for name in self.__dataclass_fields__:
+            if not self._is_propagatable_field(name):
+                continue
+            value = getattr(self, name, None)
+            if value is None:
+                continue
+            try:
+                pickle.dumps(value)
+            except Exception:
+                logger.warning(
+                    f"Config field '{name}' is not picklable; not propagating it "
+                    f"to spawn workers."
+                )
+                continue
+            snapshot[name] = value
+        return snapshot
+
+    def apply_config_snapshot(self, snapshot: Dict[str, Any]) -> None:
+        """Re-apply a get_config_snapshot() result onto this singleton.
+
+        Called from a spawn worker initializer so the fresh singleton keeps the
+        parent's programmatically-set values instead of silently falling back to
+        env/None (a least-privilege / data-placement regression otherwise).
+        """
+        for name, value in snapshot.items():
+            if self._is_propagatable_field(name):
+                setattr(self, name, value)
 
     @contextlib.contextmanager
     def _validate_sso_token(self, profile):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
@@ -12,6 +12,22 @@ from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.ingestion.pipeline import run_transformations
 from llama_index.core.schema import BaseNode, Document
 
+from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
+
+
+def _init_worker(config_snapshot):
+    """Re-apply the parent's GraphRAGConfig scalars in a spawn-started worker.
+
+    spawn re-imports config.py in a clean interpreter, so the GraphRAGConfig
+    singleton loses any programmatically-set value and would silently fall back
+    to env/None - widening effective permissions (a scoped aws_profile becomes
+    the ambient role) and mis-placing data (s3_chunk_store -> None falls back to
+    the in-graph chunk store, dropping the intended KMS CMK). Re-applying the
+    snapshot keeps workers consistent with the parent.
+    """
+    GraphRAGConfig.apply_config_snapshot(config_snapshot)
+
+
 def _sink():
     def _sink_from(generator):
         for item in generator:
@@ -38,10 +54,15 @@ def run_pipeline(
     )
 
     # Use "spawn": a forked worker can inherit a held lock (e.g. a logging
-    # thread's) and deadlock. Spawn starts workers from a clean interpreter.
+    # thread's) and deadlock. Spawn starts workers from a clean interpreter,
+    # which also drops the GraphRAGConfig singleton's programmatically-set
+    # values - so propagate a picklable snapshot via the worker initializer.
+    config_snapshot = GraphRAGConfig.get_config_snapshot()
     with ProcessPoolExecutor(
         max_workers=num_workers,
         mp_context=multiprocessing.get_context('spawn'),
+        initializer=_init_worker,
+        initargs=(config_snapshot,),
     ) as p:
         processed_node_batches = p.map(transform, node_batches)
         

--- a/lexical-graph/tests/unit/indexing/utils/test_pipeline_utils.py
+++ b/lexical-graph/tests/unit/indexing/utils/test_pipeline_utils.py
@@ -1,16 +1,103 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import multiprocessing
+import pickle
+from concurrent.futures import ProcessPoolExecutor
+
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from llama_index.core.schema import TextNode, Document
 from llama_index.core.ingestion import IngestionPipeline
 
+from graphrag_toolkit.lexical_graph import GraphRAGConfig
 from graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils import (
     sink,
     run_pipeline,
-    node_batcher
+    node_batcher,
+    _init_worker,
 )
+
+
+def _worker_reads_config(_):
+    """Top-level so spawn can import it. Returns what the worker's fresh
+    GraphRAGConfig singleton resolves for the propagated settings."""
+    from graphrag_toolkit.lexical_graph import GraphRAGConfig
+    return (GraphRAGConfig.aws_profile, GraphRAGConfig.s3_chunk_store)
+
+
+class TestConfigPropagationToWorkers:
+    """M2: spawn re-imports config.py in a clean interpreter, so programmatically
+    set GraphRAGConfig values are lost unless propagated via the initializer."""
+
+    def test_snapshot_roundtrip_and_excludes_non_picklable(self, monkeypatch):
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.delenv("S3_CHUNK_STORE", raising=False)
+        orig = (GraphRAGConfig._aws_profile, GraphRAGConfig._s3_chunk_store)
+        try:
+            GraphRAGConfig._aws_profile = None
+            GraphRAGConfig._s3_chunk_store = None
+            GraphRAGConfig.aws_profile = "scoped-ingest"
+            GraphRAGConfig.s3_chunk_store = "s3://bucket/prefix"
+
+            snapshot = GraphRAGConfig.get_config_snapshot()
+            # Picklable (it is passed as initargs across processes).
+            assert pickle.loads(pickle.dumps(snapshot)) == snapshot
+            # Never carries session/clients/LLM/embedding objects.
+            for banned in ("_session", "_boto3_session", "_aws_clients",
+                           "_extraction_llm", "_response_llm", "_embed_model"):
+                assert banned not in snapshot
+
+            # Applying onto a fresh singleton restores the values.
+            from graphrag_toolkit.lexical_graph.config import _GraphRAGConfig
+            fresh = _GraphRAGConfig()
+            fresh.apply_config_snapshot(snapshot)
+            assert fresh.aws_profile == "scoped-ingest"
+            assert fresh.s3_chunk_store == "s3://bucket/prefix"
+        finally:
+            GraphRAGConfig._aws_profile, GraphRAGConfig._s3_chunk_store = orig
+
+    def test_non_picklable_field_is_skipped_with_warning(self, monkeypatch, caplog):
+        """A field holding a non-picklable value is dropped (with a warning),
+        not silently corrupting the snapshot nor crashing worker startup."""
+        import logging
+        orig = GraphRAGConfig._local_output_dir
+        try:
+            GraphRAGConfig._local_output_dir = lambda: None  # not picklable
+            with caplog.at_level(logging.WARNING):
+                snapshot = GraphRAGConfig.get_config_snapshot()
+            assert '_local_output_dir' not in snapshot
+            assert 'not picklable' in caplog.text
+        finally:
+            GraphRAGConfig._local_output_dir = orig
+
+    def test_spawn_workers_see_programmatic_config(self, monkeypatch):
+        """Two-worker spawn run: the worker must see the parent's scoped
+        aws_profile and s3_chunk_store, not fall back to env/None."""
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.delenv("S3_CHUNK_STORE", raising=False)
+        orig = (GraphRAGConfig._aws_profile, GraphRAGConfig._s3_chunk_store)
+        try:
+            GraphRAGConfig._aws_profile = None
+            GraphRAGConfig._s3_chunk_store = None
+            GraphRAGConfig.aws_profile = "scoped-ingest"
+            GraphRAGConfig.s3_chunk_store = "s3://bucket/prefix"
+            snapshot = GraphRAGConfig.get_config_snapshot()
+
+            with ProcessPoolExecutor(
+                max_workers=2,
+                mp_context=multiprocessing.get_context("spawn"),
+                initializer=_init_worker,
+                initargs=(snapshot,),
+            ) as p:
+                results = list(p.map(_worker_reads_config, [0, 1]))
+
+            assert results, "expected results from workers"
+            for profile, chunk_store in results:
+                assert profile == "scoped-ingest"
+                assert chunk_store == "s3://bucket/prefix"
+        finally:
+            GraphRAGConfig._aws_profile, GraphRAGConfig._s3_chunk_store = orig
 
 
 class TestSink:
@@ -100,6 +187,37 @@ class TestRunPipeline:
                 assert call_kwargs['max_workers'] == 1
                 assert call_kwargs['mp_context'].get_start_method() == 'spawn'
     
+    def test_run_pipeline_passes_config_snapshot_to_workers(self, monkeypatch):
+        """run_pipeline must wire the config snapshot into the pool initializer,
+        or spawn workers silently lose programmatically-set settings."""
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        orig = GraphRAGConfig._aws_profile
+        try:
+            GraphRAGConfig._aws_profile = None
+            GraphRAGConfig.aws_profile = "scoped-ingest"
+
+            mock_pipeline = Mock(spec=IngestionPipeline)
+            mock_pipeline.transformations = []
+            mock_pipeline.cache = None
+            mock_pipeline.disable_cache = True
+            node_batches = [[TextNode(text="Node 1", id_="1")]]
+
+            with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.run_transformations'):
+                with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.ProcessPoolExecutor') as mock_executor:
+                    mock_pool = MagicMock()
+                    mock_pool.__enter__.return_value = mock_pool
+                    mock_pool.map.return_value = [node_batches[0]]
+                    mock_executor.return_value = mock_pool
+
+                    list(run_pipeline(mock_pipeline, node_batches, num_workers=2))
+
+            _, call_kwargs = mock_executor.call_args
+            assert call_kwargs['initializer'] is _init_worker
+            (snapshot,) = call_kwargs['initargs']
+            assert snapshot.get('_aws_profile') == "scoped-ingest"
+        finally:
+            GraphRAGConfig._aws_profile = orig
+
     def test_run_pipeline_with_cache(self):
         """Verify run_pipeline uses cache when not disabled."""
         mock_cache = Mock()


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Propagate GraphRAGConfig to spawn extraction/build workers
## Changes

<!-- List the key changes made -->

- A deployment that deliberately scopes ingestion to a narrow `aws_profile` gets the ambient instance/task role instead 
- `s3_chunk_store` resolving to `None` makes `ChunkStoreFactory` fall back to the in-graph chunk store, so chunk text lands on the Neptune node as `chunk.value`

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
