### PR TITLE
[FIX] Overlap chunk uploads across documents and carry the thread count into workers

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -378,30 +378,63 @@ class S3ChunkUploader(BaseComponent):
                 ServerSideEncryption='AES256'
             )
 
-    def upload(self, source_documents: List[SourceDocument]):
+    def _drain(self, futures):
+        for future in futures:
+            try:
+                future.result()
+            except Exception as e:
+                logger.error(f'Error uploading chunk: {str(e)}')
 
+    def upload(self, source_documents: List[SourceDocument]):
+        """
+        Upload each source document's chunks, yielding a document once its own
+        chunks are written.
+
+        Uploads for several documents are in flight at once. Waiting for one
+        document before submitting the next held in-flight uploads to that
+        document's chunk count - 3.31 on the WikiHow benchmark corpus - so the
+        pool sat idle however many threads it was given, and the write phase
+        took the same 13 minutes at 16, 32 and 64 threads.
+
+        Documents are still yielded in order, and still only after their own
+        chunks are durable, so a consumer sees what it saw before.
+        """
         s3_client = GraphRAGConfig.s3
-        
-        with concurrent.futures.ThreadPoolExecutor(max_workers=GraphRAGConfig.extraction_num_threads_per_worker) as executor:
+        num_threads = GraphRAGConfig.extraction_num_threads_per_worker
+
+        # Enough queued chunks to keep every thread busy while the oldest
+        # document drains, without reading the whole corpus into memory.
+        max_inflight = num_threads * 2
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+
+            pending = deque()
+            inflight = 0
 
             for source_document in source_documents:
-        
+
                 root_path =  join(self.collection_prefix, source_document.source_id())
                 logger.debug(f'Writing source document to S3 [bucket: {self.bucket_name}, prefix: {root_path}]')
 
                 futures = [
                     executor.submit(self._upload_chunk, root_path, n, s3_client)
-                    for n in source_document.nodes 
+                    for n in source_document.nodes
                     if not [key for key in [INDEX_KEY] if key in n.metadata]
                 ]
 
-                for future in futures:
-                    try:
-                        future.result()
-                    except Exception as e:
-                        logger.error(f'Error uploading chunk: {str(e)}')
+                pending.append((source_document, futures))
+                inflight += len(futures)
 
-                yield source_document
+                while inflight > max_inflight:
+                    (oldest, oldest_futures) = pending.popleft()
+                    self._drain(oldest_futures)
+                    inflight -= len(oldest_futures)
+                    yield oldest
+
+            while pending:
+                (oldest, oldest_futures) = pending.popleft()
+                self._drain(oldest_futures)
+                yield oldest
 
 
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -32,11 +32,23 @@ BATCH_SIZE = 100
 
 logger = logging.getLogger(__name__)
 
+class ConfiguredThreadCount:
+    """
+    Sizes a thread pool from a caller-supplied count, falling back to the config
+    for a component built outside S3BasedDocs.
+    """
+
+    num_threads:Optional[int]=None
+
+    def _num_threads(self):
+        return self.num_threads or GraphRAGConfig.extraction_num_threads_per_worker
+
+
 def to_batches(xs, n):
     n = max(1, n)
     return [xs[i:i+n] for i in range(0, len(xs), n)]
 
-class S3DocDownloader(BaseComponent):
+class S3DocDownloader(ConfiguredThreadCount, BaseComponent):
 
     key_prefix:str
     collection_id:str
@@ -88,7 +100,7 @@ class S3DocDownloader(BaseComponent):
 
         logger.debug(f'Started getting source documents from S3 [bucket: {self.bucket_name}, collection_path: {collection_path}, num_prefixes: {len(source_doc_prefixes)}]')
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=GraphRAGConfig.extraction_num_threads_per_worker) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self._num_threads()) as executor:
 
             for source_doc_prefixes_batch in source_doc_prefixes_batches:
 
@@ -109,23 +121,14 @@ class S3DocDownloader(BaseComponent):
                     logger.debug(f'Yielding source document [source: {doc.source_id()}, num_nodes: {len(doc.nodes)}]')
                     yield doc
 
