### PR TITLE
[FEATURE] Make the source id text digest width configurable

### DIFF
--- a/docs-site/src/content/docs/lexical-graph/configuration.mdx
+++ b/docs-site/src/content/docs/lexical-graph/configuration.mdx
@@ -44,6 +44,7 @@ The configuration includes the following parameters:
 | `embed_dimensions` | Number of dimensions in each vector | `1024` | `EMBEDDINGS_DIMENSIONS` |
 | `extraction_num_workers` | The number of parallel processes to use when running the extract stage | `2` | `EXTRACTION_NUM_WORKERS` |
 | `extraction_num_threads_per_worker` | The number of threads used by each process in the extract stage | `4` | `EXTRACTION_NUM_THREADS_PER_WORKER` |
+| `source_id_hash_length` | Characters of the text digest used in a source id. Widening it separates documents that would otherwise share an id, and changes every source and chunk id, so a graph written at one width cannot be read at another | `8` | `SOURCE_ID_HASH_LENGTH` |
 | `extraction_batch_size` | The number of input nodes to be processed in parallel across all workers in the extract stage | `4` | `EXTRACTION_BATCH_SIZE` |
 | `build_num_workers` | The number of parallel processes to use when running the build stage | `2` | `BUILD_NUM_WORKERS` |
 | `build_batch_size` | The number of input nodes to be processed in parallel across all workers in the build stage | `4` | `BUILD_BATCH_SIZE` |

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -42,6 +42,10 @@ DEFAULT_EMBEDDINGS_DIMENSIONS = 1024
 DEFAULT_EXTRACTION_NUM_WORKERS = 2
 DEFAULT_EXTRACTION_BATCH_SIZE = 4
 DEFAULT_EXTRACTION_NUM_THREADS_PER_WORKER = 4
+# Characters of the text digest that go into a source id. Eight is what every
+# existing graph was written with; an md5 hex digest is 32, which is the ceiling.
+DEFAULT_SOURCE_ID_HASH_LENGTH = 8
+MAX_SOURCE_ID_HASH_LENGTH = 32
 # botocore's own default. Not a chosen value - it's the floor the S3 pool is
 # never sized below. Distinct from DEFAULT_MAX_POOL_CONNECTIONS in
 # neptune_graph_stores, which is that client's chosen size.
@@ -334,6 +338,7 @@ class _GraphRAGConfig:
     _bedrock_reranking_model: Optional[str] = None
     _extraction_num_workers: Optional[int] = None
     _extraction_num_threads_per_worker: Optional[int] = None
+    _source_id_hash_length: Optional[int] = None
     _extraction_batch_size: Optional[int] = None
     _build_num_workers: Optional[int] = None
     _build_batch_size: Optional[int] = None
@@ -696,6 +701,35 @@ class _GraphRAGConfig:
                 each worker during extraction operations.
         """
         self._extraction_num_threads_per_worker = num_threads
+
+    @property
+    def source_id_hash_length(self) -> int:
+        """
+        Characters of the text digest that go into a source id.
+
+        Eight is what every existing graph was written with. A wider setting
+        separates documents that would otherwise share an id, and changes every
+        source id and chunk id, so a graph written at one length cannot be read
+        at another.
+
+        Returns:
+            int: The number of digest characters used in a source id.
+        """
+        if self._source_id_hash_length is None:
+            self.source_id_hash_length = int(
+                os.environ.get('SOURCE_ID_HASH_LENGTH', DEFAULT_SOURCE_ID_HASH_LENGTH))
+
+        return self._source_id_hash_length
+
+    @source_id_hash_length.setter
+    def source_id_hash_length(self, hash_length: int) -> None:
+        """
+        Sets the number of digest characters used in a source id.
+
+        Args:
+            hash_length (int): The number of digest characters.
+        """
+        self._source_id_hash_length = hash_length
 
     @property
     def extraction_batch_size(self) -> int:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -728,7 +728,16 @@ class _GraphRAGConfig:
 
         Args:
             hash_length (int): The number of digest characters.
+
+        Raises:
+            ValueError: If hash_length falls outside the md5 digest.
         """
