### PR TITLE
[FIX] Derive the S3 document key suffix from the document so a retry overwrites

### DIFF
--- a/docs-site/src/content/docs/lexical-graph/configuration.mdx
+++ b/docs-site/src/content/docs/lexical-graph/configuration.mdx
@@ -44,6 +44,7 @@ The configuration includes the following parameters:
 | `embed_dimensions` | Number of dimensions in each vector | `1024` | `EMBEDDINGS_DIMENSIONS` |
 | `extraction_num_workers` | The number of parallel processes to use when running the extract stage | `2` | `EXTRACTION_NUM_WORKERS` |
 | `extraction_num_threads_per_worker` | The number of threads used by each process in the extract stage | `4` | `EXTRACTION_NUM_THREADS_PER_WORKER` |
+| `source_id_hash_length` | Characters of the text digest used in a source id. Widening it separates documents that would otherwise share an id, and changes every source and chunk id, so a graph written at one width cannot be read at another | `8` | `SOURCE_ID_HASH_LENGTH` |
 | `extraction_batch_size` | The number of input nodes to be processed in parallel across all workers in the extract stage | `4` | `EXTRACTION_BATCH_SIZE` |
 | `build_num_workers` | The number of parallel processes to use when running the build stage | `2` | `BUILD_NUM_WORKERS` |
 | `build_batch_size` | The number of input nodes to be processed in parallel across all workers in the build stage | `4` | `BUILD_BATCH_SIZE` |

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -42,6 +42,10 @@ DEFAULT_EMBEDDINGS_DIMENSIONS = 1024
 DEFAULT_EXTRACTION_NUM_WORKERS = 2
 DEFAULT_EXTRACTION_BATCH_SIZE = 4
 DEFAULT_EXTRACTION_NUM_THREADS_PER_WORKER = 4
+# Characters of the text digest that go into a source id. Eight is what every
+# existing graph was written with; an md5 hex digest is 32, which is the ceiling.
+DEFAULT_SOURCE_ID_HASH_LENGTH = 8
+MAX_SOURCE_ID_HASH_LENGTH = 32
 # botocore's own default. Not a chosen value - it's the floor the S3 pool is
 # never sized below. Distinct from DEFAULT_MAX_POOL_CONNECTIONS in
 # neptune_graph_stores, which is that client's chosen size.
@@ -334,6 +338,7 @@ class _GraphRAGConfig:
     _bedrock_reranking_model: Optional[str] = None
     _extraction_num_workers: Optional[int] = None
     _extraction_num_threads_per_worker: Optional[int] = None
+    _source_id_hash_length: Optional[int] = None
     _extraction_batch_size: Optional[int] = None
     _build_num_workers: Optional[int] = None
     _build_batch_size: Optional[int] = None
@@ -696,6 +701,35 @@ class _GraphRAGConfig:
                 each worker during extraction operations.
         """
         self._extraction_num_threads_per_worker = num_threads
+
+    @property
+    def source_id_hash_length(self) -> int:
+        """
+        Characters of the text digest that go into a source id.
+
+        Eight is what every existing graph was written with. A wider setting
+        separates documents that would otherwise share an id, and changes every
+        source id and chunk id, so a graph written at one length cannot be read
+        at another.
+
+        Returns:
+            int: The number of digest characters used in a source id.
+        """
+        if self._source_id_hash_length is None:
+            self.source_id_hash_length = int(
+                os.environ.get('SOURCE_ID_HASH_LENGTH', DEFAULT_SOURCE_ID_HASH_LENGTH))
+
+        return self._source_id_hash_length
+
+    @source_id_hash_length.setter
+    def source_id_hash_length(self, hash_length: int) -> None:
+        """
+        Sets the number of digest characters used in a source id.
+
+        Args:
+            hash_length (int): The number of digest characters.
+        """
+        self._source_id_hash_length = hash_length
 
     @property
     def extraction_batch_size(self) -> int:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -728,7 +728,16 @@ class _GraphRAGConfig:
 
         Args:
             hash_length (int): The number of digest characters.
+
+        Raises:
+            ValueError: If hash_length falls outside the md5 digest.
         """
