### PR TITLE
[FIX] Validate ids used to build FileSystemTap output paths

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/file_system_tap.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/file_system_tap.py
@@ -53,6 +53,24 @@ class FileSystemTap(PipelineDecorator):
         self.chunks_dir = chunks_dir
         self.sources_dir = sources_dir
 
+    @staticmethod
+    def _validate_id(value:str, name:str) -> None:
+        """
+        Reject an id that would write outside the directories the tap prepared.
+
+        Output paths join an id onto a prepared directory, so a separator in the
+        id opens a new path segment and a climbing id lands anywhere. Rewritten
+        ids are IdGenerator hashes and carry no separator.
+        """
+        if not value or not value.strip():
+            raise ValueError(f'{name} must be a non-empty string.')
+        if '/' in value or '\\' in value:
+            raise ValueError(f'{name} must not contain a path separator: {value!r}')
+        if any(ord(c) < 0x20 or ord(c) == 0x7f for c in value):
+            raise ValueError(f'{name} must not contain control characters: {value!r}')
+        if value.strip() in ('.', '..'):
+            raise ValueError(f'{name} must not name a directory: {value!r}')
+
     def handle_input_docs(self, docs:Iterable[SourceDocument]) -> Iterable[SourceDocument]:
         """
         Processes a collection of source documents, saving their raw textual content and JSON representation
@@ -69,6 +87,7 @@ class FileSystemTap(PipelineDecorator):
         for doc in docs:
             if doc.refNode and isinstance(doc.refNode, Document):
                 ref_node = doc.refNode
+                self._validate_id(ref_node.doc_id, 'doc_id')
                 raw_source_output_path = join(self.raw_sources_dir, ref_node.doc_id)
                 source_output_path = join(self.sources_dir, f'{ref_node.doc_id}.json')
                 with open(raw_source_output_path, 'w') as f:
@@ -91,6 +110,7 @@ class FileSystemTap(PipelineDecorator):
                 unmodified.
         """
         for node in doc.nodes:
+            self._validate_id(node.node_id, 'node_id')
             chunk_output_path = join(self.chunks_dir, f'{node.node_id}.json')
             with open(chunk_output_path, 'w') as f:
                 json.dump(node.to_dict(), f, indent=4)
@@ -135,8 +155,3 @@ class FileSystemTap(PipelineDecorator):
             os.makedirs(sources_dir)
   
         return (raw_sources_dir, chunks_dir, sources_dir)
-    
-
-
-
-    

--- a/lexical-graph/tests/unit/indexing/extract/test_file_system_tap.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_file_system_tap.py
@@ -346,3 +346,114 @@ class TestFileSystemTapIntegration:
             assert os.path.exists(os.path.join(tap.sources_dir, "doc1.json"))
             assert os.path.exists(os.path.join(tap.chunks_dir, "chunk1.json"))
             assert os.path.exists(os.path.join(tap.chunks_dir, "chunk2.json"))
+
+
+def _files_under(root):
+    """Every file below `root`, so a test can assert nothing escaped."""
+    return {p for p in Path(root).rglob('*') if p.is_file()}
+
+
+def _doc(doc_id, text='Test document content'):
+    return SourceDocument(refNode=Document(text=text, doc_id=doc_id))
+
+
+class TestFileSystemTapIdValidation:
+    """The tap builds output paths from ids it is handed, so an id carrying a
+    path separator would write outside the directories it prepared."""
+
+    def test_no_file_is_written_outside_the_output_directory(self):
+        """An id that climbs is refused, and nothing lands anywhere else."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = os.path.join(temp_dir, 'out')
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=output_dir
+            )
+
+            before = _files_under(temp_dir)
+
+            with pytest.raises(ValueError):
+                tap.handle_input_docs([_doc('../../escaped')])
+
+            assert _files_under(temp_dir) == before
+
+    @pytest.mark.parametrize('doc_id', ['a/b', 'a\\b', '../b', '/abs'])
+    def test_doc_id_with_a_path_separator_is_rejected(self, doc_id):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=temp_dir
+            )
+
+            with pytest.raises(ValueError, match='separator'):
+                tap.handle_input_docs([_doc(doc_id)])
+
+    @pytest.mark.parametrize('doc_id', ['a\nb', 'a\tb', 'a\x00b', 'a\x7fb'])
+    def test_doc_id_with_a_control_character_is_rejected(self, doc_id):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=temp_dir
+            )
+
+            with pytest.raises(ValueError, match='control character'):
+                tap.handle_input_docs([_doc(doc_id)])
+
+    @pytest.mark.parametrize('doc_id', ['', '   '])
+    def test_doc_id_that_is_empty_is_rejected(self, doc_id):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=temp_dir
+            )
+
+            with pytest.raises(ValueError, match='non-empty'):
+                tap.handle_input_docs([_doc(doc_id)])
+
+    @pytest.mark.parametrize('doc_id', ['.', '..'])
+    def test_doc_id_that_names_a_directory_is_rejected(self, doc_id):
+        """Neither can climb without a separator, but both resolve to a
+        directory and would otherwise fail inside open() with no id named."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=temp_dir
+            )
+
+            with pytest.raises(ValueError, match='directory'):
+                tap.handle_input_docs([_doc(doc_id)])
+
+    def test_node_id_with_a_path_separator_is_rejected(self):
+        """The chunk write builds its path the same way as the source writes."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=temp_dir
+            )
+
+            doc = _doc('doc1')
+            doc.nodes = [TextNode(text="chunk", id_="../escaped")]
+
+            with pytest.raises(ValueError, match='separator'):
+                tap.handle_output_doc(doc)
+
+    def test_a_rewritten_id_still_writes_both_files(self):
+        """The ids the pipeline actually produces carry no separator."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tap = FileSystemTap(
+                subdirectory_name="test_run",
+                clean=True,
+                output_dir=temp_dir
+            )
+
+            doc_id = 'aws::1a2b3c4d:5e6f'
+            tap.handle_input_docs([_doc(doc_id)])
+
+            assert os.path.exists(os.path.join(tap.raw_sources_dir, doc_id))
+            assert os.path.exists(os.path.join(tap.sources_dir, f'{doc_id}.json'))