+        if hash_length is not None and not 1 <= hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
+            raise ValueError(
+                f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '
+                f'[source_id_hash_length: {hash_length}]'
+            )
+
         self._source_id_hash_length = hash_length
 
     @property

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -234,8 +234,7 @@ class BuildPipeline():
             source_metadata_formatter=source_metadata_formatter, 
             id_generator=IdGenerator(
                 tenant_id=tenant_id, 
-                include_classification_in_entity_id=include_classification_in_entity_id,
-                source_id_hash_length=GraphRAGConfig.source_id_hash_length
+                include_classification_in_entity_id=include_classification_in_entity_id
             )
         )
         self.node_filter = NodeFilter() if not checkpoint else checkpoint.add_filter(NodeFilter(), tenant_id)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -234,7 +234,8 @@ class BuildPipeline():
             source_metadata_formatter=source_metadata_formatter, 
             id_generator=IdGenerator(
                 tenant_id=tenant_id, 
-                include_classification_in_entity_id=include_classification_in_entity_id
+                include_classification_in_entity_id=include_classification_in_entity_id,
+                source_id_hash_length=GraphRAGConfig.source_id_hash_length
             )
         )
         self.node_filter = NodeFilter() if not checkpoint else checkpoint.add_filter(NodeFilter(), tenant_id)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -254,7 +254,8 @@ class ExtractionPipeline():
 
         id_generator=IdGenerator(
             tenant_id=tenant_id, 
-            include_classification_in_entity_id=include_classification_in_entity_id
+            include_classification_in_entity_id=include_classification_in_entity_id,
+            source_id_hash_length=GraphRAGConfig.source_id_hash_length
         )
         
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -31,7 +31,7 @@ class IdGenerator(BaseModel):
     use_chunk_id_delimiter:bool
     source_id_hash_length:int
 
-    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=DEFAULT_SOURCE_ID_HASH_LENGTH):
+    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=None):
         """
         Initialize the IdGenerator.
 
@@ -41,13 +41,15 @@ class IdGenerator(BaseModel):
             use_chunk_id_delimiter: Whether to use delimiter in chunk ID hashing to prevent
                 boundary collisions. Defaults to False for backward compatibility with existing
                 graphs. Set to True for new graphs to enable collision-resistant hashing.
-            source_id_hash_length: Characters of the text digest used in a source ID. Eight
-                is what existing graphs were written with. A wider setting separates documents
-                that would otherwise share an ID, and changes every source and chunk ID.
+            source_id_hash_length: Characters of the text digest used in a source ID.
+                Defaults to the configured value. Eight is what existing graphs were
+                written with; widening it changes every source and chunk ID.
 
         Raises:
-            ValueError: If source_id_hash_length falls outside the digest.
+            ValueError: If the resolved width falls outside the digest.
         """
+        source_id_hash_length = coalesce(source_id_hash_length, GraphRAGConfig.source_id_hash_length)
+
         if not 1 <= source_id_hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
             raise ValueError(
                 f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 from graphrag_toolkit.lexical_graph import TenantId, GraphRAGConfig
+from graphrag_toolkit.lexical_graph.config import DEFAULT_SOURCE_ID_HASH_LENGTH, MAX_SOURCE_ID_HASH_LENGTH
 from graphrag_toolkit.lexical_graph.indexing.utils.hash_utils import get_hash
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
@@ -28,8 +29,9 @@ class IdGenerator(BaseModel):
     tenant_id:TenantId
     include_classification_in_entity_id:bool
     use_chunk_id_delimiter:bool
+    source_id_hash_length:int
 
-    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False):
+    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=DEFAULT_SOURCE_ID_HASH_LENGTH):
         """
         Initialize the IdGenerator.
 
@@ -39,11 +41,24 @@ class IdGenerator(BaseModel):
             use_chunk_id_delimiter: Whether to use delimiter in chunk ID hashing to prevent
                 boundary collisions. Defaults to False for backward compatibility with existing
                 graphs. Set to True for new graphs to enable collision-resistant hashing.
+            source_id_hash_length: Characters of the text digest used in a source ID. Eight
+                is what existing graphs were written with. A wider setting separates documents
+                that would otherwise share an ID, and changes every source and chunk ID.
+
+        Raises:
+            ValueError: If source_id_hash_length falls outside the digest.
         """
