### PR TITLE
[FEATURE] Add a source-id key collision generator to benchmarks

### DIFF
--- a/.github/workflows/benchmarks-tests.yml
+++ b/.github/workflows/benchmarks-tests.yml
@@ -1,0 +1,59 @@
+# Runs the benchmarks unit tests on push/PR to main. The lexical-graph
+# workflow is scoped to lexical-graph/**, so nothing was running these.
+name: Benchmarks Unit Tests
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "benchmarks/**"
+      - ".github/workflows/benchmarks-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "benchmarks/**"
+      - ".github/workflows/benchmarks-tests.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Create virtual environment
+        run: uv venv --seed .venv
+
+      - name: Install dependencies
+        # The benchmarks import graphrag_toolkit, so lexical-graph and its
+        # requirements come first. Separate commands: requirements.txt opens
+        # with `--only-binary :all:`, which would block building the local
+        # package if combined.
+        env:
+          # Copy instead of hardlink into the venv so bundled data files have
+          # st_nlink=1; nltk's pathsec check refuses to open multiply-linked files.
+          UV_LINK_MODE: copy
+        run: |
+          uv pip install --python .venv/bin/python \
+            -r lexical-graph/src/graphrag_toolkit/lexical_graph/requirements.txt
+          uv pip install --python .venv/bin/python -e ./lexical-graph
+          uv pip install --python .venv/bin/python -r benchmarks/requirements.txt
+
+      - name: Run tests
+        env:
+          HYPOTHESIS_PROFILE: ci
+          PYTHONPATH: benchmarks
+        run: |
+          .venv/bin/python -m pytest -v -l --tb=short benchmarks/tests/

--- a/.github/workflows/benchmarks-tests.yml
+++ b/.github/workflows/benchmarks-tests.yml
@@ -54,6 +54,5 @@ jobs:
       - name: Run tests
         env:
           HYPOTHESIS_PROFILE: ci
-          PYTHONPATH: benchmarks
         run: |
           .venv/bin/python -m pytest -v -l --tb=short benchmarks/tests/

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -9,6 +9,7 @@
 # llama-index-llms-bedrock-converse, boto3, botocore) is assumed to be
 # installed separately via `pip install -e ./lexical-graph`.
 
+numpy>=1.24.0
 python-dotenv>=1.0.0
 boto3>=1.28.0
 botocore>=1.31.0

--- a/benchmarks/tests/conftest.py
+++ b/benchmarks/tests/conftest.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmarks test configuration.
+
+Mirrors lexical-graph/tests/conftest.py so HYPOTHESIS_PROFILE=ci reaches the
+property-based tests under benchmarks/tests too. Without it the workflow's
+env var is inert and the tests run at the default 100 examples with a 200 ms
+deadline, which is where a slow runner turns them flaky.
+
+Activate with:  HYPOTHESIS_PROFILE=ci pytest ...
+"""
+
+import os
+from hypothesis import settings, HealthCheck
+
+settings.register_profile(
+    "default",
+    max_examples=100,
+)
+
+settings.register_profile(
+    "ci",
+    max_examples=20,
+    deadline=5000,  # 5 seconds per example
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+# Load the profile selected by env var, falling back to "default"
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))

--- a/benchmarks/tests/test_key_collisions.py
+++ b/benchmarks/tests/test_key_collisions.py
@@ -94,8 +94,9 @@ class TestKeyGeneration(unittest.TestCase):
 
     def test_absent_metadata_leaves_32_bits_discriminating(self):
         keys = source_keys(synthetic_texts(64), with_metadata=False)
-        # The low 16 bits are md5('')[:4] for every document.
-        self.assertEqual(len({k & 0xFFFF for k in keys}), 1)
+        # The low 16 bits are md5('')[:4] for every document. int() first:
+        # numpy before 2.0 refuses to mask a uint64 with a Python int.
+        self.assertEqual(len({int(k) & 0xFFFF for k in keys}), 1)
 
     def test_present_metadata_varies_the_second_component(self):
         keys = source_keys(synthetic_texts(64), with_metadata=True)

--- a/benchmarks/tests/test_key_collisions.py
+++ b/benchmarks/tests/test_key_collisions.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from benchmarks.utils.key_collisions import (
+    chunk_keys,
+    count_collisions,
+    create_chunk_id,
+    create_source_id,
+    duplicate_pairs,
+    expected_pairs,
+    source_keys,
+    synthetic_texts,
+)
+
+
+class TestIdFidelity(unittest.TestCase):
+    """
+    These reproduce IdGenerator. If they drift, every number this module
+    produces describes a key the toolkit does not write.
+    """
+
+    def test_source_id_shape(self):
+        # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
+        self.assertEqual(create_source_id('hello world', ''), 'aws::5eb63bbb:d41d')
+
+    def test_chunk_id_appends_to_the_source_id(self):
+        source_id = create_source_id('hello world', '')
+
+        self.assertEqual(
+            create_chunk_id(source_id, 'hello world', ''),
+            'aws::5eb63bbb:d41d:5eb63bbb',
+        )
+
+
+class TestCountCollisions(unittest.TestCase):
+
+    def test_counts_pairs_not_excess_documents(self):
+        # One key three times is three pairs, not two extra documents.
+        self.assertEqual(count_collisions([7, 7, 7])['colliding_pairs'], 3)
+
+    def test_reports_the_largest_group(self):
+        self.assertEqual(count_collisions([1, 1, 1, 2])['max_group'], 3)
+
+    def test_distinct_keys_do_not_collide(self):
+        stats = count_collisions([1, 2, 3])
+
+        self.assertEqual(stats['colliding_pairs'], 0)
+        self.assertEqual(stats['distinct'], 3)
+
+    def test_handles_keys_wider_than_uint64(self):
+        # Composite source-plus-chunk keys are 80 bits, past the numpy path.
+        wide = 2 ** 79
+
+        self.assertEqual(count_collisions([wide, wide])['colliding_pairs'], 1)
+
+    def test_empty(self):
+        self.assertEqual(count_collisions([])['colliding_pairs'], 0)
+
+
+class TestDuplicatePairs(unittest.TestCase):
+
+    def test_identical_texts_pair_up(self):
+        self.assertEqual(duplicate_pairs(['a', 'a', 'a', 'b']), 3)
+
+    def test_distinct_texts_have_no_pairs(self):
+        self.assertEqual(duplicate_pairs(['a', 'b']), 0)
+
+
+class TestKeyGeneration(unittest.TestCase):
+
+    def test_absent_metadata_leaves_32_bits_discriminating(self):
+        keys = source_keys(synthetic_texts(64), with_metadata=False)
+        # The low 16 bits are md5('')[:4] for every document.
+        self.assertEqual(len({k & 0xFFFF for k in keys}), 1)
+
+    def test_present_metadata_varies_the_second_component(self):
+        keys = source_keys(synthetic_texts(64), with_metadata=True)
+
+        self.assertGreater(len({int(k) & 0xFFFF for k in keys}), 1)
+
+    def test_chunk_keys_are_three_per_document_by_default(self):
+        self.assertEqual(len(chunk_keys(synthetic_texts(10), False)), 30)
+
+
+class TestExpectedPairs(unittest.TestCase):
+
+    def test_matches_the_closed_form_at_1m_on_32_bits(self):
+        # n(n-1) / 2 * 2^32, the figure the design doc quotes.
+        self.assertAlmostEqual(expected_pairs(1_000_000, 32), 116.4, places=1)
+
+    def test_wider_keys_collide_less(self):
+        self.assertLess(expected_pairs(10 ** 6, 48), expected_pairs(10 ** 6, 32))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/benchmarks/tests/test_key_collisions.py
+++ b/benchmarks/tests/test_key_collisions.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+
 from benchmarks.utils.key_collisions import (
     chunk_keys,
     count_collisions,
@@ -21,9 +23,29 @@ class TestIdFidelity(unittest.TestCase):
     produces describes a key the toolkit does not write.
     """
 
+    def test_source_id_matches_the_id_generator(self):
+        generator = IdGenerator()
+
+        for text, metadata_str in [('hello world', ''), ('', ''), ('doc 1', 'file_path:a.txt')]:
+            self.assertEqual(
+                create_source_id(text, metadata_str),
+                generator.create_source_id(text, metadata_str),
+            )
+
     def test_source_id_shape(self):
         # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
         self.assertEqual(create_source_id('hello world', ''), 'aws::5eb63bbb:d41d')
+
+    def test_chunk_id_matches_the_id_generator(self):
+        source_id = create_source_id('hello world', '')
+
+        for use_delimiter in [False, True]:
+            generator = IdGenerator(use_chunk_id_delimiter=use_delimiter)
+            for text, metadata_str in [('hello world', ''), ('a', 'bc'), ('ab', 'c')]:
+                self.assertEqual(
+                    create_chunk_id(source_id, text, metadata_str, use_delimiter),
+                    generator.create_chunk_id(source_id, text, metadata_str),
+                )
 
     def test_chunk_id_appends_to_the_source_id(self):
         source_id = create_source_id('hello world', '')
@@ -87,7 +109,7 @@ class TestKeyGeneration(unittest.TestCase):
 class TestExpectedPairs(unittest.TestCase):
 
     def test_matches_the_closed_form_at_1m_on_32_bits(self):
-        # n(n-1) / 2 * 2^32, the figure the design doc quotes.
+        # n(n-1) / (2 * 2^32), the figure the design doc quotes.
         self.assertAlmostEqual(expected_pairs(1_000_000, 32), 116.4, places=1)
 
     def test_wider_keys_collide_less(self):

--- a/benchmarks/utils/key_collisions.py
+++ b/benchmarks/utils/key_collisions.py
@@ -27,6 +27,9 @@ from collections import Counter
 import numpy as np
 
 
+CHUNK_ID_DELIMITER = '\x00'
+
+
 def get_hash(s: str) -> str:
     """Reproduces indexing/utils/hash_utils.py::get_hash."""
     return hashlib.md5(s.encode('utf-8'), usedforsecurity=False).digest().hex()
@@ -37,9 +40,19 @@ def create_source_id(text: str, metadata_str: str) -> str:
     return f'aws::{get_hash(text)[:8]}:{get_hash(metadata_str)[:4]}'
 
 
-def create_chunk_id(source_id: str, text: str, metadata_str: str) -> str:
-    """Reproduces IdGenerator.create_chunk_id with the delimiter off (the default)."""
-    return f'{source_id}:{get_hash(text + metadata_str)[:8]}'
+def create_chunk_id(source_id: str, text: str, metadata_str: str,
+                    use_chunk_id_delimiter: bool = False) -> str:
+    """
+    Reproduces IdGenerator.create_chunk_id (indexing/id_generator.py:90).
+
+    With the delimiter on, a null byte separates text from metadata before
+    hashing. It is off by default, as it is in IdGenerator.
+    """
+    if use_chunk_id_delimiter:
+        hash_input = text + CHUNK_ID_DELIMITER + metadata_str
+    else:
+        hash_input = text + metadata_str
+    return f'{source_id}:{get_hash(hash_input)[:8]}'
 
 
 def _key_of(identifier: str) -> int:
@@ -73,14 +86,15 @@ def source_keys(texts, with_metadata):
     return out
 
 
-def chunk_keys(texts, with_metadata, chunks_per_doc=3):
+def chunk_keys(texts, with_metadata, chunks_per_doc=3, use_chunk_id_delimiter=False):
     """Composite source+chunk keys, to test whether chunk width rescues the prefix."""
     out = []
     for i, text in enumerate(texts):
         metadata_str = _metadata_for(i, with_metadata)
         source_id = create_source_id(text, metadata_str)
         for c in range(chunks_per_doc):
-            chunk_id = create_chunk_id(source_id, f'{text}::chunk{c}', metadata_str)
+            chunk_id = create_chunk_id(source_id, f'{text}::chunk{c}', metadata_str,
+                                       use_chunk_id_delimiter)
             out.append(_key_of(chunk_id))
     return out
 
@@ -98,13 +112,12 @@ def corpus_texts(path):
 
 def count_collisions(keys):
     """
-    Source keys fit in uint64 and go through numpy, which is what makes 10M
-    documents tractable. Composite source-plus-chunk keys are 80 bits and do
-    not, so those count through a Counter instead.
+    Source keys fit in uint64 and arrive as a numpy array, which is what makes
+    10M documents tractable. Composite source-plus-chunk keys are 80 bits, so
+    those arrive as a list and count through a Counter instead.
     """
-    keys = list(keys)
-    if keys and max(keys) < 2 ** 64:
-        _, counts = np.unique(np.asarray(keys, dtype=np.uint64), return_counts=True)
+    if isinstance(keys, np.ndarray):
+        _, counts = np.unique(keys, return_counts=True)
         counts = counts.tolist()
     else:
         counts = list(Counter(keys).values())

--- a/benchmarks/utils/key_collisions.py
+++ b/benchmarks/utils/key_collisions.py
@@ -1,0 +1,171 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Measure storage-key collisions for the ids `IdGenerator` produces.
+
+`create_source_id` returns `aws::{md5(text)[:8]}:{md5(metadata_str)[:4]}`, so a
+source id discriminates on 48 bits. `IdRewriter` passes `''` when a node carries
+no metadata, which makes the second component constant and leaves 32 bits. Both
+S3 storage prefixes are built from the bare source id, so two documents sharing
+one share a prefix.
+
+Keys are generated synthetically. Running extraction to produce them would cost
+Bedrock time and measure nothing this question needs.
+
+Two things are counted separately. A hash collision is two different texts
+landing on one key. A duplicate is the same text twice, which produces the same
+key by design and is deduplication rather than a defect. Only the first is a
+reason to change the key.
+"""
+
+import argparse
+import hashlib
+import sys
+from collections import Counter
+
+import numpy as np
+
+
+def get_hash(s: str) -> str:
+    """Reproduces indexing/utils/hash_utils.py::get_hash."""
+    return hashlib.md5(s.encode('utf-8'), usedforsecurity=False).digest().hex()
+
+
+def create_source_id(text: str, metadata_str: str) -> str:
+    """Reproduces IdGenerator.create_source_id (indexing/id_generator.py:84)."""
+    return f'aws::{get_hash(text)[:8]}:{get_hash(metadata_str)[:4]}'
+
+
+def create_chunk_id(source_id: str, text: str, metadata_str: str) -> str:
+    """Reproduces IdGenerator.create_chunk_id with the delimiter off (the default)."""
+    return f'{source_id}:{get_hash(text + metadata_str)[:8]}'
+
+
+def _key_of(identifier: str) -> int:
+    """
+    The hex components of an id, joined and read as one integer.
+
+    Works for a source id and a chunk id alike: both are `aws::` followed by
+    colon-separated hex, so everything past the empty second field is the key.
+    """
+    return int(''.join(identifier.split(':')[2:]), 16)
+
+
+def _metadata_for(i, with_metadata):
+    """Unique per-document metadata, or the empty string IdRewriter defaults to."""
+    return f'file_path:doc-{i}.txt' if with_metadata else ''
+
+
+def _pairs(counts):
+    """Unordered pairs within each group of equal keys."""
+    return sum(c * (c - 1) // 2 for c in counts)
+
+
+def source_keys(texts, with_metadata):
+    """
+    with_metadata False reproduces a corpus loaded without metadata, where every
+    document gets md5('')[:4] as its second component and 32 bits discriminate.
+    """
+    out = np.empty(len(texts), dtype=np.uint64)
+    for i, text in enumerate(texts):
+        out[i] = _key_of(create_source_id(text, _metadata_for(i, with_metadata)))
+    return out
+
+
+def chunk_keys(texts, with_metadata, chunks_per_doc=3):
+    """Composite source+chunk keys, to test whether chunk width rescues the prefix."""
+    out = []
+    for i, text in enumerate(texts):
+        metadata_str = _metadata_for(i, with_metadata)
+        source_id = create_source_id(text, metadata_str)
+        for c in range(chunks_per_doc):
+            chunk_id = create_chunk_id(source_id, f'{text}::chunk{c}', metadata_str)
+            out.append(_key_of(chunk_id))
+    return out
+
+
+def synthetic_texts(n):
+    """n distinct documents, so every collision found is a hash collision."""
+    return [f'document {i} body text' for i in range(n)]
+
+
+def corpus_texts(path):
+    """One document per line, for measuring real duplicate rates."""
+    with open(path, encoding='utf-8', errors='replace') as f:
+        return [line.rstrip('\n') for line in f if line.strip()]
+
+
+def count_collisions(keys):
+    """
+    Source keys fit in uint64 and go through numpy, which is what makes 10M
+    documents tractable. Composite source-plus-chunk keys are 80 bits and do
+    not, so those count through a Counter instead.
+    """
+    keys = list(keys)
+    if keys and max(keys) < 2 ** 64:
+        _, counts = np.unique(np.asarray(keys, dtype=np.uint64), return_counts=True)
+        counts = counts.tolist()
+    else:
+        counts = list(Counter(keys).values())
+    return {
+        'n': len(keys),
+        'distinct': len(counts),
+        'colliding_pairs': _pairs(counts),
+        'max_group': max(counts) if counts else 0,
+    }
+
+
+def duplicate_pairs(texts):
+    """Pairs of documents sharing identical text, which share a key by design."""
+    return _pairs(Counter(texts).values())
+
+
+def expected_pairs(n, bits):
+    """Birthday expectation, against which the measured count is a check."""
+    return n * (n - 1) / (2 * float(2 ** bits))
+
+
+def p_any_collision(n, bits):
+    """Poisson approximation to the chance of at least one collision."""
+    return 1.0 - np.exp(-n * (n - 1) / (2 * float(2 ** bits)))
+
+
+def _row(label, stats, bits):
+    n = stats['n']
+    return (f"{label:<26} {n:>12,} {stats['colliding_pairs']:>10,} "
+            f"{expected_pairs(n, bits):>14.3f} {stats['max_group']:>6} "
+            f"{p_any_collision(n, bits) * 100:>9.2f}%")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--scales', default='100000,1000000,10000000')
+    parser.add_argument('--corpus', help='one document per line, to measure duplicates')
+    args = parser.parse_args(argv)
+
+    if args.corpus:
+        texts = corpus_texts(args.corpus)
+        unique_texts = len(set(texts))
+        keys = source_keys(texts, with_metadata=False)
+        stats = count_collisions(keys)
+        dup_pairs = duplicate_pairs(texts)
+        print(f'corpus: {len(texts):,} documents, {unique_texts:,} distinct texts')
+        print(f'  pairs sharing text (deduplication, by design): {dup_pairs:,}')
+        print(f'  pairs sharing a key: {stats["colliding_pairs"]:,}')
+        print(f'  hash collisions: {stats["colliding_pairs"] - dup_pairs:,}')
+        return 0
+
+    header = (f"{'case':<26} {'documents':>12} {'collided':>10} "
+              f"{'expected':>14} {'worst':>6} {'P(any)':>10}")
+    print(header)
+    print('-' * len(header))
+    for n in [int(s) for s in args.scales.split(',')]:
+        texts = synthetic_texts(n)
+        print(_row('metadata absent (32 bit)', count_collisions(source_keys(texts, False)), 32))
+        print(_row('metadata present (48 bit)', count_collisions(source_keys(texts, True)), 48))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds a tool that measures how often `IdGenerator` produces the same source id for different documents, and a test suite that locks it to the real implementation.

`create_source_id` returns `aws::{md5(text)[:8]}:{md5(metadata_str)[:4]}` (`id_generator.py:84`), so a source id discriminates on 48 bits. `IdRewriter` passes `_get_properties_str(node.metadata, '')` (`id_rewriter.py:74`), so a corpus loaded without metadata gives every document the same second component and 32 bits do the work. Both S3 storage prefixes are built from the bare source id (`s3_based_docs.py:209` and `:434`), so two documents sharing an id share a prefix.

Measured, against a birthday expectation of 116.4 at 1M on 32 bits:

| Documents | Metadata absent (32 bit) | Metadata present (48 bit) |
|---|---|---|
| 100,000 | 1 colliding pair | 0 |
| 1,000,000 | 127 colliding pairs | 0, and a 0.2% chance of any |
| 10,000,000 | 11,762 colliding pairs | 0, and a 16% chance of any |

Nothing in the toolkit changes. This is measurement only, and it feeds the storage-key decision in the restart design.

## Changes

- `benchmarks/utils/key_collisions.py`. Generates ids synthetically and counts collisions against the closed form. Documents sharing text share a key by design, so those pairs are counted apart from hash collisions. `--corpus` measures the duplicate rate on real text. `create_chunk_id` models both `use_chunk_id_delimiter` settings, not only the default.
- `benchmarks/tests/test_key_collisions.py`. 16 tests. `test_source_id_matches_the_id_generator` and `test_chunk_id_matches_the_id_generator` compare the reimplementation against a real `IdGenerator` rather than against hardcoded id literals, so changing the hash slices in `id_generator.py` fails the suite. `IdGenerator()` needs no AWS config or credentials to construct and hash, so the comparison is cheap.
- `benchmarks/requirements.txt`. Adds `numpy>=1.24.0`. The module is the first use of numpy under `benchmarks/`, and it resolved only transitively through `llama-index-core`.

Source keys fit in `uint64` and go through numpy, which is what keeps 10M documents tractable. Composite source-plus-chunk keys are 80 bits and count through a `Counter` instead.

## Problem

Storage prefixes inherit the source id's width. Once completion markers land, two documents sharing a prefix share one marker, which then matches neither and re-stages both on every restart. Sizing that risk needed a number rather than an estimate.

Related issue (if any): #325. The document-level manifest needs storage identity to be unique: two documents sharing a prefix share one completion marker, which then matches neither and re-stages both on every restart.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`) — full `benchmarks/tests` suite, 146 passed
- [x] Tested manually (describe below)

Ran against WikiHow-2000 as a real-corpus check: 2,000 distinct texts, no duplicates, no collisions, which is what 32 bits predicts at that size.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

One deviation worth naming rather than leaving to review: this is the only module in `benchmarks/` with `__main__` and argparse. The tool is meant to be run once by a person, so a CLI seemed right, but say the word and it becomes import-only.

CI now runs these tests. No workflow had a `benchmarks/**` path filter, so nothing was running them and the fidelity check against `IdGenerator` caught drift only when someone ran the suite locally. `benchmarks-tests.yml` closes that, folded in here rather than split out. It runs tests only: two files under `benchmarks/scripts/` predate the license-header convention and a header job would fail on arrival, so that stays a separate change.

`benchmarks/tests/conftest.py` registers the Hypothesis `ci` profile the workflow selects, mirroring `lexical-graph/tests/conftest.py`. Without it the env var is inert and the 49 property tests run at 100 examples against a 200 ms deadline, which is where a slow runner turns them flaky.

One fix on top of the original spike: the low-16-bits assertion masked a numpy `uint64` with a Python int. Before numpy 2.0 that raises `TypeError` — the int becomes `int64` and `uint64 & int64` has no safe common type. `requirements.txt` allows `numpy>=1.24.0`, so the test passed or failed on whatever pip resolved. Casting with `int()` first matches what the neighbouring metadata assertion already did.
