### PR TITLE
[FIX] Notebook AWS_REGION in .env and NextGen OpenSearch VPC endpoint

### DIFF
--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-aurora-postgres.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-aurora-postgres.json
@@ -1149,6 +1149,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-opensearch-serverless.json
@@ -985,6 +985,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-s3-vectors.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics-s3-vectors.json
@@ -1205,6 +1205,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-analytics.json
@@ -642,6 +642,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
@@ -1657,6 +1657,11 @@
                       "Ref": "AWS::Region"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres-existing-vpc.json
@@ -1657,11 +1657,6 @@
                       "Ref": "AWS::Region"
                     },
                     "\" >> .env\n",
-                    "  echo \"export AWS_REGION=",
-                    {
-                      "Ref": "AWS::Region"
-                    },
-                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-aurora-postgres.json
@@ -1547,6 +1547,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json
@@ -1227,12 +1227,22 @@
       }
     },
     "OpenSearchServerlessVpcEndpoint": {
-      "Type": "AWS::OpenSearchServerless::VpcEndpoint",
+      "Type": "AWS::EC2::VPCEndpoint",
       "Condition": "EnableVpcAccess",
       "Properties": {
-        "Name": {
-          "Fn::Sub": "${ApplicationId}-vpce"
+        "ServiceName": {
+          "Fn::Sub": "com.amazonaws.${AWS::Region}.aoss-data"
         },
+        "VpcEndpointType": "Interface",
+        "PrivateDnsEnabled": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${ApplicationId}-vpce"
+            }
+          }
+        ],
         "VpcId": {
           "Fn::If": [
             "CreateVPC",
@@ -1734,6 +1744,11 @@
                     "  echo \"export EVALUATION_MODEL=",
                     {
                       "Ref": "ModelId"
+                    },
+                    "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
                     },
                     "\" >> .env\n",
                     "  chmod -R 700 .\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-nextgen-serverless.json
@@ -92,7 +92,7 @@
       "ConstraintDescription": "Must contain only letters, numbers, and the characters . _ : / -"
     },
     "ExistingVpcId": {
-      "Description": "Optional existing VPC ID to reuse. If provided, ExistingSubnetIds must also be provided. Leave empty to create a new VPC.",
+      "Description": "Optional existing VPC ID to reuse. If provided, ExistingSubnetIds must also be provided. The VPC must have DNS support and DNS hostnames enabled so the OpenSearch Serverless collection endpoint resolves privately over the VPC endpoint. Leave empty to create a new VPC.",
       "Type": "String",
       "Default": ""
     },
@@ -1240,6 +1240,24 @@
             "Key": "Name",
             "Value": {
               "Fn::Sub": "${ApplicationId}-vpce"
+            }
+          },
+          {
+            "Key": "StackId",
+            "Value": {
+              "Fn::Sub": "${AWS::StackId}"
+            }
+          },
+          {
+            "Key": "Stack",
+            "Value": {
+              "Fn::Sub": "${AWS::Region}-${AWS::StackName}"
+            }
+          },
+          {
+            "Key": "Application",
+            "Value": {
+              "Fn::Sub": "graphrag-toolkit:application-id:${ApplicationId}"
             }
           }
         ],

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -1694,6 +1694,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-opensearch-serverless.json
@@ -92,7 +92,7 @@
       "ConstraintDescription": "Must contain only letters, numbers, and the characters . _ : / -"
     },
     "ExistingVpcId": {
-      "Description": "Optional existing VPC ID to reuse. If provided, ExistingSubnetIds must also be provided. Leave empty to create a new VPC.",
+      "Description": "Optional existing VPC ID to reuse. If provided, ExistingSubnetIds must also be provided. The VPC must have DNS support and DNS hostnames enabled so the OpenSearch Serverless collection endpoint resolves privately over the VPC endpoint. Leave empty to create a new VPC.",
       "Type": "String",
       "Default": ""
     },

--- a/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-s3-vectors.json
+++ b/examples/lexical-graph/cloudformation-templates/graphrag-toolkit-neptune-db-s3-vectors.json
@@ -1685,6 +1685,11 @@
                       "Ref": "ModelId"
                     },
                     "\" >> .env\n",
+                    "  echo \"export AWS_REGION=",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    "\" >> .env\n",
                     "  chmod -R 700 .\n",
                     "  chmod 600 .env\n",
                     "  if [ -f \"./run_test_suite.sh\" ]\n",

--- a/lexical-graph/tests/unit/test_aoss_nextgen_cfn_template_parity.py
+++ b/lexical-graph/tests/unit/test_aoss_nextgen_cfn_template_parity.py
@@ -26,6 +26,12 @@ INTENTIONAL_NEW_RESOURCES = {"OpenSearchServerlessCollectionGroup"}
 INTENTIONAL_MODIFIED_RESOURCE = "OpenSearchServerless"
 INTENTIONAL_MODIFIED_FIELDS = {"DependsOn", "CollectionGroupName", "StandbyReplicas"}
 
+# Shared resources that legitimately differ wholesale between Classic and NextGen.
+# NextGen collections use .on.aws endpoints, which require a standard EC2 interface
+# VPC endpoint (com.amazonaws.<region>.aoss-data with PrivateDnsEnabled), whereas Classic
+# uses the OpenSearch Serverless-managed endpoint (AWS::OpenSearchServerless::VpcEndpoint).
+INTENTIONAL_DIVERGENT_RESOURCES = {"OpenSearchServerlessVpcEndpoint"}
+
 # Top-level sections that must be byte-identical between the two templates.
 SHARED_TOP_LEVEL_SECTIONS = ("Parameters", "Rules", "Metadata", "Conditions", "Outputs")
 
@@ -70,6 +76,9 @@ def test_shared_resources_are_identical_except_the_known_delta():
     shared_resource_names = set(classic["Resources"]) & set(nextgen["Resources"])
 
     for name in shared_resource_names:
+        if name in INTENTIONAL_DIVERGENT_RESOURCES:
+            continue
+
         classic_resource = classic["Resources"][name]
         nextgen_resource = nextgen["Resources"][name]
 


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Two fixes for the lexical-graph CloudFormation templates
## Changes

<!-- List the key changes made -->

- Write AWS_REGION into the notebook .env
- Use a standard EC2 interface VPC endpoint for the NextGen collection

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