-class S3DocUploader(BaseComponent):
+class S3DocUploader(ConfiguredThreadCount, BaseComponent):
 
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
-    num_threads:Optional[int]=None
     _semaphore:Semaphore = PrivateAttr(default=None)
     _queue:queue.Queue = PrivateAttr(default=None)
     
-    def _num_threads(self):
-        """
-        Threads the caller asked for, or whatever this process can see.
-
-        The fallback keeps a directly-constructed uploader working as before.
-        """
-        return self.num_threads or GraphRAGConfig.extraction_num_threads_per_worker
-
     def _upload_doc(self, root_path:str, doc:SourceDocument, s3_client):
 
         doc_output_path = join(root_path, f'{doc.source_id()}-{uuid.uuid4().hex[:5]}.jsonl')
@@ -271,7 +274,7 @@ class S3DocUploader(BaseComponent):
             source_docs_batch = []
             logger.debug(f'Total uploaded: {total}')
 
-class S3ChunkDownloader(BaseComponent):
+class S3ChunkDownloader(ConfiguredThreadCount, BaseComponent):
 
     key_prefix:str
     collection_id:str
@@ -312,7 +315,7 @@ class S3ChunkDownloader(BaseComponent):
 
         logger.debug(f'Started getting source documents from S3 [bucket: {self.bucket_name}, collection_path: {collection_path}, num_prefixes: {len(source_doc_prefixes)}]')
 
-        num_threads = GraphRAGConfig.extraction_num_threads_per_worker
+        num_threads = self._num_threads()
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as download_executor, \
              concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as list_executor:
@@ -358,20 +361,11 @@ class S3ChunkDownloader(BaseComponent):
 
                 yield SourceDocument(nodes=nodes)
 
-class S3ChunkUploader(BaseComponent):
+class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
 
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
-    num_threads:Optional[int]=None
-
-    def _num_threads(self):
-        """
-        Threads the caller asked for, or whatever this process can see.
-
-        The fallback keeps a directly-constructed uploader working as before.
-        """
-        return self.num_threads or GraphRAGConfig.extraction_num_threads_per_worker
 
     def _upload_chunk(self, root_path:str, n:TextNode, s3_client):
         chunk_output_path = join(root_path, f'{n.node_id}.json')
@@ -405,29 +399,31 @@ class S3ChunkUploader(BaseComponent):
 
     def upload(self, source_documents: List[SourceDocument]):
         """
-        Upload each source document's chunks, yielding a document once its own
-        chunks are written.
+        Upload each document's chunks, yielding a document once its own uploads
+        have been attempted.
 
-        Uploads for several documents are in flight at once. Waiting for one
-        document before submitting the next held in-flight uploads to that
-        document's chunk count - 3.31 on the WikiHow benchmark corpus - so the
-        pool sat idle however many threads it was given, and the write phase
-        took the same 13 minutes at 16, 32 and 64 threads.
-
-        Documents are still yielded in order, and still only after their own
-        chunks are durable, so a consumer sees what it saw before.
+        Chunks for several documents are in flight at once; waiting for one
+        document first capped them at that document's chunk count rather than at
+        the pool. Documents are yielded in order. A failed chunk is logged, not
+        raised, so a yielded document is not proof every chunk reached S3.
         """
         s3_client = GraphRAGConfig.s3
         num_threads = self._num_threads()
 
-        # Enough queued chunks to keep every thread busy while the oldest
-        # document drains, without reading the whole corpus into memory.
+        # Enough queued to keep the pool busy while the oldest document drains.
         max_inflight = num_threads * 2
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
 
             pending = deque()
             inflight = 0
+
+            def release_oldest():
+                nonlocal inflight
+                (oldest, oldest_futures) = pending.popleft()
+                self._drain(oldest_futures)
+                inflight -= len(oldest_futures)
+                return oldest
 
             for source_document in source_documents:
 
@@ -444,15 +440,10 @@ class S3ChunkUploader(BaseComponent):
                 inflight += len(futures)
 
                 while inflight > max_inflight:
-                    (oldest, oldest_futures) = pending.popleft()
-                    self._drain(oldest_futures)
-                    inflight -= len(oldest_futures)
-                    yield oldest
+                    yield release_oldest()
 
             while pending:
-                (oldest, oldest_futures) = pending.popleft()
-                self._drain(oldest_futures)
-                yield oldest
+                yield release_oldest()
 
 
 
@@ -480,12 +471,9 @@ class S3BasedDocs(NodeHandler):
                  for_jsonl:Optional[bool]=False,
                  num_threads:Optional[int]=None):
 
-        # Resolved here rather than where the uploader is built. __init__ runs
-        # in the process that configured GraphRAGConfig; accept() runs in a
-        # worker spawned by run_pipeline, which inherits no parent memory and
-        # reads back the default however the parent was configured. Carrying the
-        # value as a field pickles it with the handler, the same trip an
-        # extractor's num_workers already survives.
+        # __init__ runs where GraphRAGConfig was configured; accept() runs in a
+        # spawned worker that inherits no parent memory and reads back the
+        # default. Carried as a field so it pickles with the handler.
         num_threads = num_threads or GraphRAGConfig.extraction_num_threads_per_worker
 
         super().__init__(
@@ -553,14 +541,16 @@ class S3BasedDocs(NodeHandler):
                     key_prefix=self.key_prefix, 
                     collection_id=self.collection_id, 
                     bucket_name=self.bucket_name, 
-                    fn=self._filter_metadata
+                    fn=self._filter_metadata,
+                    num_threads=self.num_threads
                 )
             else:
                 self._downloader = S3ChunkDownloader(
                     key_prefix=self.key_prefix, 
                     collection_id=self.collection_id, 
                     bucket_name=self.bucket_name, 
-                    fn=self._filter_metadata
+                    fn=self._filter_metadata,
+                    num_threads=self.num_threads
                 )
 
         path = join(self.key_prefix,  self.collection_id, '')

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -114,9 +114,18 @@ class S3DocUploader(BaseComponent):
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
+    num_threads:Optional[int]=None
     _semaphore:Semaphore = PrivateAttr(default=None)
     _queue:queue.Queue = PrivateAttr(default=None)
     
+    def _num_threads(self):
+        """
+        Threads the caller asked for, or whatever this process can see.
+
+        The fallback keeps a directly-constructed uploader working as before.
+        """
+        return self.num_threads or GraphRAGConfig.extraction_num_threads_per_worker
+
     def _upload_doc(self, root_path:str, doc:SourceDocument, s3_client):
 
         doc_output_path = join(root_path, f'{doc.source_id()}-{uuid.uuid4().hex[:5]}.jsonl')
@@ -181,7 +190,7 @@ class S3DocUploader(BaseComponent):
         
         try:
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=GraphRAGConfig.extraction_num_threads_per_worker) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self._num_threads()) as executor:
 
                 count = 0
 
@@ -354,6 +363,15 @@ class S3ChunkUploader(BaseComponent):
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
+    num_threads:Optional[int]=None
+
+    def _num_threads(self):
+        """
+        Threads the caller asked for, or whatever this process can see.
+
+        The fallback keeps a directly-constructed uploader working as before.
+        """
+        return self.num_threads or GraphRAGConfig.extraction_num_threads_per_worker
 
     def _upload_chunk(self, root_path:str, n:TextNode, s3_client):
         chunk_output_path = join(root_path, f'{n.node_id}.json')