+        if hash_length is not None and not 1 <= hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
+            raise ValueError(
+                f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '
+                f'[source_id_hash_length: {hash_length}]'
+            )
+
         self._source_id_hash_length = hash_length
 
     @property

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -234,8 +234,7 @@ class BuildPipeline():
             source_metadata_formatter=source_metadata_formatter, 
             id_generator=IdGenerator(
                 tenant_id=tenant_id, 
-                include_classification_in_entity_id=include_classification_in_entity_id,
-                source_id_hash_length=GraphRAGConfig.source_id_hash_length
+                include_classification_in_entity_id=include_classification_in_entity_id
             )
         )
         self.node_filter = NodeFilter() if not checkpoint else checkpoint.add_filter(NodeFilter(), tenant_id)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/build/build_pipeline.py
@@ -234,7 +234,8 @@ class BuildPipeline():
             source_metadata_formatter=source_metadata_formatter, 
             id_generator=IdGenerator(
                 tenant_id=tenant_id, 
-                include_classification_in_entity_id=include_classification_in_entity_id
+                include_classification_in_entity_id=include_classification_in_entity_id,
+                source_id_hash_length=GraphRAGConfig.source_id_hash_length
             )
         )
         self.node_filter = NodeFilter() if not checkpoint else checkpoint.add_filter(NodeFilter(), tenant_id)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -254,7 +254,8 @@ class ExtractionPipeline():
 
         id_generator=IdGenerator(
             tenant_id=tenant_id, 
-            include_classification_in_entity_id=include_classification_in_entity_id
+            include_classification_in_entity_id=include_classification_in_entity_id,
+            source_id_hash_length=GraphRAGConfig.source_id_hash_length
         )
         
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -31,7 +31,7 @@ class IdGenerator(BaseModel):
     use_chunk_id_delimiter:bool
     source_id_hash_length:int
 
-    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=DEFAULT_SOURCE_ID_HASH_LENGTH):
+    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=None):
         """
         Initialize the IdGenerator.
 
@@ -41,13 +41,15 @@ class IdGenerator(BaseModel):
             use_chunk_id_delimiter: Whether to use delimiter in chunk ID hashing to prevent
                 boundary collisions. Defaults to False for backward compatibility with existing
                 graphs. Set to True for new graphs to enable collision-resistant hashing.
-            source_id_hash_length: Characters of the text digest used in a source ID. Eight
-                is what existing graphs were written with. A wider setting separates documents
-                that would otherwise share an ID, and changes every source and chunk ID.
+            source_id_hash_length: Characters of the text digest used in a source ID.
+                Defaults to the configured value. Eight is what existing graphs were
+                written with; widening it changes every source and chunk ID.
 
         Raises:
-            ValueError: If source_id_hash_length falls outside the digest.
+            ValueError: If the resolved width falls outside the digest.
         """
+        source_id_hash_length = coalesce(source_id_hash_length, GraphRAGConfig.source_id_hash_length)
+
         if not 1 <= source_id_hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
             raise ValueError(
                 f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 from graphrag_toolkit.lexical_graph import TenantId, GraphRAGConfig
+from graphrag_toolkit.lexical_graph.config import DEFAULT_SOURCE_ID_HASH_LENGTH, MAX_SOURCE_ID_HASH_LENGTH
 from graphrag_toolkit.lexical_graph.indexing.utils.hash_utils import get_hash
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
@@ -28,8 +29,9 @@ class IdGenerator(BaseModel):
     tenant_id:TenantId
     include_classification_in_entity_id:bool
     use_chunk_id_delimiter:bool
+    source_id_hash_length:int
 
-    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False):
+    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=DEFAULT_SOURCE_ID_HASH_LENGTH):
         """
         Initialize the IdGenerator.
 
@@ -39,11 +41,24 @@ class IdGenerator(BaseModel):
             use_chunk_id_delimiter: Whether to use delimiter in chunk ID hashing to prevent
                 boundary collisions. Defaults to False for backward compatibility with existing
                 graphs. Set to True for new graphs to enable collision-resistant hashing.
+            source_id_hash_length: Characters of the text digest used in a source ID. Eight
+                is what existing graphs were written with. A wider setting separates documents
+                that would otherwise share an ID, and changes every source and chunk ID.
+
+        Raises:
+            ValueError: If source_id_hash_length falls outside the digest.
         """
+        if not 1 <= source_id_hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
+            raise ValueError(
+                f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '
+                f'[source_id_hash_length: {source_id_hash_length}]'
+            )
+
         super().__init__(
             tenant_id=tenant_id or TenantId(),
             include_classification_in_entity_id=coalesce(include_classification_in_entity_id, GraphRAGConfig.include_classification_in_entity_id),
-            use_chunk_id_delimiter=use_chunk_id_delimiter
+            use_chunk_id_delimiter=use_chunk_id_delimiter,
+            source_id_hash_length=source_id_hash_length
         )
 
     def _get_hash(self, s):