+        if not 1 <= source_id_hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
+            raise ValueError(
+                f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '
+                f'[source_id_hash_length: {source_id_hash_length}]'
+            )
+
         super().__init__(
             tenant_id=tenant_id or TenantId(),
             include_classification_in_entity_id=coalesce(include_classification_in_entity_id, GraphRAGConfig.include_classification_in_entity_id),
-            use_chunk_id_delimiter=use_chunk_id_delimiter
+            use_chunk_id_delimiter=use_chunk_id_delimiter,
+            source_id_hash_length=source_id_hash_length
         )
 
     def _get_hash(self, s):
@@ -81,7 +96,7 @@ class IdGenerator(BaseModel):
             hashed substrings derived from the input text and metadata.
 
         """
-        return f"aws::{self._get_hash(text)[:8]}:{self._get_hash(metadata_str)[:4]}"
+        return f"aws::{self._get_hash(text)[:self.source_id_hash_length]}:{self._get_hash(metadata_str)[:4]}"
 
     # Delimiter used to separate text and metadata in chunk ID hashing.
     # Using null byte as it cannot appear in valid UTF-8 text strings.

--- a/lexical-graph/tests/unit/indexing/test_id_generator.py
+++ b/lexical-graph/tests/unit/indexing/test_id_generator.py
@@ -1,8 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+
 import pytest
-from unittest.mock import patch
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.schema import Document, NodeRelationship
@@ -464,6 +465,18 @@ def test_id_generator_tenant_isolation_property(tenant_id1, tenant_id2):
 
 
 
+@pytest.fixture(autouse=True)
+def isolated_hash_length(monkeypatch):
+    """
+    The width is env-backed and cached on the config, so a value left in either
+    place changes ids for every test that follows.
+    """
+    monkeypatch.delenv('SOURCE_ID_HASH_LENGTH', raising=False)
+    GraphRAGConfig.source_id_hash_length = None
+    yield
+    GraphRAGConfig.source_id_hash_length = None
+
+
 class TestSourceIdHashLength:
     """
     A source id discriminates on 48 bits, and on 32 when a document carries no
@@ -494,14 +507,24 @@ class TestSourceIdHashLength:
 
         assert wide.split(':')[-1] == narrow.split(':')[-1]
 
-    def test_widening_separates_texts_that_collide_at_eight_characters(self):
-        narrow, wide = IdGenerator(), IdGenerator(source_id_hash_length=32)
-        a, b = 'first document', 'second document'
+    def test_widening_separates_texts_that_collide_at_a_narrow_width(self):
+        narrow, wide = IdGenerator(source_id_hash_length=2), IdGenerator(source_id_hash_length=32)
+        a, b = self._colliding_texts(width=2)
 
-        with patch.object(narrow, '_get_hash', side_effect=lambda s: 'c0ffee' + '0' * 26):
-            assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
-
+        assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
         assert wide.create_source_id(a, '') != wide.create_source_id(b, '')
+
+    @staticmethod
+    def _colliding_texts(width):
+        """Two different texts whose digests agree on the first `width` characters."""
+        seen = {}
+        for i in range(100000):
+            text = f'document {i}'
+            prefix = hashlib.md5(text.encode('utf-8')).hexdigest()[:width]
+            if prefix in seen:
+                return seen[prefix], text
+            seen[prefix] = text
+        raise AssertionError(f'no collision found at width {width}')
 
     def test_chunk_ids_follow_the_wider_source_id(self):
         generator = IdGenerator(source_id_hash_length=32)
@@ -519,11 +542,7 @@ class TestSourceIdHashLength:
 
 
 class TestSourceIdHashLengthReachesTheIds:
-    """
-    An unreachable setting is the mistake use_chunk_id_delimiter already made:
-    it exists on IdGenerator and no caller sets it. These cover the path from
-    configuration to the ids a run actually writes.
-    """
+    """Covers the path from configuration to the ids a run writes."""
 
     def _ids(self, hash_length):
         generator = IdGenerator(source_id_hash_length=hash_length)
@@ -540,12 +559,8 @@ class TestSourceIdHashLengthReachesTheIds:
 
     def test_config_reads_the_environment(self, monkeypatch):
         monkeypatch.setenv('SOURCE_ID_HASH_LENGTH', '32')
