### PR TITLE
[FEATURE] Split release changelog by project (lexical-graph | byokg | both)

### DIFF
--- a/.github/release_message.sh
+++ b/.github/release_message.sh
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
-previous_tag=$(git tag --sort=-creatordate | sed -n 2p)
-git shortlog "${previous_tag}.." | sed 's/^./    &/'
+# Print the changelog for a single project since its previous release tag.
+#
+# Usage: release_message.sh [lexical-graph|byokg|both] [--to <ref>]
+# Default project is "both". Delegates to scripts/generate_changelog.py, which
+# classifies each commit by the project folders it touched. See RELEASE.md.
+set -euo pipefail
+
+project="${1:-both}"
+shift || true
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${script_dir}/scripts/generate_changelog.py" --project "${project}" "$@"

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate a release changelog grouped/filtered by project.
+
+The toolkit is a monorepo that releases ``lexical-graph`` and ``byokg`` one at a
+time, but the changelog historically listed every commit since the previous tag
+regardless of project. This script classifies each commit in a git range into
+``lexical-graph``, ``byokg``, or ``both`` by the top-level folders it changed,
+then emits markdown release notes for the requested project.
+
+Classification (by changed path):
+    * ``lexical-graph/``, ``lexical-graph-contrib/``, ``examples/lexical-graph*``
+      -> lexical-graph
+    * ``byokg-rag/``, ``examples/byokg*`` -> byokg
+    * anything else (docs-site, benchmarks, integration-tests, .github, root, ...)
+      is "shared" and reported under ``both`` since it can affect either package
+
+A commit that touches both packages is ``both``; a commit that touches only
+shared paths is also ``both``. A single-project changelog includes that
+project's commits plus the ``both`` commits (those changes ship in the release
+too).
+
+Range: pass ``--from``/``--to`` explicitly, or let the script pick the previous
+released tag of the same project (``.dev`` prereleases are ignored as baselines)
+as the start and ``--to`` (default ``HEAD``) as the end.
+
+Examples:
+    generate_changelog.py --project lexical-graph
+    generate_changelog.py --project byokg --to graphrag-byokg/v3.19.1
+    generate_changelog.py --project both --from graphrag-lexical-graph/v3.19.0
+"""
+
+import argparse
+import subprocess
+import sys
+from typing import Dict, List, NamedTuple, Optional, Set
+
+LEXICAL = 'lexical-graph'
+BYOKG = 'byokg'
+BOTH = 'both'
+PROJECTS = (LEXICAL, BYOKG, BOTH)
+
+# Top-level path prefixes that map a changed file to a package. Order matters
+# only in that the lexical-graph-contrib prefix is listed explicitly (it is not
+# under 'lexical-graph/'). str.startswith accepts a tuple of prefixes.
+LEXICAL_PREFIXES = ('lexical-graph/', 'lexical-graph-contrib/', 'examples/lexical-graph')
+BYOKG_PREFIXES = ('byokg-rag/', 'examples/byokg')
+
+# Human-readable section headings used when rendering the 'both' report.
+SECTION_TITLES = {
+    LEXICAL: 'lexical-graph',
+    BYOKG: 'byokg',
+    BOTH: 'Shared / both projects',
+}
+
+# Field/record separators for the machine-readable git log format. Using control
+# characters avoids collisions with anything in a commit subject.
+_REC = '\x1e'   # record separator: one per commit
+_FLD = '\x1f'   # field separator: between sha / short-sha / subject
+
+
+class Commit(NamedTuple):
+    sha: str
+    short_sha: str
+    subject: str
+    files: List[str]
+
+
+def bucket_for_path(path: str) -> str:
+    """Map one changed file path to 'lexical', 'byokg', or 'shared'."""
+    if path.startswith(LEXICAL_PREFIXES):
+        return 'lexical'
+    if path.startswith(BYOKG_PREFIXES):
+        return 'byokg'
+    return 'shared'
+
+
+def classify_commit(files: List[str]) -> str:
+    """Classify a commit by the packages its changed files touch."""
+    buckets: Set[str] = {bucket_for_path(p) for p in files}
+    has_lexical = 'lexical' in buckets
+    has_byokg = 'byokg' in buckets
+    if has_lexical and has_byokg:
+        return BOTH
+    if has_lexical:
+        return LEXICAL
+    if has_byokg:
+        return BYOKG
+    # Only shared paths (or no files): affects both packages.
+    return BOTH
+
+
+def is_relevant(label: str, project: str) -> bool:
+    """Whether a commit with `label` belongs in `project`'s changelog."""
+    if project == BOTH:
+        return True
+    if project == LEXICAL:
+        return label in (LEXICAL, BOTH)
+    if project == BYOKG:
+        return label in (BYOKG, BOTH)
+    raise ValueError(f'unknown project: {project}')
+
+
+def parse_git_log(text: str) -> List[Commit]:
+    """Parse the output of `git log --pretty=... --name-only` into commits."""
+    commits: List[Commit] = []
+    for record in text.split(_REC):
+        record = record.strip('\n')
+        if not record:
+            continue
+        header, _, rest = record.partition('\n')
+        sha, short_sha, subject = header.split(_FLD)
+        files = [line for line in rest.split('\n') if line.strip()]
+        commits.append(Commit(sha=sha, short_sha=short_sha, subject=subject, files=files))
+    return commits
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ['git', *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _is_ancestor(ancestor: str, ref: str) -> bool:
+    return subprocess.run(
+        ['git', 'merge-base', '--is-ancestor', ancestor, ref],
+        capture_output=True,
+    ).returncode == 0
+
+
+def previous_release_tag(project: str, to_ref: str) -> Optional[str]:
+    """Find the previous released tag for `project` reachable from `to_ref`.
+
+    Considers tags of the same project (or of either project for `both`),
+    ignores `.dev` prereleases as baselines, and returns the most recent one
+    that is an ancestor of `to_ref` and not `to_ref` itself. Returns None if
+    there is no suitable baseline (then the whole history is used).
+    """
+    if project == BYOKG:
+        patterns = ['graphrag-byokg/v*']
+    elif project == LEXICAL:
+        patterns = ['graphrag-lexical-graph/v*']
+    else:
+        patterns = ['graphrag-lexical-graph/v*', 'graphrag-byokg/v*']
+
+    tags: List[str] = []
+    for pattern in patterns:
+        tags.extend(
+            t for t in _git('tag', '--list', pattern, '--sort=-creatordate').splitlines() if t
+        )
+    # Newest first; drop the current ref and .dev prereleases (a final release
+    # should diff against the previous real release, not its own prerelease).
+    for tag in tags:
+        if tag == to_ref or '.dev' in tag:
+            continue
+        if _is_ancestor(tag, to_ref):
+            return tag
+    return None
+
+
+def read_commits(from_ref: Optional[str], to_ref: str) -> List[Commit]:
+    range_spec = f'{from_ref}..{to_ref}' if from_ref else to_ref
+    fmt = f'{_REC}%H{_FLD}%h{_FLD}%s'
+    out = _git('log', '--no-merges', f'--pretty=format:{fmt}', '--name-only', range_spec)
+    return parse_git_log(out)
+
+
+def _render_entry(commit: Commit) -> str:
+    # Squash-merge subjects already carry the "(#123)" PR ref that GitHub
+    # auto-links in release notes; add the short sha only when no PR ref present.
+    if '(#' in commit.subject:
+        return f'- {commit.subject}'
+    return f'- {commit.subject} ({commit.short_sha})'
+
+
+def render(commits: List[Commit], project: str, baseline: Optional[str]) -> str:
+    labelled = [(classify_commit(c.files), c) for c in commits]
+    relevant = [(label, c) for label, c in labelled if is_relevant(label, project)]
+
+    since = f' since {baseline}' if baseline else ''
+    lines: List[str] = []
+
+    if project == BOTH:
+        lines.append(f'## Changelog by project{since}')
+        for section in (LEXICAL, BYOKG, BOTH):
+            entries = [c for label, c in relevant if label == section]
+            lines.append('')
+            lines.append(f'### {SECTION_TITLES[section]}')
+            if entries:
+                lines.extend(_render_entry(c) for c in entries)
+            else:
+                lines.append('_No changes._')
+    else:
+        lines.append(f"## What's changed in {project}{since}")
+        lines.append('')
+        if relevant:
+            lines.extend(_render_entry(c) for _, c in relevant)
+        else:
+            lines.append('_No changes._')
+
+    return '\n'.join(lines) + '\n'
+
+
+def build_changelog(project: str, from_ref: Optional[str], to_ref: str) -> str:
+    baseline = from_ref if from_ref else previous_release_tag(project, to_ref)
+    commits = read_commits(baseline, to_ref)
+    return render(commits, project, baseline)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--project', required=True, choices=PROJECTS,
+                        help="which project's changelog to produce")
+    parser.add_argument('--from', dest='from_ref', default=None,
+                        help='baseline ref (default: previous released tag of the project)')
+    parser.add_argument('--to', dest='to_ref', default='HEAD',
+                        help='end ref (default: HEAD; in CI pass the release tag)')
+    parser.add_argument('--output', default=None,
+                        help='write to this file instead of stdout')
+    args = parser.parse_args(argv)
+
+    changelog = build_changelog(args.project, args.from_ref, args.to_ref)
+
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as fh:
+            fh.write(changelog)
+    else:
+        sys.stdout.write(changelog)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -117,29 +117,43 @@ def parse_git_log(text: str) -> List[Commit]:
 
 
 def _git(*args: str) -> str:
-    result = subprocess.run(
-        ['git', *args],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    result = subprocess.run(['git', *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
     return result.stdout
 
 
-def _is_ancestor(ancestor: str, ref: str) -> bool:
-    return subprocess.run(
-        ['git', 'merge-base', '--is-ancestor', ancestor, ref],
-        capture_output=True,
-    ).returncode == 0
+def _peel(ref: str) -> Optional[str]:
+    """Resolve a ref to the commit SHA it points at (peels annotated tags)."""
+    try:
+        return _git('rev-parse', f'{ref}^{{}}').strip()
+    except RuntimeError:
+        return None
 
 
 def previous_release_tag(project: str, to_ref: str) -> Optional[str]:
-    """Find the previous released tag for `project` reachable from `to_ref`.
+    """Find the previous released tag for `project` to diff `to_ref` against.
 
-    Considers tags of the same project (or of either project for `both`),
-    ignores `.dev` prereleases as baselines, and returns the most recent one
-    that is an ancestor of `to_ref` and not `to_ref` itself. Returns None if
-    there is no suitable baseline (then the whole history is used).
+    Considers tags of the same project (or either project for `both`), newest
+    first by creation date, and returns the first real release (not a `.dev`
+    prerelease) that does not point at the same commit as `to_ref`.
+
+    Two deliberate choices, both driven by the real release topology:
+
+    * **No ancestor filter.** Releases are tagged on release branches and
+      squash-downmerged into main, so the previous release usually is *not* an
+      ancestor of a main commit. `git log <tag>..<to_ref>` computes the right
+      set regardless; requiring ancestry would skip every recent release and
+      fall back to a far-older baseline (observed: 142 commits instead of 11).
+    * **Compare peeled commit SHAs, not tag names.** `graphrag-byokg/vX` and
+      `graphrag-lexical-graph/vX` are the same commit, so for `both` a name
+      compare would pick the sibling tag as the baseline and emit an empty
+      changelog; skipping any tag on `to_ref`'s commit avoids that (and also
+      excludes `to_ref` itself).
+
+    Returns None if there is no suitable baseline (then the whole history is used).
     """
     if project == BYOKG:
         patterns = ['graphrag-byokg/v*']
@@ -148,25 +162,24 @@ def previous_release_tag(project: str, to_ref: str) -> Optional[str]:
     else:
         patterns = ['graphrag-lexical-graph/v*', 'graphrag-byokg/v*']
 
-    tags: List[str] = []
-    for pattern in patterns:
-        tags.extend(
-            t for t in _git('tag', '--list', pattern, '--sort=-creatordate').splitlines() if t
-        )
-    # Newest first; drop the current ref and .dev prereleases (a final release
-    # should diff against the previous real release, not its own prerelease).
+    # One --list call with all patterns so 'both' is globally ordered by date.
+    tags = [t for t in _git('tag', '--list', *patterns, '--sort=-creatordate').splitlines() if t]
+
+    to_sha = _peel(to_ref)
     for tag in tags:
-        if tag == to_ref or '.dev' in tag:
+        if '.dev' in tag:
             continue
-        if _is_ancestor(tag, to_ref):
-            return tag
+        if to_sha is not None and _peel(tag) == to_sha:
+            continue
+        return tag
     return None
 
 
 def read_commits(from_ref: Optional[str], to_ref: str) -> List[Commit]:
     range_spec = f'{from_ref}..{to_ref}' if from_ref else to_ref
     fmt = f'{_REC}%H{_FLD}%h{_FLD}%s'
-    out = _git('log', '--no-merges', f'--pretty=format:{fmt}', '--name-only', range_spec)
+    out = _git('-c', 'core.quotepath=false', 'log', '--no-merges',
+               f'--pretty=format:{fmt}', '--name-only', range_spec)
     return parse_git_log(out)
 
 

--- a/.github/scripts/test_generate_changelog.py
+++ b/.github/scripts/test_generate_changelog.py
@@ -1,0 +1,138 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for generate_changelog.py (pure functions; no git required)."""
+
+import generate_changelog as gc
+
+
+class TestBucketForPath:
+    def test_lexical_graph_folder(self):
+        assert gc.bucket_for_path('lexical-graph/src/foo.py') == 'lexical'
+
+    def test_lexical_graph_contrib_folder(self):
+        # lexical-graph-contrib/ must not be mistaken for shared: it is not
+        # under 'lexical-graph/'.
+        assert gc.bucket_for_path('lexical-graph-contrib/bar.py') == 'lexical'
+
+    def test_lexical_examples(self):
+        assert gc.bucket_for_path('examples/lexical-graph/notebooks/a.ipynb') == 'lexical'
+        assert gc.bucket_for_path('examples/lexical-graph-hybrid-dev/x.ipynb') == 'lexical'
+
+    def test_byokg_folder(self):
+        assert gc.bucket_for_path('byokg-rag/src/foo.py') == 'byokg'
+
+    def test_byokg_examples(self):
+        assert gc.bucket_for_path('examples/byokg-rag/nb.ipynb') == 'byokg'
+
+    def test_shared_paths(self):
+        for path in ('docs-site/x.md', 'benchmarks/y.py', 'integration-tests/z.sh',
+                     '.github/workflows/w.yml', 'README.md', 'images/logo.png'):
+            assert gc.bucket_for_path(path) == 'shared'
+
+
+class TestClassifyCommit:
+    def test_only_lexical(self):
+        assert gc.classify_commit(['lexical-graph/a.py', 'lexical-graph/b.py']) == gc.LEXICAL
+
+    def test_only_byokg(self):
+        assert gc.classify_commit(['byokg-rag/a.py']) == gc.BYOKG
+
+    def test_both_when_touching_each(self):
+        assert gc.classify_commit(['lexical-graph/a.py', 'byokg-rag/b.py']) == gc.BOTH
+
+    def test_lexical_plus_shared_is_lexical(self):
+        assert gc.classify_commit(['lexical-graph/a.py', 'README.md']) == gc.LEXICAL
+
+    def test_byokg_plus_shared_is_byokg(self):
+        assert gc.classify_commit(['byokg-rag/a.py', '.github/x.yml']) == gc.BYOKG
+
+    def test_only_shared_is_both(self):
+        assert gc.classify_commit(['docs-site/x.md', '.github/x.yml']) == gc.BOTH
+
+    def test_no_files_is_both(self):
+        assert gc.classify_commit([]) == gc.BOTH
+
+
+class TestIsRelevant:
+    def test_both_project_includes_everything(self):
+        assert all(gc.is_relevant(label, gc.BOTH) for label in (gc.LEXICAL, gc.BYOKG, gc.BOTH))
+
+    def test_lexical_includes_lexical_and_both_only(self):
+        assert gc.is_relevant(gc.LEXICAL, gc.LEXICAL)
+        assert gc.is_relevant(gc.BOTH, gc.LEXICAL)
+        assert not gc.is_relevant(gc.BYOKG, gc.LEXICAL)
+
+    def test_byokg_includes_byokg_and_both_only(self):
+        assert gc.is_relevant(gc.BYOKG, gc.BYOKG)
+        assert gc.is_relevant(gc.BOTH, gc.BYOKG)
+        assert not gc.is_relevant(gc.LEXICAL, gc.BYOKG)
+
+
+class TestParseGitLog:
+    def _record(self, sha, short, subject, files):
+        header = gc._FLD.join([sha, short, subject])
+        body = ''.join('\n' + f for f in files)
+        return gc._REC + header + '\n' + body
+
+    def test_parses_multiple_commits(self):
+        text = (
+            self._record('aaa', 'aaa1', 'Fix lexical bug (#1)', ['lexical-graph/a.py'])
+            + self._record('bbb', 'bbb2', 'Shared CI tweak', ['.github/x.yml'])
+        )
+        commits = gc.parse_git_log(text)
+        assert len(commits) == 2
+        assert commits[0].sha == 'aaa'
+        assert commits[0].subject == 'Fix lexical bug (#1)'
+        assert commits[0].files == ['lexical-graph/a.py']
+        assert commits[1].files == ['.github/x.yml']
+
+    def test_commit_with_no_files(self):
+        text = gc._REC + gc._FLD.join(['ccc', 'ccc3', 'Empty commit']) + '\n'
+        commits = gc.parse_git_log(text)
+        assert len(commits) == 1
+        assert commits[0].files == []
+
+    def test_empty_input(self):
+        assert gc.parse_git_log('') == []
+
+
+class TestRender:
+    def _commits(self):
+        return [
+            gc.Commit('a', 'a1', 'Lexical feature (#10)', ['lexical-graph/a.py']),
+            gc.Commit('b', 'b2', 'BYOKG fix (#11)', ['byokg-rag/b.py']),
+            gc.Commit('c', 'c3', 'Bump shared dep', ['.github/x.yml']),
+        ]
+
+    def test_lexical_report_excludes_byokg_only(self):
+        out = gc.render(self._commits(), gc.LEXICAL, 'graphrag-lexical-graph/v1.0.0')
+        assert 'Lexical feature (#10)' in out
+        assert 'Bump shared dep' in out          # 'both' commit ships in the release
+        assert 'BYOKG fix' not in out
+        assert 'since graphrag-lexical-graph/v1.0.0' in out
+
+    def test_byokg_report_excludes_lexical_only(self):
+        out = gc.render(self._commits(), gc.BYOKG, None)
+        assert 'BYOKG fix (#11)' in out
+        assert 'Bump shared dep' in out
+        assert 'Lexical feature' not in out
+
+    def test_both_report_has_three_sections(self):
+        out = gc.render(self._commits(), gc.BOTH, None)
+        assert '### lexical-graph' in out
+        assert '### byokg' in out
+        assert '### Shared / both projects' in out
+
+    def test_pr_ref_kept_and_sha_added_when_absent(self):
+        commits = [
+            gc.Commit('a', 'a1', 'Has PR ref (#10)', ['lexical-graph/a.py']),
+            gc.Commit('b', 'b2', 'No PR ref', ['lexical-graph/b.py']),
+        ]
+        out = gc.render(commits, gc.LEXICAL, None)
+        assert '- Has PR ref (#10)\n' in out
+        assert '- No PR ref (b2)' in out
+
+    def test_empty_relevant_shows_no_changes(self):
+        commits = [gc.Commit('b', 'b2', 'BYOKG only', ['byokg-rag/b.py'])]
+        out = gc.render(commits, gc.LEXICAL, None)
+        assert '_No changes._' in out

--- a/.github/scripts/test_generate_changelog.py
+++ b/.github/scripts/test_generate_changelog.py
@@ -230,3 +230,39 @@ class TestPreviousReleaseTag:
         monkeypatch.chdir(repo)
 
         assert gc.previous_release_tag('lexical-graph', 'HEAD') is None
+
+    def test_non_ancestor_release_is_still_the_baseline(self, tmp_path, monkeypatch):
+        """A release tagged on a divergent branch (squash-downmerge) must still be
+        chosen — not skipped in favour of an older ancestor tag."""
+        repo = tmp_path
+        _git(repo, 'init', '-q', '-b', 'main')
+        _commit(repo, 'c1', '2020-01-01T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.0.0', '2020-01-01T00:00:00')
+        # v1.1.0 is tagged on a release branch that never merges back linearly.
+        _git(repo, 'checkout', '-q', '-b', 'release')
+        _commit(repo, 'r1', '2020-01-02T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.1.0', '2020-01-02T00:00:00')
+        _git(repo, 'checkout', '-q', 'main')
+        _commit(repo, 'c2', '2020-01-03T00:00:00')  # HEAD not descended from v1.1.0
+        monkeypatch.chdir(repo)
+
+        # v1.1.0 is NOT an ancestor of HEAD, but it is the most recent release, so
+        # it must be the baseline (not the older, ancestor v1.0.0).
+        assert gc.previous_release_tag('lexical-graph', 'HEAD') == 'graphrag-lexical-graph/v1.1.0'
+
+    def test_both_skips_same_commit_sibling_tag(self, tmp_path, monkeypatch):
+        """For `both`, the sibling project's tag on the same release commit must
+        not be chosen as the baseline (that would yield an empty changelog)."""
+        repo = tmp_path
+        _git(repo, 'init', '-q', '-b', 'main')
+        _commit(repo, 'c1', '2020-01-01T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.0.0', '2020-01-01T00:00:00')
+        _tag(repo, 'graphrag-byokg/v1.0.0', '2020-01-01T00:00:01')
+        _commit(repo, 'c2', '2020-01-02T00:00:00')
+        # The release commit carries both projects' tags (identical commit).
+        _tag(repo, 'graphrag-lexical-graph/v1.1.0', '2020-01-02T00:00:00')
+        _tag(repo, 'graphrag-byokg/v1.1.0', '2020-01-02T00:00:01')
+        monkeypatch.chdir(repo)
+
+        baseline = gc.previous_release_tag('both', 'graphrag-lexical-graph/v1.1.0')
+        assert baseline in ('graphrag-lexical-graph/v1.0.0', 'graphrag-byokg/v1.0.0')

--- a/.github/scripts/test_generate_changelog.py
+++ b/.github/scripts/test_generate_changelog.py
@@ -1,6 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for generate_changelog.py (pure functions; no git required)."""
+"""Unit tests for generate_changelog.py.
+
+Most tests exercise the pure functions and need no git. TestPreviousReleaseTag
+builds a throwaway git repo in a tmp dir to lock in the baseline-selection logic
+(same-project tags only, .dev prereleases skipped, current ref excluded).
+"""
+
+import os
+import subprocess
 
 import generate_changelog as gc
 
@@ -136,3 +144,89 @@ class TestRender:
         commits = [gc.Commit('b', 'b2', 'BYOKG only', ['byokg-rag/b.py'])]
         out = gc.render(commits, gc.LEXICAL, None)
         assert '_No changes._' in out
+
+
+def _git(repo, *args, date=None):
+    """Run git in `repo` with a fixed identity and (optionally) a fixed date.
+
+    A fixed date makes tag creatordate ordering deterministic, so
+    --sort=-creatordate in previous_release_tag returns a stable result.
+    """
+    env = {
+        **os.environ,
+        'GIT_AUTHOR_NAME': 'test', 'GIT_AUTHOR_EMAIL': 'test@example.com',
+        'GIT_COMMITTER_NAME': 'test', 'GIT_COMMITTER_EMAIL': 'test@example.com',
+    }
+    if date:
+        env['GIT_AUTHOR_DATE'] = date
+        env['GIT_COMMITTER_DATE'] = date
+    subprocess.run(['git', *args], cwd=repo, env=env, check=True, capture_output=True, text=True)
+
+
+def _commit(repo, message, date):
+    (repo / 'file.txt').write_text(message)
+    _git(repo, 'add', '.', date=date)
+    _git(repo, 'commit', '-m', message, date=date)
+
+
+def _tag(repo, name, date):
+    # Annotated tags so creatordate is the (fixed) tagger date.
+    _git(repo, 'tag', '-a', name, '-m', name, date=date)
+
+
+class TestPreviousReleaseTag:
+    """git-backed tests for previous_release_tag baseline selection."""
+
+    def _init(self, repo):
+        _git(repo, 'init', '-q')
+
+    def test_skips_dev_prerelease_and_other_project(self, tmp_path, monkeypatch):
+        repo = tmp_path
+        self._init(repo)
+        _commit(repo, 'c1', '2020-01-01T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.0.0', '2020-01-01T00:00:00')
+        _commit(repo, 'c2', '2020-01-02T00:00:00')
+        # A .dev prerelease and an other-project tag must both be ignored for lexical.
+        _tag(repo, 'graphrag-lexical-graph/v1.1.0.dev1', '2020-01-02T00:00:00')
+        _tag(repo, 'graphrag-byokg/v2.0.0', '2020-01-02T00:00:01')
+        _commit(repo, 'c3', '2020-01-03T00:00:00')
+        monkeypatch.chdir(repo)
+
+        assert gc.previous_release_tag('lexical-graph', 'HEAD') == 'graphrag-lexical-graph/v1.0.0'
+        assert gc.previous_release_tag('byokg', 'HEAD') == 'graphrag-byokg/v2.0.0'
+
+    def test_picks_most_recent_release(self, tmp_path, monkeypatch):
+        repo = tmp_path
+        self._init(repo)
+        _commit(repo, 'c1', '2020-01-01T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.0.0', '2020-01-01T00:00:00')
+        _commit(repo, 'c2', '2020-01-02T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.2.0', '2020-01-02T00:00:00')
+        _commit(repo, 'c3', '2020-01-03T00:00:00')
+        monkeypatch.chdir(repo)
+
+        assert gc.previous_release_tag('lexical-graph', 'HEAD') == 'graphrag-lexical-graph/v1.2.0'
+        # 'both' considers either project's tags.
+        assert gc.previous_release_tag('both', 'HEAD') == 'graphrag-lexical-graph/v1.2.0'
+
+    def test_excludes_the_ref_being_released(self, tmp_path, monkeypatch):
+        repo = tmp_path
+        self._init(repo)
+        _commit(repo, 'c1', '2020-01-01T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v1.0.0', '2020-01-01T00:00:00')
+        _commit(repo, 'c2', '2020-01-02T00:00:00')
+        _tag(repo, 'graphrag-lexical-graph/v2.0.0', '2020-01-02T00:00:00')
+        monkeypatch.chdir(repo)
+
+        # Releasing v2.0.0 should diff against the prior release, not itself.
+        assert gc.previous_release_tag(
+            'lexical-graph', 'graphrag-lexical-graph/v2.0.0'
+        ) == 'graphrag-lexical-graph/v1.0.0'
+
+    def test_none_when_no_release_tag(self, tmp_path, monkeypatch):
+        repo = tmp_path
+        self._init(repo)
+        _commit(repo, 'c1', '2020-01-01T00:00:00')
+        monkeypatch.chdir(repo)
+
+        assert gc.previous_release_tag('lexical-graph', 'HEAD') is None

--- a/.github/scripts/test_update_release_notes.py
+++ b/.github/scripts/test_update_release_notes.py
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the idempotent release-notes merge logic."""
+
+from update_release_notes import (
+    CHANGELOG_START,
+    CHANGELOG_END,
+    merge_release_body,
+)
+
+CHANGELOG = "## What's changed in byokg\n\n- Fix a thing (#1)\n"
+
+
+def _block_count(body: str) -> int:
+    return body.count(CHANGELOG_START)
+
+
+class TestMergeReleaseBody:
+    def test_appends_block_after_author_notes(self):
+        body = merge_release_body('Author notes here.', CHANGELOG)
+        assert body.startswith('Author notes here.')
+        assert CHANGELOG_START in body and CHANGELOG_END in body
+        assert 'Fix a thing (#1)' in body
+        # The author's notes precede the generated block.
+        assert body.index('Author notes here.') < body.index(CHANGELOG_START)
+
+    def test_empty_body_yields_only_block(self):
+        body = merge_release_body('', CHANGELOG)
+        assert body == f'{CHANGELOG_START}\n{CHANGELOG.strip()}\n{CHANGELOG_END}\n'
+
+    def test_none_body_is_treated_as_empty(self):
+        assert merge_release_body(None, CHANGELOG) == \
+            f'{CHANGELOG_START}\n{CHANGELOG.strip()}\n{CHANGELOG_END}\n'
+
+    def test_idempotent_across_reruns(self):
+        """Re-running with the same changelog must not duplicate the block."""
+        once = merge_release_body('Author notes.', CHANGELOG)
+        twice = merge_release_body(once, CHANGELOG)
+        assert once == twice
+        assert _block_count(twice) == 1
+
+    def test_replaces_stale_block_with_new_changelog(self):
+        """A regenerated changelog replaces the previous block, not appends to it."""
+        old = merge_release_body('Author notes.', "## Old\n\n- Old entry (#0)\n")
+        new = merge_release_body(old, CHANGELOG)
+        assert _block_count(new) == 1
+        assert 'Old entry (#0)' not in new
+        assert 'Fix a thing (#1)' in new
+        assert new.startswith('Author notes.')

--- a/.github/scripts/update_release_notes.py
+++ b/.github/scripts/update_release_notes.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Idempotently write a per-project changelog block into a GitHub release body.
+
+softprops/action-gh-release with ``append_body: true`` appends the changelog on
+every run, so re-running a release from the Actions UI - or a ``released`` event
+following a ``prereleased`` one for the same release - would append a second
+copy. This script instead reads the release's current body, removes any
+previously inserted changelog block (delimited by HTML-comment markers), appends
+a freshly generated block, and sets the body via ``gh release edit``. Running it
+again produces the same body, and author-written notes outside the markers are
+preserved.
+
+Usage:
+    update_release_notes.py --tag <release-tag> --changelog <path-to-md>
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from typing import List, Optional
+
+# HTML comments render invisibly in GitHub release notes, so the markers delimit
+# the auto-generated block without showing up in the rendered output.
+CHANGELOG_START = '<!-- auto-changelog:start -->'
+CHANGELOG_END = '<!-- auto-changelog:end -->'
+
+_BLOCK_RE = re.compile(
+    re.escape(CHANGELOG_START) + r'.*?' + re.escape(CHANGELOG_END),
+    re.DOTALL,
+)
+
+
+def merge_release_body(current_body: str, changelog: str) -> str:
+    """Return the release body with exactly one auto-changelog block.
+
+    Any existing marked block is removed first (so a re-run replaces it rather
+    than appending a duplicate), then a fresh block is appended after whatever
+    notes the author wrote. Idempotent: feeding the result back in with the same
+    changelog yields the same string.
+    """
+    body = _BLOCK_RE.sub('', current_body or '').rstrip()
+    block = f'{CHANGELOG_START}\n{changelog.strip()}\n{CHANGELOG_END}'
+    return f'{body}\n\n{block}\n' if body else f'{block}\n'
+
+
+def _gh(*args: str) -> str:
+    return subprocess.run(['gh', *args], check=True, capture_output=True, text=True).stdout
+
+
+def get_release_body(tag: str) -> str:
+    # `.body // ""` makes jq emit an empty string (not "null") for a release
+    # created without notes.
+    return _gh('release', 'view', tag, '--json', 'body', '--jq', '.body // ""')
+
+
+def set_release_body(tag: str, body: str) -> None:
+    with tempfile.NamedTemporaryFile('w', suffix='.md', delete=False, encoding='utf-8') as fh:
+        fh.write(body)
+        notes_path = fh.name
+    try:
+        _gh('release', 'edit', tag, '--notes-file', notes_path)
+    finally:
+        os.unlink(notes_path)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--tag', required=True, help='release tag to update')
+    parser.add_argument('--changelog', required=True,
+                        help='path to the generated changelog markdown')
+    args = parser.parse_args(argv)
+
+    with open(args.changelog, encoding='utf-8') as fh:
+        changelog = fh.read()
+
+    current_body = get_release_body(args.tag)
+    set_release_body(args.tag, merge_release_body(current_body, changelog))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/byokg-rag-prerelease.yml
+++ b/.github/workflows/byokg-rag-prerelease.yml
@@ -24,6 +24,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history + tags so the changelog generator can find the previous
+          # release tag and diff commit paths against it.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -62,6 +67,14 @@ jobs:
             VERSION="v$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')"
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Generate per-project changelog
+        working-directory: ${{ github.workspace }}
+        run: |
+          python .github/scripts/generate_changelog.py \
+            --project byokg \
+            --to "$GITHUB_REF_NAME" \
+            --output "$GITHUB_WORKSPACE/RELEASE_CHANGELOG.md"
 
       - name: Zip byokg-rag source
         run: |
@@ -113,6 +126,10 @@ jobs:
       - name: Attach artifacts to GitHub Pre-Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # Append the byokg-only changelog to the release notes, preserving any
+          # notes the release author already wrote.
+          body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
+          append_body: true
           files: |
             byokg-rag/dist/*
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/byokg-rag-prerelease.yml
+++ b/.github/workflows/byokg-rag-prerelease.yml
@@ -69,6 +69,8 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Generate per-project changelog
+        # Cosmetic step: never fail the release job (and block pypi-publish) over a changelog.
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         run: |
           python .github/scripts/generate_changelog.py \
@@ -135,6 +137,8 @@ jobs:
           prerelease: true
 
       - name: Update release notes with per-project changelog (idempotent)
+        # Cosmetic step: a release-notes hiccup must not fail the job or block publish.
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/byokg-rag-prerelease.yml
+++ b/.github/workflows/byokg-rag-prerelease.yml
@@ -126,12 +126,20 @@ jobs:
       - name: Attach artifacts to GitHub Pre-Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          # Append the byokg-only changelog to the release notes, preserving any
-          # notes the release author already wrote.
-          body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
-          append_body: true
+          # Assets only; the changelog is written idempotently in the next step
+          # (append_body here would duplicate it when a pre-release is re-run).
           files: |
             byokg-rag/dist/*
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
             examples/byokg-rag/byokg-notebooks-latest.zip
           prerelease: true
+
+      - name: Update release notes with per-project changelog (idempotent)
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python .github/scripts/update_release_notes.py \
+            --tag "$RELEASE_TAG" \
+            --changelog "$GITHUB_WORKSPACE/RELEASE_CHANGELOG.md"

--- a/.github/workflows/byokg-rag-release.yml
+++ b/.github/workflows/byokg-rag-release.yml
@@ -25,6 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history + tags so the changelog generator can find the previous
+          # release tag and diff commit paths against it.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -64,6 +69,14 @@ jobs:
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "pypi_version=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Generate per-project changelog
+        working-directory: ${{ github.workspace }}
+        run: |
+          python .github/scripts/generate_changelog.py \
+            --project byokg \
+            --to "$GITHUB_REF_NAME" \
+            --output "$GITHUB_WORKSPACE/RELEASE_CHANGELOG.md"
 
       - name: Zip byokg-rag source
         run: |
@@ -115,6 +128,10 @@ jobs:
       - name: Attach artifacts to GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # Append the byokg-only changelog to the release notes, preserving any
+          # notes the release author already wrote.
+          body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
+          append_body: true
           files: |
             byokg-rag/dist/*
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/byokg-rag-release.yml
+++ b/.github/workflows/byokg-rag-release.yml
@@ -71,6 +71,8 @@ jobs:
           echo "pypi_version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Generate per-project changelog
+        # Cosmetic step: never fail the release job (and block pypi-publish) over a changelog.
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         run: |
           python .github/scripts/generate_changelog.py \
@@ -137,6 +139,8 @@ jobs:
           prerelease: false
 
       - name: Update release notes with per-project changelog (idempotent)
+        # Cosmetic step: a release-notes hiccup must not fail the job or block publish.
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/byokg-rag-release.yml
+++ b/.github/workflows/byokg-rag-release.yml
@@ -128,15 +128,23 @@ jobs:
       - name: Attach artifacts to GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          # Append the byokg-only changelog to the release notes, preserving any
-          # notes the release author already wrote.
-          body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
-          append_body: true
+          # Assets only; the changelog is written idempotently in the next step
+          # (append_body here would duplicate it when a release is re-run).
           files: |
             byokg-rag/dist/*
             examples/byokg-rag/byokg-notebooks-${{ steps.version.outputs.version }}.zip
             examples/byokg-rag/byokg-notebooks-latest.zip
           prerelease: false
+
+      - name: Update release notes with per-project changelog (idempotent)
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python .github/scripts/update_release_notes.py \
+            --tag "$RELEASE_TAG" \
+            --changelog "$GITHUB_WORKSPACE/RELEASE_CHANGELOG.md"
 
   pypi-publish:
     if: github.event.action == 'released'

--- a/.github/workflows/changelog-tools-tests.yml
+++ b/.github/workflows/changelog-tools-tests.yml
@@ -1,0 +1,37 @@
+# Runs the unit tests for the release-tooling scripts under .github/scripts on
+# any change to those scripts or to this workflow.
+name: Changelog Tools Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/changelog-tools-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/changelog-tools-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: python -m pip install --disable-pip-version-check pytest
+
+      - name: Run tests
+        working-directory: .github/scripts
+        run: python -m pytest -v

--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -33,6 +33,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history + tags so the changelog generator can find the previous
+          # release tag and diff commit paths against it.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -72,6 +77,14 @@ jobs:
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "pypi_version=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Generate per-project changelog
+        working-directory: ${{ github.workspace }}
+        run: |
+          python .github/scripts/generate_changelog.py \
+            --project lexical-graph \
+            --to "$GITHUB_REF_NAME" \
+            --output "$GITHUB_WORKSPACE/RELEASE_CHANGELOG.md"
 
       - name: Zip lexical-graph notebooks
         working-directory: examples/lexical-graph/notebooks
@@ -142,6 +155,10 @@ jobs:
       - name: Attach Artifacts to GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # Append the lexical-graph-only changelog to the release notes,
+          # preserving any notes the release author already wrote.
+          body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
+          append_body: true
           files: |
             lexical-graph/dist/*
             examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -79,6 +79,8 @@ jobs:
           echo "pypi_version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Generate per-project changelog
+        # Cosmetic step: never fail release-build (and block pypi-publish) over a changelog.
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         run: |
           python .github/scripts/generate_changelog.py \
@@ -166,6 +168,8 @@ jobs:
           prerelease: ${{ github.event.action == 'prereleased' }}
 
       - name: Update release notes with per-project changelog (idempotent)
+        # Cosmetic step: a release-notes hiccup must not fail the job or block publish.
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/lexical-graph-release.yml
+++ b/.github/workflows/lexical-graph-release.yml
@@ -155,10 +155,8 @@ jobs:
       - name: Attach Artifacts to GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          # Append the lexical-graph-only changelog to the release notes,
-          # preserving any notes the release author already wrote.
-          body_path: ${{ github.workspace }}/RELEASE_CHANGELOG.md
-          append_body: true
+          # Assets only; the changelog is written idempotently in the next step
+          # (append_body here would duplicate it when a release is re-run).
           files: |
             lexical-graph/dist/*
             examples/lexical-graph/notebooks/lexical-graph-examples-${{ steps.version.outputs.version }}.zip
@@ -166,6 +164,16 @@ jobs:
             examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-${{ steps.version.outputs.version }}.zip
             examples/lexical-graph-hybrid-dev/notebooks/lexical-graph-hybrid-dev-examples-latest.zip
           prerelease: ${{ github.event.action == 'prereleased' }}
+
+      - name: Update release notes with per-project changelog (idempotent)
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python .github/scripts/update_release_notes.py \
+            --tag "$RELEASE_TAG" \
+            --changelog "$GITHUB_WORKSPACE/RELEASE_CHANGELOG.md"
 
   pypi-publish:
     if: github.event.action == 'released'

--- a/byokg-rag/RELEASE.md
+++ b/byokg-rag/RELEASE.md
@@ -17,9 +17,21 @@ This document describes the release process for the graphrag-toolkit components.
 5. Update the GitHub release to remove the pre-release label, promoting it to a full release.
 6. Test the final release from PyPI.
 
-TODO: 
-- filter changelog to show differences between graphrag-byokg/vX.Y.Z releases
-- filter out any differences not related to byokg (ie, lexical-graph changes)
+### Changelog
+
+Release notes are generated per project. The [BYOKG-RAG Pre-Release](/.github/workflows/byokg-rag-prerelease.yml) and [BYOKG-RAG Release](/.github/workflows/byokg-rag-release.yml) workflows append a byokg-only changelog to the GitHub release notes: commits that touched `byokg-rag/` or `examples/byokg*`, plus shared changes (docs, CI, etc.) that affect both projects. Commits that touched only `lexical-graph/` are excluded. The baseline is the previous released `graphrag-byokg/v*` tag (`.dev` prereleases are skipped).
+
+To preview the changelog locally before releasing:
+
+```bash
+# byokg changelog since the previous byokg release tag
+.github/release_message.sh byokg
+
+# ...or for an explicit tag
+python .github/scripts/generate_changelog.py --project byokg --to graphrag-byokg/vX.Y.Z
+```
+
+The path-based classifier lives in [.github/scripts/generate_changelog.py](/.github/scripts/generate_changelog.py).
 
 ### Step 1: Create a Pre-release Tag
 

--- a/lexical-graph/RELEASE.md
+++ b/lexical-graph/RELEASE.md
@@ -17,6 +17,22 @@ This document describes the release process for the graphrag-toolkit components.
 5. Update the GitHub release to remove the pre-release label, promoting it to a full release.
 6. Test the final release from PyPI.
 
+### Changelog
+
+Release notes are generated per project. The [Lexical Graph Release](/.github/workflows/lexical-graph-release.yml) workflow (which runs on both pre-release and release events) appends a lexical-graph-only changelog to the GitHub release notes: commits that touched `lexical-graph/`, `lexical-graph-contrib/`, or `examples/lexical-graph*`, plus shared changes (docs, CI, etc.) that affect both projects. Commits that touched only `byokg-rag/` are excluded. The baseline is the previous released `graphrag-lexical-graph/v*` tag (`.dev` prereleases are skipped).
+
+To preview the changelog locally before releasing:
+
+```bash
+# lexical-graph changelog since the previous lexical-graph release tag
+.github/release_message.sh lexical-graph
+
+# ...or for an explicit tag
+python .github/scripts/generate_changelog.py --project lexical-graph --to graphrag-lexical-graph/vX.Y.Z
+```
+
+The path-based classifier lives in [.github/scripts/generate_changelog.py](/.github/scripts/generate_changelog.py).
+
 ### Step 1: Create a Pre-release Tag
 
 All tags are created from the `main` branch, which is the ongoing development branch. Pre-release tags use a `.devN` suffix:


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Add a path-based changelog generator that classifies each commit by the project folders it touched, so per-project releases no longer list the other project's changes.

## Changes

<!-- List the key changes made -->

- classify commits by changed top-level folders
- `release_message.sh` now delegates to the generator for local previews (`release_message.sh lexical-graph|byokg|both`)
- Unit tests

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