@@ -81,7 +96,7 @@ class IdGenerator(BaseModel):
             hashed substrings derived from the input text and metadata.
 
         """
-        return f"aws::{self._get_hash(text)[:8]}:{self._get_hash(metadata_str)[:4]}"
+        return f"aws::{self._get_hash(text)[:self.source_id_hash_length]}:{self._get_hash(metadata_str)[:4]}"
 
     # Delimiter used to separate text and metadata in chunk ID hashing.
     # Using null byte as it cannot appear in valid UTF-8 text strings.

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -33,6 +33,10 @@ BATCH_SIZE = 100
 
 logger = logging.getLogger(__name__)
 
+# Joins node ids before hashing them. Without a separator ['ab', 'c'] and
+# ['a', 'bc'] hash alike.
+_DOC_SUFFIX_DELIMITER = '\x00'
+
 class ConfiguredThreadCount:
     """
     Sizes a thread pool from a caller-supplied count, falling back to the config
@@ -72,7 +76,12 @@ class S3DocDownloader(ConfiguredThreadCount, BaseComponent):
             for node_obj in node_page['Contents'] 
         ]
 
+        # Every object under the prefix merges into one SourceDocument, and a
+        # run that packs a source's chunks differently writes a new object
+        # beside the old one, so a node id can arrive twice. Keys sort
+        # lexicographically, so the first copy wins rather than the newest.
         nodes = []
+        seen_node_ids = set()
 
         for node_key in node_keys:
         
@@ -81,7 +90,10 @@ class S3DocDownloader(ConfiguredThreadCount, BaseComponent):
                 io_stream.seek(0)
                 data = io_stream.readline().decode('UTF-8')
                 while data:
-                    nodes.append(self.fn(TextNode.from_json(data)))
+                    node = TextNode.from_json(data)
+                    if node.node_id not in seen_node_ids:
+                        seen_node_ids.add(node.node_id)
+                        nodes.append(self.fn(node))
                     data = io_stream.readline().decode('UTF-8')
 
         return SourceDocument(nodes=nodes)
@@ -135,20 +147,24 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
     _semaphore:Semaphore = PrivateAttr(default=None)
     _queue:queue.Queue = PrivateAttr(default=None)
     
+    def _written_nodes(self, doc:SourceDocument) -> List[TextNode]:
+        """The nodes this uploader writes into the object body."""
+        return [n for n in doc.nodes if INDEX_KEY not in n.metadata]
+
     def _doc_suffix(self, doc:SourceDocument) -> str:
         """
-        What distinguishes one object from another under a source document's prefix.
+        What separates one object from another under a source document's prefix.
 
-        A random suffix makes the key different on every attempt, so a retry
-        writes a second object beside the first. Deriving it from the document's
-        own node ids makes a retry overwrite, and keeps the separate
-        SourceDocuments an auto-tuned run emits for one source apart, because
-        those carry different chunks.
+        A random suffix differs on every attempt, so a retry writes a second
+        object rather than replacing the first. Hashing the ids of the nodes
+        written instead makes a retry overwrite, while keeping the separate
+        SourceDocuments an auto-tuned run emits for one source apart.
         """
         if not self.deterministic_document_key:
             return uuid.uuid4().hex[:5]
 
-        return get_hash(''.join(sorted(n.node_id for n in doc.nodes)))[:5]
+        node_ids = sorted(n.node_id for n in self._written_nodes(doc))
+        return get_hash(_DOC_SUFFIX_DELIMITER.join(node_ids))[:5]
 
     def _upload_doc(self, root_path:str, doc:SourceDocument, s3_client):
 
@@ -160,8 +176,7 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
 
             s = '\n'.join([
                 json.dumps(n.to_dict())
-                for n in doc.nodes 
-                if not [key for key in [INDEX_KEY] if key in n.metadata]
+                for n in self._written_nodes(doc)
             ]) 
 
             if self.s3_encryption_key_id:
@@ -387,7 +402,6 @@ class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
-    deterministic_document_key:bool=False
 
     def _upload_chunk(self, root_path:str, n:TextNode, s3_client):
         chunk_output_path = join(root_path, f'{n.node_id}.json')
@@ -628,8 +642,7 @@ class S3BasedDocs(NodeHandler):
                     bucket_name=self.bucket_name, 
                     collection_prefix=collection_prefix,
                     s3_encryption_key_id=self.s3_encryption_key_id,