-        GraphRAGConfig.source_id_hash_length = None
 
-        try:
-            assert GraphRAGConfig.source_id_hash_length == 32
-        finally:
-            GraphRAGConfig.source_id_hash_length = None
+        assert GraphRAGConfig.source_id_hash_length == 32
 
     def test_widening_changes_ids_but_not_chunk_text(self):
         narrow, wide = self._ids(8), self._ids(32)
@@ -559,3 +574,16 @@ class TestSourceIdHashLengthReachesTheIds:
 
         assert len(source_of(wide[0])) > len(source_of(narrow[0]))
         assert source_of(narrow[0]) != source_of(wide[0])
+
+
+class TestSourceIdHashLengthConfig:
+
+    def test_a_bare_generator_takes_the_configured_width(self):
+        GraphRAGConfig.source_id_hash_length = 16
+
+        assert IdGenerator().source_id_hash_length == 16
+
+    @pytest.mark.parametrize('length', [0, -1, 33])
+    def test_the_config_rejects_a_width_outside_the_digest(self, length):
+        with pytest.raises(ValueError):
+            GraphRAGConfig.source_id_hash_length = length

--- a/lexical-graph/tests/unit/indexing/test_id_generator.py
+++ b/lexical-graph/tests/unit/indexing/test_id_generator.py
@@ -2,8 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from unittest.mock import patch
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
+from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.schema import Document, NodeRelationship
+from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
+from graphrag_toolkit.lexical_graph.indexing.extract.id_rewriter import IdRewriter
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
 
 
 class TestCreateChunkIdBackwardCompatible:
@@ -456,3 +462,100 @@ def test_id_generator_tenant_isolation_property(tenant_id1, tenant_id2):
     assert id_parts1[1] != id_parts2[1], \
         f"Tenant components should differ: '{id_parts1[1]}' vs '{id_parts2[1]}'"
 
+
+
+class TestSourceIdHashLength:
+    """
+    A source id discriminates on 48 bits, and on 32 when a document carries no
+    metadata, so distinct documents collide at scale. The text component's width
+    is configurable so the collision rate can be set to the corpus, and it
+    defaults to today's 8 characters because widening it changes every id.
+    """
+
+    def test_defaults_to_eight_characters(self):
+        generator = IdGenerator()
+
+        assert generator.source_id_hash_length == 8
+
+    def test_default_matches_the_shipped_id_exactly(self):
+        # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
+        assert IdGenerator().create_source_id('hello world', '') == 'aws::5eb63bbb:d41d'
+
+    def test_a_wider_setting_lengthens_the_text_component(self):
+        generator = IdGenerator(source_id_hash_length=16)
+
+        source_id = generator.create_source_id('hello world', '')
+
+        assert source_id == 'aws::5eb63bbbe01eeed0:d41d'
+
+    def test_the_metadata_component_is_unchanged_by_the_setting(self):
+        wide = IdGenerator(source_id_hash_length=32).create_source_id('hello world', 'k:v')
+        narrow = IdGenerator().create_source_id('hello world', 'k:v')
+
+        assert wide.split(':')[-1] == narrow.split(':')[-1]
+
+    def test_widening_separates_texts_that_collide_at_eight_characters(self):
+        narrow, wide = IdGenerator(), IdGenerator(source_id_hash_length=32)
+        a, b = 'first document', 'second document'
+
+        with patch.object(narrow, '_get_hash', side_effect=lambda s: 'c0ffee' + '0' * 26):
+            assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
+
+        assert wide.create_source_id(a, '') != wide.create_source_id(b, '')
+
+    def test_chunk_ids_follow_the_wider_source_id(self):
+        generator = IdGenerator(source_id_hash_length=32)
+
+        source_id = generator.create_source_id('hello world', '')
+
+        assert generator.create_chunk_id(source_id, 'hello world', '').startswith(source_id)
+
+    @pytest.mark.parametrize('length', [0, -1, 33])
+    def test_rejects_a_length_outside_the_digest(self, length):
+        # An md5 hex digest is 32 characters, so anything past it silently
+        # truncates and anything below 1 produces a keyless id.
+        with pytest.raises(ValueError):
+            IdGenerator(source_id_hash_length=length)
+
+
+class TestSourceIdHashLengthReachesTheIds:
+    """
+    An unreachable setting is the mistake use_chunk_id_delimiter already made:
+    it exists on IdGenerator and no caller sets it. These cover the path from
+    configuration to the ids a run actually writes.
+    """
+
+    def _ids(self, hash_length):
+        generator = IdGenerator(source_id_hash_length=hash_length)
+        rewriter = IdRewriter(
+            inner=SentenceSplitter(chunk_size=256, chunk_overlap=25),
+            id_generator=generator,
+        )
+        document = Document(text='sentence one. ' * 400, metadata={'file_path': 'a.txt'})
+        chunks = rewriter.handle_source_docs([SourceDocument(nodes=[document])])[0].nodes
+        return chunks
+
+    def test_config_default_leaves_ids_where_they_are(self):
+        assert GraphRAGConfig.source_id_hash_length == 8
+
+    def test_config_reads_the_environment(self, monkeypatch):
+        monkeypatch.setenv('SOURCE_ID_HASH_LENGTH', '32')
+        GraphRAGConfig.source_id_hash_length = None
+
+        try:
+            assert GraphRAGConfig.source_id_hash_length == 32
+        finally:
+            GraphRAGConfig.source_id_hash_length = None
+
+    def test_widening_changes_ids_but_not_chunk_text(self):
+        narrow, wide = self._ids(8), self._ids(32)
+
+        assert [c.text for c in narrow] == [c.text for c in wide]
+        assert [c.id_ for c in narrow] != [c.id_ for c in wide]
+
+    def test_widening_separates_the_source_relationship(self):
+        narrow, wide = self._ids(8), self._ids(32)
+        source_of = lambda c: c.relationships[NodeRelationship.SOURCE].node_id
+
+        assert len(source_of(wide[0])) > len(source_of(narrow[0]))
+        assert source_of(narrow[0]) != source_of(wide[0])