@@ -400,7 +418,7 @@ class S3ChunkUploader(BaseComponent):
         chunks are durable, so a consumer sees what it saw before.
         """
         s3_client = GraphRAGConfig.s3
-        num_threads = GraphRAGConfig.extraction_num_threads_per_worker
+        num_threads = self._num_threads()
 
         # Enough queued chunks to keep every thread busy while the oldest
         # document drains, without reading the whole corpus into memory.
@@ -447,6 +465,7 @@ class S3BasedDocs(NodeHandler):
     s3_encryption_key_id:Optional[str]=None
     metadata_keys:Optional[List[str]]=None
     for_jsonl:Optional[bool]=False
+    num_threads:Optional[int]=None
 
     _uploader:Any = PrivateAttr(default=None)
     _downloader:Any = PrivateAttr(default=None)
@@ -458,8 +477,17 @@ class S3BasedDocs(NodeHandler):
                  collection_id:Optional[str]=None,
                  s3_encryption_key_id:Optional[str]=None, 
                  metadata_keys:Optional[List[str]]=None,
-                 for_jsonl:Optional[bool]=False):
-        
+                 for_jsonl:Optional[bool]=False,
+                 num_threads:Optional[int]=None):
+
+        # Resolved here rather than where the uploader is built. __init__ runs
+        # in the process that configured GraphRAGConfig; accept() runs in a
+        # worker spawned by run_pipeline, which inherits no parent memory and
+        # reads back the default however the parent was configured. Carrying the
+        # value as a field pickles it with the handler, the same trip an
+        # extractor's num_workers already survives.
+        num_threads = num_threads or GraphRAGConfig.extraction_num_threads_per_worker
+
         super().__init__(
             region=region,
             bucket_name=bucket_name,
@@ -467,7 +495,8 @@ class S3BasedDocs(NodeHandler):
             collection_id=collection_id or datetime.now().strftime('%Y%m%d-%H%M%S'),
             s3_encryption_key_id=s3_encryption_key_id,
             metadata_keys=metadata_keys,
-            for_jsonl=for_jsonl
+            for_jsonl=for_jsonl,
+            num_threads=num_threads
         )
 
     def docs(self):
@@ -573,14 +602,16 @@ class S3BasedDocs(NodeHandler):
                 self._uploader = S3DocUploader(
                     bucket_name=self.bucket_name, 
                     collection_prefix=collection_prefix,
-                    s3_encryption_key_id=self.s3_encryption_key_id
+                    s3_encryption_key_id=self.s3_encryption_key_id,
+                    num_threads=self.num_threads
                 )
                 
             else:
                 self._uploader = S3ChunkUploader(
                     bucket_name=self.bucket_name, 
                     collection_prefix=collection_prefix,
-                    s3_encryption_key_id=self.s3_encryption_key_id
+                    s3_encryption_key_id=self.s3_encryption_key_id,
+                    num_threads=self.num_threads
                 )
         
         for doc in self._uploader.upload(source_documents):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -38,10 +38,14 @@ class ConfiguredThreadCount:
     for a component built outside S3BasedDocs.
     """
 
+    # Declared on the mixin and collected by BaseComponent's pydantic field
+    # machinery across the MRO, so each subclass carries num_threads as a field.
     num_threads:Optional[int]=None
 
     def _num_threads(self):
-        return self.num_threads or GraphRAGConfig.extraction_num_threads_per_worker
+        if self.num_threads is None:
+            return GraphRAGConfig.extraction_num_threads_per_worker
+        return self.num_threads
 
 
 def to_batches(xs, n):
@@ -410,7 +414,7 @@ class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
         s3_client = GraphRAGConfig.s3
         num_threads = self._num_threads()
 
-        # Enough queued to keep the pool busy while the oldest document drains.
+        # Two documents per thread keeps the pool busy while the oldest drains.
         max_inflight = num_threads * 2
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
@@ -474,7 +478,8 @@ class S3BasedDocs(NodeHandler):
         # __init__ runs where GraphRAGConfig was configured; accept() runs in a
         # spawned worker that inherits no parent memory and reads back the
         # default. Carried as a field so it pickles with the handler.