-                    num_threads=self.num_threads,
-                    deterministic_document_key=self.deterministic_document_key
+                    num_threads=self.num_threads
                 )
         
         for doc in self._uploader.upload(source_documents):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -19,6 +19,7 @@ from threading import Semaphore
 from typing import List, Any, Generator, Optional, Dict, Callable
 
 from graphrag_toolkit.lexical_graph.indexing import NodeHandler
+from graphrag_toolkit.lexical_graph.indexing.utils.hash_utils import get_hash
 from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument, SourceType, source_documents_from_source_types
 from graphrag_toolkit.lexical_graph.indexing.constants import PROPOSITIONS_KEY, TOPICS_KEY
 from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
@@ -130,12 +131,28 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
+    deterministic_document_key:bool=False
     _semaphore:Semaphore = PrivateAttr(default=None)
     _queue:queue.Queue = PrivateAttr(default=None)
     
+    def _doc_suffix(self, doc:SourceDocument) -> str:
+        """
+        What distinguishes one object from another under a source document's prefix.
+
+        A random suffix makes the key different on every attempt, so a retry
+        writes a second object beside the first. Deriving it from the document's
+        own node ids makes a retry overwrite, and keeps the separate
+        SourceDocuments an auto-tuned run emits for one source apart, because
+        those carry different chunks.
+        """
+        if not self.deterministic_document_key:
+            return uuid.uuid4().hex[:5]
+
+        return get_hash(''.join(sorted(n.node_id for n in doc.nodes)))[:5]
+
     def _upload_doc(self, root_path:str, doc:SourceDocument, s3_client):
 
-        doc_output_path = join(root_path, f'{doc.source_id()}-{uuid.uuid4().hex[:5]}.jsonl')
+        doc_output_path = join(root_path, f'{doc.source_id()}-{self._doc_suffix(doc)}.jsonl')
 
         logger.debug(f'Writing source document as JSONL to S3: [bucket: {self.bucket_name}, key: {doc_output_path}]')
         
@@ -370,6 +387,7 @@ class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
     bucket_name:str
     collection_prefix:str
     s3_encryption_key_id:Optional[str]=None
+    deterministic_document_key:bool=False
 
     def _upload_chunk(self, root_path:str, n:TextNode, s3_client):
         chunk_output_path = join(root_path, f'{n.node_id}.json')
@@ -461,6 +479,7 @@ class S3BasedDocs(NodeHandler):
     metadata_keys:Optional[List[str]]=None
     for_jsonl:Optional[bool]=False
     num_threads:Optional[int]=None
+    deterministic_document_key:bool=False
 
     _uploader:Any = PrivateAttr(default=None)
     _downloader:Any = PrivateAttr(default=None)
@@ -473,7 +492,8 @@ class S3BasedDocs(NodeHandler):
                  s3_encryption_key_id:Optional[str]=None, 
                  metadata_keys:Optional[List[str]]=None,
                  for_jsonl:Optional[bool]=False,
-                 num_threads:Optional[int]=None):
+                 num_threads:Optional[int]=None,
+                 deterministic_document_key:bool=False):
 
         # __init__ runs where GraphRAGConfig was configured; accept() runs in a
         # spawned worker that inherits no parent memory and reads back the
@@ -489,7 +509,8 @@ class S3BasedDocs(NodeHandler):
             s3_encryption_key_id=s3_encryption_key_id,
             metadata_keys=metadata_keys,
             for_jsonl=for_jsonl,
-            num_threads=num_threads
+            num_threads=num_threads,
+            deterministic_document_key=deterministic_document_key
         )
 
     def docs(self):
@@ -598,7 +619,8 @@ class S3BasedDocs(NodeHandler):
                     bucket_name=self.bucket_name, 
                     collection_prefix=collection_prefix,
                     s3_encryption_key_id=self.s3_encryption_key_id,
-                    num_threads=self.num_threads
+                    num_threads=self.num_threads,
+                    deterministic_document_key=self.deterministic_document_key
                 )
                 
             else:
@@ -606,7 +628,8 @@ class S3BasedDocs(NodeHandler):
                     bucket_name=self.bucket_name, 
                     collection_prefix=collection_prefix,
                     s3_encryption_key_id=self.s3_encryption_key_id,
-                    num_threads=self.num_threads
+                    num_threads=self.num_threads,
+                    deterministic_document_key=self.deterministic_document_key
                 )
         
         for doc in self._uploader.upload(source_documents):

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -983,3 +983,80 @@ class TestDeterministicDocumentKey:
         )
 
         assert docs.deterministic_document_key is True