### PR DESCRIPTION
## Description

A source id is `md5(text)[:8]` plus `md5(metadata_str)[:4]` (`id_generator.py:84`), so 48 bits. `IdRewriter` passes `_get_properties_str(node.metadata, '')`, so a corpus loaded without metadata gives every document the same second component and 32 bits discriminate. Measured collision counts on synthetic ids:

| Documents | Metadata absent (32 bit) | Metadata present (48 bit) |
|---|---|---|
| 100,000 | 1 colliding pair | 0 |
| 1,000,000 | 127 colliding pairs | 0, and a 0.2% chance of any |
| 10,000,000 | 11,762 colliding pairs | 0, and a 16% chance of any |

Colliding documents share a `__Source__` node, so chunks from both attach to one document, and they share an S3 storage prefix.

This makes the text component's width a setting rather than a literal. It changes nothing by default.

## Changes

- `IdGenerator` takes `source_id_hash_length`, defaulting to 8, and rejects a length outside the 32-character digest.
- `GraphRAGConfig.source_id_hash_length`, read from `SOURCE_ID_HASH_LENGTH`, following the pattern of the other extraction settings.
- Both `IdGenerator` call sites pass it, so the setting reaches the ids a run writes rather than sitting unreachable on a constructor.

Widening changes every source id and chunk id, since a chunk id embeds the source id, so a graph written at one width cannot be read at another. Chunk text is unaffected: a re-ingest reproduces the same chunks under new ids rather than re-chunking the corpus.

## Problem

Related issue (if any): #325. Restart needs storage identity to be unique, and the same collision merges distinct documents in the graph.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`) — 2,087 in `tests/unit`
- [x] Tested manually (describe below)

Verified end to end through `IdRewriter` and `SentenceSplitter` that widening changes ids while leaving chunk text byte-identical, and that the default produces `aws::5eb63bbb:d41d` for `('hello world', '')` exactly as before.

One pre-existing failure is unrelated and reproduces on a clean tree: `test_integ_dependency_compatibility.py` errors with `No module named pip` in this venv.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

The width to use at scale is still open and is being taken to the team, which is why this ships the mechanism at today's default rather than picking a number.