-        num_threads = num_threads or GraphRAGConfig.extraction_num_threads_per_worker
+        if num_threads is None:
+            num_threads = GraphRAGConfig.extraction_num_threads_per_worker
 
         super().__init__(
             region=region,

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -690,3 +690,130 @@ class TestS3ChunkDownloaderParallelListing:
                 # while the executors unwind.
                 with pytest.raises(RuntimeError, match='transient S3 listing error'):
                     next(gen)
+
+
+from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
+
+
+def _doc(source_id, num_chunks, index_key_chunks=0):
+    """A stand-in source document whose chunks the uploader will write."""
+    nodes = [
+        TextNode(text=f'{source_id}-chunk-{i}', id_=f'{source_id}-chunk-{i}')
+        for i in range(num_chunks)
+    ]
+    for i in range(index_key_chunks):
+        skipped = TextNode(text='skip', id_=f'{source_id}-index-{i}')
+        skipped.metadata[INDEX_KEY] = {'index': 'chunk'}
+        nodes.append(skipped)
+
+    doc = Mock()
+    doc.nodes = nodes
+    doc.source_id.return_value = source_id
+    return doc
+
+
+@contextlib.contextmanager
+def _uploader_with(num_threads, on_put):
+    """Run S3ChunkUploader against an instrumented put_object."""
+    uploader = S3ChunkUploader(bucket_name='test-bucket', collection_prefix='prefix/collection')
+    with patch(
+        'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+    ) as config:
+        config.extraction_num_threads_per_worker = num_threads
+        config.s3 = MagicMock()
+        config.s3.put_object = on_put
+        yield uploader
+
+
+class TestS3ChunkUploaderConcurrency:
+    """Uploads for several documents are in flight at once."""
+
+    def test_uploads_overlap_across_documents(self):
+        """
+        Waiting for each document before submitting the next capped in-flight
+        uploads at that document's chunk count. With one chunk per document
+        that is a single upload at a time, whatever the pool size.
+        """
+        # Releases only if this many uploads are in flight together, so a
+        # one-at-a-time uploader cannot satisfy it.
+        barrier = threading.Barrier(4)
+        peak = 0
+        inflight = 0
+        lock = threading.Lock()
+
+        def on_put(**kwargs):
+            nonlocal peak, inflight
+            with lock:
+                inflight += 1
+                peak = max(peak, inflight)
+            with contextlib.suppress(threading.BrokenBarrierError):
+                barrier.wait(timeout=5)
+            with lock:
+                inflight -= 1
+
+        with _uploader_with(8, on_put) as uploader:
+            docs = [_doc(f'src-{i}', 1) for i in range(8)]
+            list(uploader.upload(docs))
+
+        assert peak >= 4
+
+    def test_yields_documents_in_order(self):
+        with _uploader_with(4, lambda **kwargs: None) as uploader:
+            docs = [_doc(f'src-{i}', 2) for i in range(10)]
+            yielded = list(uploader.upload(docs))
+
+        assert [d.source_id() for d in yielded] == [f'src-{i}' for i in range(10)]
+
+    def test_every_chunk_is_uploaded_once(self):
+        keys = []
+        lock = threading.Lock()
+
+        def on_put(**kwargs):
+            with lock:
+                keys.append(kwargs['Key'])
+
+        with _uploader_with(4, on_put) as uploader:
+            docs = [_doc(f'src-{i}', 3) for i in range(10)]
+            list(uploader.upload(docs))
+
+        assert len(keys) == 30
+        assert len(set(keys)) == 30
+
+    def test_document_is_yielded_only_after_its_own_chunks_are_written(self):
+        """The durability contract a consumer already relies on."""
+        written = set()
+        lock = threading.Lock()
+
+        def on_put(**kwargs):
+            time.sleep(0.01)
+            with lock:
+                written.add(kwargs['Key'])
+
+        with _uploader_with(8, on_put) as uploader:
+            docs = [_doc(f'src-{i}', 3) for i in range(8)]
+            for doc in uploader.upload(docs):
+                source_id = doc.source_id()
+                with lock:
+                    for i in range(3):
+                        assert f'prefix/collection/{source_id}/{source_id}-chunk-{i}.json' in written
+
+    def test_index_key_chunks_are_skipped(self):
+        keys = []
+
+        def on_put(**kwargs):
+            keys.append(kwargs['Key'])
+
+        with _uploader_with(4, on_put) as uploader:
+            list(uploader.upload([_doc('src-0', 2, index_key_chunks=3)]))
+
+        assert len(keys) == 2
+
+    def test_a_failed_chunk_does_not_stop_the_stream(self):
+        def on_put(**kwargs):
+            if 'src-1' in kwargs['Key']:
+                raise RuntimeError('upload failed')
+
+        with _uploader_with(4, on_put) as uploader:
+            yielded = list(uploader.upload([_doc(f'src-{i}', 2) for i in range(4)]))
+
+        assert [d.source_id() for d in yielded] == [f'src-{i}' for i in range(4)]

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -16,6 +16,7 @@ from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
     S3ChunkUploader
 )
 from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
 
 
 class TestS3BasedDocsInitialization:
@@ -692,9 +693,6 @@ class TestS3ChunkDownloaderParallelListing:
                     next(gen)
 
 
-from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
-
-
 def _doc(source_id, num_chunks, index_key_chunks=0):
     """A stand-in source document whose chunks the uploader will write."""
     nodes = [
@@ -729,13 +727,8 @@ class TestS3ChunkUploaderConcurrency:
     """Uploads for several documents are in flight at once."""
 
     def test_uploads_overlap_across_documents(self):
-        """
-        Waiting for each document before submitting the next capped in-flight
-        uploads at that document's chunk count. With one chunk per document
-        that is a single upload at a time, whatever the pool size.
-        """
-        # Releases only if this many uploads are in flight together, so a
-        # one-at-a-time uploader cannot satisfy it.
+        """One chunk per document, so the old code managed one upload at a time."""
+        # Releases only on four simultaneous uploads, so serial code times out.
         barrier = threading.Barrier(4)
         peak = 0
         inflight = 0
@@ -780,7 +773,7 @@ class TestS3ChunkUploaderConcurrency:
         assert len(set(keys)) == 30
 
     def test_document_is_yielded_only_after_its_own_chunks_are_written(self):
-        """The durability contract a consumer already relies on."""
+        """A document's own chunks are written before it is yielded."""
         written = set()
         lock = threading.Lock()
 
@@ -820,14 +813,9 @@ class TestS3ChunkUploaderConcurrency:
 
 
 class TestUploadThreadPropagation:
-    """
-    The thread count has to reach the process that does the uploading.
+    """S3BasedDocs is built where the config was set; accept() runs elsewhere."""
 
-    S3BasedDocs is built where GraphRAGConfig was configured; accept() runs in a
-    worker spawned by run_pipeline, which sees the default instead.
-    """
-
-    def _handler(self, configured_threads, num_threads=None):
+    def _handler(self, configured_threads, num_threads=None, for_jsonl=False):
         with patch(
             'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
         ) as config:
@@ -837,6 +825,7 @@ class TestUploadThreadPropagation:
                 bucket_name='test-bucket',
                 key_prefix='prefix',
                 num_threads=num_threads,
+                for_jsonl=for_jsonl,
             )
 
     def test_thread_count_is_captured_at_construction(self):
@@ -876,6 +865,34 @@ class TestUploadThreadPropagation:
 
         assert handler._uploader.num_threads == 64
         assert peak > 4
+
+    def test_doc_uploader_keeps_the_count_when_the_process_sees_the_default(self):
+        """The jsonl path carries the count the same way the chunk path does."""
+        handler = self._handler(64, for_jsonl=True)
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.extraction_num_threads_per_worker = 4
+            config.s3 = MagicMock()
+            list(handler.accept([_doc('src-0', 2)]))
+
+        assert handler._uploader.num_threads == 64
+        assert handler._uploader._num_threads() == 64
+
+    def test_downloader_keeps_the_count_when_the_process_sees_the_default(self):
+        """Read back runs in a spawned worker too, and needs the same count."""
+        handler = self._handler(64)
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.extraction_num_threads_per_worker = 4
+            config.s3 = MagicMock()
+            config.s3.get_paginator.return_value.paginate.return_value = []
+            list(iter(handler))
+
+        assert handler._downloader._num_threads() == 64
 
     def test_uploader_falls_back_to_config_when_built_directly(self):
         uploader = S3ChunkUploader(bucket_name='b', collection_prefix='p')

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -817,3 +817,71 @@ class TestS3ChunkUploaderConcurrency:
             yielded = list(uploader.upload([_doc(f'src-{i}', 2) for i in range(4)]))
 
         assert [d.source_id() for d in yielded] == [f'src-{i}' for i in range(4)]
+
+
+class TestUploadThreadPropagation:
+    """
+    The thread count has to reach the process that does the uploading.
+
+    S3BasedDocs is built where GraphRAGConfig was configured; accept() runs in a
+    worker spawned by run_pipeline, which sees the default instead.
+    """
+
+    def _handler(self, configured_threads, num_threads=None):
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.extraction_num_threads_per_worker = configured_threads
+            return S3BasedDocs(
+                region='us-east-1',
+                bucket_name='test-bucket',
+                key_prefix='prefix',
+                num_threads=num_threads,
+            )
+
+    def test_thread_count_is_captured_at_construction(self):
+        handler = self._handler(64)
+
+        assert handler.num_threads == 64
+
+    def test_explicit_thread_count_wins_over_config(self):
+        handler = self._handler(64, num_threads=8)
+
+        assert handler.num_threads == 8
+
+    def test_uploader_keeps_the_count_when_the_process_sees_the_default(self):
+        """Stands in for the spawned worker: same handler, config back at 4."""
+        handler = self._handler(64)
+
+        peak = 0
+        inflight = 0
+        lock = threading.Lock()
+
+        def on_put(**kwargs):
+            nonlocal peak, inflight
+            with lock:
+                inflight += 1
+                peak = max(peak, inflight)
+            time.sleep(0.02)
+            with lock:
+                inflight -= 1
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.extraction_num_threads_per_worker = 4
+            config.s3 = MagicMock()
+            config.s3.put_object = on_put
+            list(handler.accept([_doc(f'src-{i}', 2) for i in range(64)]))
+
+        assert handler._uploader.num_threads == 64
+        assert peak > 4
+
+    def test_uploader_falls_back_to_config_when_built_directly(self):
+        uploader = S3ChunkUploader(bucket_name='b', collection_prefix='p')
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.extraction_num_threads_per_worker = 7
+            assert uploader._num_threads() == 7


### PR DESCRIPTION
## Description

`S3ChunkUploader` drained one source document's chunk uploads before submitting the next, so in-flight uploads were bounded by a single document's chunk count, not by the thread pool. The WikiHow corpus averages 3.31 chunks per document, so most of the pool sat idle at any size. A thread sweep measured the write phase at ~13 minutes for 16, 32 and 64 threads alike, while extraction either side of it halved with each doubling.

The pool was also sized wrong. `S3BasedDocs` read `GraphRAGConfig.extraction_num_threads_per_worker` at upload time, inside a worker spawned by `run_pipeline` that inherits no parent memory, so a run asking for 64 uploaded with the default of 4.

End to end this is 1.15x on the same LLM work, with byte-identical output.

## Changes

- `S3ChunkUploader.upload` keeps a bounded window of documents in flight. Documents are still yielded in order, and still only once their own chunk uploads have been attempted.
- Thread count is resolved in `S3BasedDocs.__init__`, which runs in the process that configured `GraphRAGConfig`, and carried as a field so it pickles with the handler, the same trip an extractor's `num_workers` already makes.
- A `ConfiguredThreadCount` mixin holds the count-or-config fallback; both uploaders and both downloaders use it, so read back is sized by whatever configured the writer.

## Problem

Uploads to the S3 doc store did not scale with `extraction_num_threads_per_worker`: the uploader never queued enough work to use the pool, and the pool was sized from a config read in the wrong process.

Related issue (if any): #

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

`pytest tests/unit`: 1981 passed. The one error, `test_integ_dependency_compatibility::test_boto3_botocore_version_alignment`, is a pre-existing pip-resolution failure unrelated to this change.

New tests cover cross-document overlap (a `threading.Barrier` that only releases on genuinely simultaneous uploads, so it fails against the serial version), yield order, each chunk uploaded exactly once, the `INDEX_KEY` skip, a failed chunk not stopping the stream, and the thread count surviving into an uploader and a downloader whose process sees the default.

Measured against the WikiHow benchmark corpus on real S3, output byte-identical to the previous implementation.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

`num_threads` is now resolved when `S3BasedDocs` is constructed, so setting `GraphRAGConfig.extraction_num_threads_per_worker` afterwards no longer affects it. The call sites in `benchmarks/scripts/benchmark_extract.py` and the integration-test scripts read the value from the environment, which the config picks up lazily, so none are affected.

A failed chunk upload is logged, not raised, and its document is still yielded. That is unchanged behaviour, but it means a yielded document doesn't guarantee every chunk reached S3. The docstring now says so.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