+
+
+class TestDocumentKeyCoversWhatIsWritten:
+    """The suffix has to be a function of the nodes that reach the object body."""
+
+    def _doc(self, chunk_ids, indexed_ids=()):
+        nodes = []
+        for chunk_id in list(chunk_ids) + list(indexed_ids):
+            node = TextNode(text='chunk text', id_=chunk_id)
+            if chunk_id in indexed_ids:
+                node.metadata[INDEX_KEY] = {'index': 'chunk'}
+            node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id='aws::dead:beef')
+            nodes.append(node)
+        return SourceDocument(nodes=nodes)
+
+    def _key(self, doc):
+        uploader = S3DocUploader(
+            bucket_name='b', collection_prefix='p', deterministic_document_key=True
+        )
+        s3_client = Mock()
+        uploader._upload_doc('root', doc, s3_client)
+        return s3_client.put_object.call_args.kwargs['Key']
+
+    def test_nodes_excluded_from_the_body_do_not_change_the_key(self):
+        assert self._key(self._doc(['c1', 'c2'])) == self._key(
+            self._doc(['c1', 'c2'], indexed_ids=['c3'])
+        )
+
+    def test_ids_that_would_concatenate_alike_get_different_keys(self):
+        # 'ab' + 'c' and 'a' + 'bc' join to the same string without a delimiter.
+        assert self._key(self._doc(['ab', 'c'])) != self._key(self._doc(['a', 'bc']))
+
+
+class TestDownloadDeduplicatesNodeIds:
+    """
+    Every object under a source prefix merges into one SourceDocument, and a run
+    that packs the chunks differently writes a new object beside the old one, so
+    the same node id can arrive twice.
+    """
+
+    def _download(self, objects):
+        downloader = S3DocDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
+        )
+        s3_client = Mock()
+        s3_client.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [{'Key': key} for key in objects]}
+        ]
+
+        def download_fileobj(bucket, key, stream):
+            stream.write('\n'.join(n.to_json() for n in objects[key]).encode('UTF-8'))
+
+        s3_client.download_fileobj.side_effect = download_fileobj
+        return downloader._download_doc('prefix', s3_client)
+
+    def _node(self, node_id):
+        node = TextNode(text=f'text for {node_id}', id_=node_id)
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id='aws::dead:beef')
+        return node
+
+    def test_a_node_id_in_two_objects_is_returned_once(self):
+        overlapping = {
+            'round-a.jsonl': [self._node('c1'), self._node('c2')],
+            'round-b.jsonl': [self._node('c2'), self._node('c3')],
+        }
+
+        doc = self._download(overlapping)
+
+        assert [n.node_id for n in doc.nodes] == ['c1', 'c2', 'c3']
+
+    def test_distinct_objects_are_all_kept(self):
+        doc = self._download({
+            'a.jsonl': [self._node('c1')],
+            'b.jsonl': [self._node('c2')],
+        })
+
+        assert len(doc.nodes) == 2

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -7,7 +7,7 @@ import time
 
 import pytest
 from unittest.mock import Mock, patch, MagicMock
-from llama_index.core.schema import TextNode
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
     S3BasedDocs,
     S3DocDownloader,
@@ -902,3 +902,84 @@ class TestUploadThreadPropagation:
         ) as config:
             config.extraction_num_threads_per_worker = 7
             assert uploader._num_threads() == 7