--- a/lexical-graph/tests/unit/indexing/extract/test_file_system_tap.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_file_system_tap.py
@@ -414,10 +414,11 @@ class TestFileSystemTapIdValidation:
             with pytest.raises(ValueError, match='non-empty'):
                 tap.handle_input_docs([_doc(doc_id)])
 
-    @pytest.mark.parametrize('doc_id', ['.', '..'])
+    @pytest.mark.parametrize('doc_id', ['.', '..', ' . ', ' .. '])
     def test_doc_id_that_names_a_directory_is_rejected(self, doc_id):
         """Neither can climb without a separator, but both resolve to a
-        directory and would otherwise fail inside open() with no id named."""
+        directory and would otherwise fail inside open() with no id named.
+        The padded forms are rejected on the same stripped comparison."""
         with tempfile.TemporaryDirectory() as temp_dir:
             tap = FileSystemTap(
                 subdirectory_name="test_run",


### PR DESCRIPTION
## Description

`FileSystemTap` builds its output paths by joining an id onto a directory it prepared, with no validation of the id. An id carrying a path separator opens a new path segment, so the write lands outside the directory the tap owns. This adds an id check at the three places the tap does that join.

The tap is opt-in. `ExtractionPipeline` defaults its decorator to `PassThroughDecorator`, and nothing in the toolkit constructs a `FileSystemTap`, so a default pipeline never reaches this code. In a pipeline that does use it, ids have normally been rewritten to `IdGenerator` hashes first, and those carry no separator.

## Changes

- `FileSystemTap._validate_id` rejects an id that is empty or whitespace only, contains a path separator, contains a control character, or names a directory. It is a blocklist, not the allowlist regex `S3ChunkStore._validate_chunk_id` uses. Filenames legitimately carry characters an S3 key allowlist has no reason to permit, and control characters and `.`/`..`, which are valid in an S3 key, have to be refused for a filesystem write.
- Called before the two source writes in `handle_input_docs`, and before the chunk write in `handle_output_doc`. That third site builds its path the same way and needed the same check.
- Rejecting separators is what makes a relative segment inert, so there is no separate parent-reference case.

## Problem

Ids reaching the tap are not guaranteed to have been rewritten, and the tap trusted them to be usable as filenames. Ids the pipeline produces are unaffected, since they hold no separators.

Related issue (if any): #

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

New tests cover each rejected form for both `doc_id` and `node_id`, a containment check that snapshots every file under the temp root and asserts nothing new appears outside the tap's own directories, and a rewritten id in the usual hash form still writing both of its files. They were written and run red against the unfixed code first. The existing tests in that file already write to real temp directories, so the check is exercised against a real filesystem rather than a mock.

`file_system_tap.py` is at 100% statement coverage. Full suite: 2073 passed, 15 skipped, 65.23% total against the 56% gate. The one error, `test_integ_dependency_compatibility::test_boto3_botocore_version_alignment`, is a pre-existing pip-resolution failure unrelated to this change.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

One behaviour change: an id that would previously have written outside the tap's directories now raises `ValueError`. No id the pipeline produces is affected, and no default pipeline reaches this code.

The end of the file also lost some trailing whitespace and gained a final newline. Both were pre-existing.

Not addressed here: `IdRewriter._new_id` returns an id unchanged when it already starts with `aws:`, so a caller can supply one that is never hashed. That is a separate concern and needs its own change.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