+
+
+class TestDeterministicDocumentKey:
+    """
+    The document key carries a random suffix, so a retry writes a second object
+    beside the first instead of replacing it and a restart cannot tell a re-stage
+    from a duplicate. Behind a flag the suffix is derived from the document's own
+    nodes instead, which makes a retry overwrite while keeping the separate
+    SourceDocuments an auto-tuned run emits for one source in separate objects.
+    """
+
+    def _doc(self, source_id, chunk_ids):
+        nodes = []
+        for chunk_id in chunk_ids:
+            node = TextNode(text='chunk text', id_=chunk_id)
+            node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=source_id)
+            nodes.append(node)
+        return SourceDocument(nodes=nodes)
+
+    def _key(self, uploader, doc):
+        s3_client = Mock()
+        uploader._upload_doc('root', doc, s3_client)
+        return s3_client.put_object.call_args.kwargs['Key']
+
+    def test_flag_defaults_off(self):
+        assert S3DocUploader(bucket_name='b', collection_prefix='p').deterministic_document_key is False
+
+    def test_off_keeps_a_random_suffix(self):
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p')
+        doc = self._doc('aws::deadbeef:d41d', ['c1', 'c2'])
+
+        first = self._key(uploader, doc)
+
+        assert first.startswith('root/aws::deadbeef:d41d-')
+        assert first != self._key(uploader, doc)
+
+    def test_on_makes_a_retry_overwrite(self):
+        uploader = S3DocUploader(
+            bucket_name='b', collection_prefix='p', deterministic_document_key=True
+        )
+        doc = self._doc('aws::deadbeef:d41d', ['c1', 'c2'])
+
+        assert self._key(uploader, doc) == self._key(uploader, doc)
+
+    def test_on_keeps_the_source_id_readable_in_the_key(self):
+        uploader = S3DocUploader(
+            bucket_name='b', collection_prefix='p', deterministic_document_key=True
+        )
+
+        key = self._key(uploader, self._doc('aws::deadbeef:d41d', ['c1']))
+
+        assert key.startswith('root/aws::deadbeef:d41d-')
+        assert key.endswith('.jsonl')
+
+    def test_on_separates_the_rounds_of_one_source_document(self):
+        # _extract_auto_tuned emits one source as several SourceDocuments when it
+        # exceeds the round capacity. A key on source_id alone would let the
+        # second round replace the first.
+        uploader = S3DocUploader(
+            bucket_name='b', collection_prefix='p', deterministic_document_key=True
+        )
+        first_round = self._doc('aws::deadbeef:d41d', ['c1', 'c2'])
+        second_round = self._doc('aws::deadbeef:d41d', ['c3', 'c4'])
+
+        assert self._key(uploader, first_round) != self._key(uploader, second_round)
+
+    def test_on_ignores_the_order_the_chunks_arrive_in(self):
+        uploader = S3DocUploader(
+            bucket_name='b', collection_prefix='p', deterministic_document_key=True
+        )
+
+        assert (self._key(uploader, self._doc('aws::dead:beef', ['c1', 'c2']))
+                == self._key(uploader, self._doc('aws::dead:beef', ['c2', 'c1'])))
+
+    def test_s3_based_docs_carries_the_flag(self):
+        docs = S3BasedDocs(
+            region='us-east-1', bucket_name='b', key_prefix='p', collection_id='c',
+            deterministic_document_key=True,
+        )
+
+        assert docs.deterministic_document_key is True

--- a/lexical-graph/tests/unit/indexing/test_id_generator.py
+++ b/lexical-graph/tests/unit/indexing/test_id_generator.py
@@ -1,8 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+
 import pytest
-from unittest.mock import patch
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.schema import Document, NodeRelationship
@@ -464,6 +465,18 @@ def test_id_generator_tenant_isolation_property(tenant_id1, tenant_id2):
 
 
 
+@pytest.fixture(autouse=True)
+def isolated_hash_length(monkeypatch):
+    """
+    The width is env-backed and cached on the config, so a value left in either
+    place changes ids for every test that follows.
+    """
+    monkeypatch.delenv('SOURCE_ID_HASH_LENGTH', raising=False)
+    GraphRAGConfig.source_id_hash_length = None
+    yield
+    GraphRAGConfig.source_id_hash_length = None
+
+
 class TestSourceIdHashLength:
     """
     A source id discriminates on 48 bits, and on 32 when a document carries no
@@ -494,14 +507,24 @@ class TestSourceIdHashLength:
 
         assert wide.split(':')[-1] == narrow.split(':')[-1]
 
-    def test_widening_separates_texts_that_collide_at_eight_characters(self):
-        narrow, wide = IdGenerator(), IdGenerator(source_id_hash_length=32)
-        a, b = 'first document', 'second document'
+    def test_widening_separates_texts_that_collide_at_a_narrow_width(self):
+        narrow, wide = IdGenerator(source_id_hash_length=2), IdGenerator(source_id_hash_length=32)
+        a, b = self._colliding_texts(width=2)
 
-        with patch.object(narrow, '_get_hash', side_effect=lambda s: 'c0ffee' + '0' * 26):
-            assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
-
+        assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
         assert wide.create_source_id(a, '') != wide.create_source_id(b, '')
+
+    @staticmethod
+    def _colliding_texts(width):
+        """Two different texts whose digests agree on the first `width` characters."""
+        seen = {}
+        for i in range(100000):
+            text = f'document {i}'
+            prefix = hashlib.md5(text.encode('utf-8')).hexdigest()[:width]
+            if prefix in seen:
+                return seen[prefix], text
+            seen[prefix] = text
+        raise AssertionError(f'no collision found at width {width}')
 
     def test_chunk_ids_follow_the_wider_source_id(self):
         generator = IdGenerator(source_id_hash_length=32)
@@ -519,11 +542,7 @@ class TestSourceIdHashLength:
 
 
 class TestSourceIdHashLengthReachesTheIds:
-    """
-    An unreachable setting is the mistake use_chunk_id_delimiter already made:
-    it exists on IdGenerator and no caller sets it. These cover the path from
-    configuration to the ids a run actually writes.
-    """
+    """Covers the path from configuration to the ids a run writes."""
 
     def _ids(self, hash_length):
         generator = IdGenerator(source_id_hash_length=hash_length)
@@ -540,12 +559,8 @@ class TestSourceIdHashLengthReachesTheIds:
 
     def test_config_reads_the_environment(self, monkeypatch):
         monkeypatch.setenv('SOURCE_ID_HASH_LENGTH', '32')
-        GraphRAGConfig.source_id_hash_length = None
 
-        try:
-            assert GraphRAGConfig.source_id_hash_length == 32
-        finally:
-            GraphRAGConfig.source_id_hash_length = None
+        assert GraphRAGConfig.source_id_hash_length == 32
 
     def test_widening_changes_ids_but_not_chunk_text(self):
         narrow, wide = self._ids(8), self._ids(32)
@@ -559,3 +574,16 @@ class TestSourceIdHashLengthReachesTheIds:
 
         assert len(source_of(wide[0])) > len(source_of(narrow[0]))
         assert source_of(narrow[0]) != source_of(wide[0])
+
+
+class TestSourceIdHashLengthConfig:
+
+    def test_a_bare_generator_takes_the_configured_width(self):
+        GraphRAGConfig.source_id_hash_length = 16
+
+        assert IdGenerator().source_id_hash_length == 16
+
+    @pytest.mark.parametrize('length', [0, -1, 33])
+    def test_the_config_rejects_a_width_outside_the_digest(self, length):
+        with pytest.raises(ValueError):
+            GraphRAGConfig.source_id_hash_length = length

--- a/lexical-graph/tests/unit/indexing/test_id_generator.py
+++ b/lexical-graph/tests/unit/indexing/test_id_generator.py
@@ -2,8 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from unittest.mock import patch
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
+from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.schema import Document, NodeRelationship
+from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
+from graphrag_toolkit.lexical_graph.indexing.extract.id_rewriter import IdRewriter
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
 
 
 class TestCreateChunkIdBackwardCompatible:
@@ -456,3 +462,100 @@ def test_id_generator_tenant_isolation_property(tenant_id1, tenant_id2):
     assert id_parts1[1] != id_parts2[1], \
         f"Tenant components should differ: '{id_parts1[1]}' vs '{id_parts2[1]}'"
 
+
+
+class TestSourceIdHashLength:
+    """
+    A source id discriminates on 48 bits, and on 32 when a document carries no
+    metadata, so distinct documents collide at scale. The text component's width
+    is configurable so the collision rate can be set to the corpus, and it
+    defaults to today's 8 characters because widening it changes every id.
+    """
+
+    def test_defaults_to_eight_characters(self):
+        generator = IdGenerator()
+
+        assert generator.source_id_hash_length == 8
+
+    def test_default_matches_the_shipped_id_exactly(self):
+        # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
+        assert IdGenerator().create_source_id('hello world', '') == 'aws::5eb63bbb:d41d'
+
+    def test_a_wider_setting_lengthens_the_text_component(self):
+        generator = IdGenerator(source_id_hash_length=16)
+
+        source_id = generator.create_source_id('hello world', '')
+
+        assert source_id == 'aws::5eb63bbbe01eeed0:d41d'
+
+    def test_the_metadata_component_is_unchanged_by_the_setting(self):
+        wide = IdGenerator(source_id_hash_length=32).create_source_id('hello world', 'k:v')
+        narrow = IdGenerator().create_source_id('hello world', 'k:v')
+
+        assert wide.split(':')[-1] == narrow.split(':')[-1]
+
+    def test_widening_separates_texts_that_collide_at_eight_characters(self):
+        narrow, wide = IdGenerator(), IdGenerator(source_id_hash_length=32)
+        a, b = 'first document', 'second document'
+
+        with patch.object(narrow, '_get_hash', side_effect=lambda s: 'c0ffee' + '0' * 26):
+            assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
+
+        assert wide.create_source_id(a, '') != wide.create_source_id(b, '')
+
+    def test_chunk_ids_follow_the_wider_source_id(self):
+        generator = IdGenerator(source_id_hash_length=32)
+
+        source_id = generator.create_source_id('hello world', '')
+
+        assert generator.create_chunk_id(source_id, 'hello world', '').startswith(source_id)
+
+    @pytest.mark.parametrize('length', [0, -1, 33])
+    def test_rejects_a_length_outside_the_digest(self, length):
+        # An md5 hex digest is 32 characters, so anything past it silently
+        # truncates and anything below 1 produces a keyless id.
+        with pytest.raises(ValueError):
+            IdGenerator(source_id_hash_length=length)
+
+
+class TestSourceIdHashLengthReachesTheIds:
+    """
+    An unreachable setting is the mistake use_chunk_id_delimiter already made:
+    it exists on IdGenerator and no caller sets it. These cover the path from
+    configuration to the ids a run actually writes.
+    """
+
+    def _ids(self, hash_length):
+        generator = IdGenerator(source_id_hash_length=hash_length)
+        rewriter = IdRewriter(
+            inner=SentenceSplitter(chunk_size=256, chunk_overlap=25),
+            id_generator=generator,
+        )
+        document = Document(text='sentence one. ' * 400, metadata={'file_path': 'a.txt'})
+        chunks = rewriter.handle_source_docs([SourceDocument(nodes=[document])])[0].nodes
+        return chunks
+
+    def test_config_default_leaves_ids_where_they_are(self):
+        assert GraphRAGConfig.source_id_hash_length == 8
+
+    def test_config_reads_the_environment(self, monkeypatch):
+        monkeypatch.setenv('SOURCE_ID_HASH_LENGTH', '32')
+        GraphRAGConfig.source_id_hash_length = None
+
+        try:
+            assert GraphRAGConfig.source_id_hash_length == 32
+        finally:
+            GraphRAGConfig.source_id_hash_length = None
+
+    def test_widening_changes_ids_but_not_chunk_text(self):
+        narrow, wide = self._ids(8), self._ids(32)
+
+        assert [c.text for c in narrow] == [c.text for c in wide]
+        assert [c.id_ for c in narrow] != [c.id_ for c in wide]
+
+    def test_widening_separates_the_source_relationship(self):
+        narrow, wide = self._ids(8), self._ids(32)
+        source_of = lambda c: c.relationships[NodeRelationship.SOURCE].node_id
+
+        assert len(source_of(wide[0])) > len(source_of(narrow[0]))
+        assert source_of(narrow[0]) != source_of(wide[0])


### PR DESCRIPTION
## Description

**Stacked on #517.** That PR is the first commit here and is not part of this review. Until it merges, the diff below shows both; the change under review is `feat(lexical-graph): derive the S3 document key suffix from the document`.

`S3DocUploader._upload_doc` builds the key as `{source_id}-{uuid4:5}.jsonl`, so the key is different on every attempt. A retry writes a second object beside the first instead of replacing it, and a restart cannot tell a re-stage from a duplicate.

Behind a flag the suffix becomes a digest of the document's own node ids. A retry then produces the same key and overwrites.

## Changes

- `deterministic_document_key` on `S3DocUploader`, `S3ChunkUploader` and `S3BasedDocs`, defaulting to `False`. With it off, keys match today's layout exactly.
- The suffix is `get_hash(sorted node ids)[:5]` when the flag is on, `uuid4().hex[:5]` when it is off.

Keying on `source_id` alone would not work. `_extract_auto_tuned` emits one source as several `SourceDocument`s when a document exceeds the round capacity, and those would overwrite each other. Node ids differ per round, so the rounds stay in separate objects while a retry of one round still overwrites. Both properties come from the same expression and both are covered.

## Problem

The random suffix is also what currently keeps two colliding documents in separate objects, so dropping it needs the wider key from #517. Sizing that collision is what #515 measured: 127 colliding pairs at 1M documents on the 32 bits that discriminate when metadata is absent.

Related issue (if any): #325. A restart cannot resume against keys that change on every attempt.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`) — 2,094 in `tests/unit`
- [ ] Tested manually (describe below)

Nine tests covering both flag states, retry stability, round separation, and independence from the order chunks arrive in.

One pre-existing failure is unrelated and reproduces on a clean tree: `test_integ_dependency_compatibility.py` errors with `No module named pip` in this venv.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

The flag is not yet reachable from configuration, so today it is set by constructing `S3BasedDocs` directly. Wiring it to a setting belongs with the rest of the restart work rather than here.
