### PR TITLE
[FIX] Surface a failed document upload instead of hanging S3 staging

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -225,7 +225,9 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
             # count it can never reach.
             try:
                 queue.put(future.result(timeout=1.0))
-            except Exception as e:
+            except BaseException as e:
+                # BaseException, matching _doc_publisher: an interrupt in a worker
+                # strands the consumer as surely as a ClientError does.
                 logger.error(f'Error uploading source document: {str(e)}')
                 queue.put(_UploadFailed(e))
             finally:
@@ -283,7 +285,7 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
 
         logger.debug(f'About to start polling queue [count: {count}, target_count: {target_count}]')
 
-        failure = None
+        failures:List[BaseException] = []
 
         while target_count is None or count < target_count:
             try:
@@ -293,22 +295,33 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
                 else:
                     count += 1
                     if isinstance(item, _UploadFailed):
-                        failure = failure or item.cause
+                        failures.append(item.cause)
                     else:
                         yield item
                 self._queue.task_done()
             except queue.Empty:
                 # A producer that died before putting its count would otherwise
-                # keep the consumer here for the rest of the run.
+                # keep the consumer here for the rest of the run. Reaching here
+                # means the batch is short, so it is a failure rather than an end.
                 if not thread.is_alive():
+                    failures.append(RuntimeError(
+                        f'Upload producer stopped before reporting its document count '
+                        f'[count: {count}, target_count: {target_count}]'
+                    ))
                     break
             
         logger.debug(f'Waiting on queue to empty [count: {count}, target_count: {target_count}]')
 
         thread.join()
 
-        if failure is not None:
-            raise failure
+        if failures:
+            # The first is raised rather than aggregated: 3.10 has no ExceptionGroup.
+            if len(failures) > 1:
+                logger.error(
+                    f'{len(failures)} source documents failed to upload, raising the first '
+                    f'[batch_size: {len(source_docs_batch)}]'
+                )
+            raise failures[0]
 
     def upload(self, source_documents: List[SourceDocument]):
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -31,11 +31,26 @@ from llama_index.core.bridge.pydantic import PrivateAttr
 QUEUE_SIZE = 1000
 BATCH_SIZE = 100
 
+# How often the staging consumer wakes to check whether its producer is still
+# alive. Uploads are slow, so this paces the liveness check, not the work.
+QUEUE_POLL_SECONDS = 1.0
+
 logger = logging.getLogger(__name__)
 
 # Joins node ids before hashing them. Without a separator ['ab', 'c'] and
 # ['a', 'bc'] hash alike.
 _DOC_SUFFIX_DELIMITER = '\x00'
+
+class _UploadFailed:
+    """
+    Stands in for a document that did not upload.
+
+    The consumer counts one item per submitted document, so a failure has to
+    occupy a slot rather than being dropped.
+    """
+
+    def __init__(self, cause:BaseException):
+        self.cause = cause
 
 class ConfiguredThreadCount:
     """
@@ -201,37 +216,49 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
             
         except Exception as e:
             logger.error(f'Error while writing source document to S3: {str(e)}')
+            raise
 
     def _task_complete_callback(self, future):
         self._semaphore.release()
 
     def _get_callback_fn(self, queue:queue.Queue):
         def _task_complete_callback(future):
+            # The consumer counts one item per submitted document, so a failure
+            # has to put something too. Putting nothing leaves it polling for a
+            # count it can never reach.
             try:
-                doc = future.result(timeout=1.0)
-                queue.put(doc)
+                queue.put(future.result(timeout=1.0))
             except Exception as e:
-                logger.error(f'Error getting result from future: {str(e)}')
-            self._semaphore.release()
+                logger.error(f'Error uploading source document: {str(e)}')
+                queue.put(_UploadFailed(e))
+            finally:
+                self._semaphore.release()
         return _task_complete_callback
     
-    def _submit_proxy(self, function, executor, queue:queue.Queue, *args, **kwargs):
+    def _submit_proxy(self, function, executor, queue:queue.Queue, *args, **kwargs) -> bool:
+        """Submit one upload. Returns whether the consumer should expect an item."""
+        self._semaphore.acquire()
         try:
-            self._semaphore.acquire()
             future = executor.submit(function, *args, **kwargs)
-            future.add_done_callback(self._get_callback_fn(queue))
         except Exception as e:
             logger.exception(f'Error in submit proxy: {str(e)}')
+            self._semaphore.release()
+            return False
+
+        future.add_done_callback(self._get_callback_fn(queue))
+        return True
     
     def _doc_publisher(self, queue:queue.Queue, source_documents:List[SourceDocument]=[]):
 
         s3_client = GraphRAGConfig.s3
-        
+
+        count = 0
+
+        # The count goes on the queue whatever happens above, including a
+        # KeyboardInterrupt, or the consumer waits on a producer that has gone.
         try:
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=self._num_threads()) as executor:
-
-                count = 0
 
                 for source_document in source_documents:
 
@@ -240,14 +267,14 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
                     
                     root_path = join(self.collection_prefix, source_document.source_id())
                    
-                    self._submit_proxy(self._upload_doc, executor, queue, root_path, source_document, s3_client)
+                    if self._submit_proxy(self._upload_doc, executor, queue, root_path, source_document, s3_client):
+                        count += 1
 
-                    count += 1
-                
-            self._queue.put(count)
-
-        except Exception as e:
+        except BaseException as e:
             logger.exception(f'Error in doc publisher: {str(e)}')
+
+        finally:
+            self._queue.put(count)
 
     def _upload_batch(self, source_docs_batch:List[SourceDocument]):
 
@@ -259,21 +286,32 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
 
         logger.debug(f'About to start polling queue [count: {count}, target_count: {target_count}]')
 
+        failure = None
+
         while target_count is None or count < target_count:
             try:
-                item = self._queue.get(timeout=60.0)
+                item = self._queue.get(timeout=QUEUE_POLL_SECONDS)
                 if isinstance(item, int):
                     target_count = item
                 else:
                     count += 1
-                    yield item
+                    if isinstance(item, _UploadFailed):
+                        failure = failure or item.cause
+                    else:
+                        yield item
                 self._queue.task_done()
-            except queue.Empty as e:
-                continue
+            except queue.Empty:
+                # A producer that died before putting its count would otherwise
+                # keep the consumer here for the rest of the run.
+                if not thread.is_alive():
+                    break
             
         logger.debug(f'Waiting on queue to empty [count: {count}, target_count: {target_count}]')
 
         thread.join()
+
+        if failure is not None:
+            raise failure
 
     def upload(self, source_documents: List[SourceDocument]):
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -218,9 +218,6 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
             logger.error(f'Error while writing source document to S3: {str(e)}')
             raise
 
-    def _task_complete_callback(self, future):
-        self._semaphore.release()
-
     def _get_callback_fn(self, queue:queue.Queue):
         def _task_complete_callback(future):
             # The consumer counts one item per submitted document, so a failure

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import logging
 import queue
 import threading
 import time
@@ -1156,11 +1157,35 @@ class TestStagingSurfacesUploadFailures:
         uploader._queue = queue.Queue()
         consumed, finished = [], threading.Event()
 
+        error = []
+
         def consume():
-            consumed.extend(uploader._upload_batch(self._docs(1)))
+            try:
+                consumed.extend(uploader._upload_batch(self._docs(1)))
+            except BaseException as e:
+                error.append(e)
             finished.set()
 
         with patch.object(S3DocUploader, '_doc_publisher', side_effect=RuntimeError('dead')):
             threading.Thread(target=consume, daemon=True).start()
 
             assert finished.wait(timeout=8), 'consumer waited on a producer that had died'
+
+        assert error, 'a truncated batch returned without raising'
+        assert 'before reporting its document count' in str(error[0])
+
+    def test_every_failure_is_reported_not_only_the_first(self, caplog):
+        """Two documents fail. The first is raised, and the log says how many."""
+        docs = self._docs(3)
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p', num_threads=2)
+
+        def upload_doc(root_path, doc, s3_client):
+            if doc is docs[0] or doc is docs[1]:
+                raise RuntimeError('S3 write failed')
+            return doc
+
+        with caplog.at_level(logging.ERROR):
+            finished, _, error = self._consume(uploader, docs, upload_doc)
+
+        assert finished and error
+        assert any('2 source documents failed to upload' in r.message for r in caplog.records)

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import queue
 import threading
 import time
 
@@ -17,6 +18,9 @@ from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
 )
 from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
 from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
+from threading import Semaphore
+
+S3_BASED_DOCS = 'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs'
 
 
 class TestS3BasedDocsInitialization:
@@ -1060,3 +1064,103 @@ class TestDownloadDeduplicatesNodeIds:
         })
 
         assert len(doc.nodes) == 2
+
+
+class TestStagingSurfacesUploadFailures:
+    """
+    Every submitted document has to put exactly one item on the queue. Without
+    that, _upload_batch polls for a count it can never reach, and a failed
+    upload becomes a hung run rather than an error.
+    """
+
+    def _docs(self, n):
+        docs = []
+        for i in range(n):
+            node = TextNode(text='chunk text', id_=f'c{i}')
+            node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+                node_id=f'aws::src{i}:d41d'
+            )
+            docs.append(SourceDocument(nodes=[node]))
+        return docs
+
+    def _consume(self, uploader, docs, upload_doc, timeout=8):
+        """Run upload() on a thread so a hang shows up as a timeout, not a stall."""
+        yielded, finished, error = [], threading.Event(), []
+
+        def consume():
+            try:
+                with patch.object(S3DocUploader, '_upload_doc', side_effect=upload_doc), \
+                     patch(f'{S3_BASED_DOCS}.GraphRAGConfig'):
+                    yielded.extend(uploader.upload(list(docs)))
+            except Exception as e:
+                error.append(e)
+            finished.set()
+
+        threading.Thread(target=consume, daemon=True).start()
+        return finished.wait(timeout=timeout), yielded, error
+
+    def test_a_failed_upload_does_not_hang_the_run(self):
+        docs = self._docs(3)
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p', num_threads=2)
+
+        def upload_doc(root_path, doc, s3_client):
+            if doc is docs[1]:
+                raise RuntimeError('S3 write failed')
+            return doc
+
+        finished, _, _ = self._consume(uploader, docs, upload_doc)
+
+        assert finished, 'upload() never returned after a document failed'
+
+    def test_a_failed_upload_raises(self):
+        docs = self._docs(3)
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p', num_threads=2)
+
+        def upload_doc(root_path, doc, s3_client):
+            if doc is docs[1]:
+                raise RuntimeError('S3 write failed')
+            return doc
+
+        _, _, error = self._consume(uploader, docs, upload_doc)
+
+        assert error, 'a failed upload was not surfaced to the caller'
+
+    def test_a_failed_document_is_not_yielded_as_staged(self):
+        docs = self._docs(3)
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p', num_threads=2)
+
+        def upload_doc(root_path, doc, s3_client):
+            if doc is docs[1]:
+                raise RuntimeError('S3 write failed')
+            return doc
+
+        _, yielded, _ = self._consume(uploader, docs, upload_doc)
+
+        assert docs[1] not in yielded
+        assert None not in yielded
+
+    def test_every_document_is_yielded_when_all_succeed(self):
+        docs = self._docs(3)
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p', num_threads=2)
+
+        finished, yielded, error = self._consume(
+            uploader, docs, lambda root_path, doc, s3_client: doc
+        )
+
+        assert finished and not error
+        assert len(yielded) == 3
+
+    def test_a_dead_producer_does_not_hang_the_consumer(self):
+        uploader = S3DocUploader(bucket_name='b', collection_prefix='p', num_threads=2)
+        uploader._semaphore = Semaphore(2)
+        uploader._queue = queue.Queue()
+        consumed, finished = [], threading.Event()
+
+        def consume():
+            consumed.extend(uploader._upload_batch(self._docs(1)))
+            finished.set()
+
+        with patch.object(S3DocUploader, '_doc_publisher', side_effect=RuntimeError('dead')):
+            threading.Thread(target=consume, daemon=True).start()
+
+            assert finished.wait(timeout=8), 'consumer waited on a producer that had died'


### PR DESCRIPTION
## Description

A failed document upload during S3 staging either hangs the run with no exception, or is reported as successfully staged. Both are silent, so a failed upload looks like a slow run or a clean one.

`_upload_batch` polls until it has seen one item per submitted document and treats `queue.Empty` as "keep waiting", never checking whether its producer is still alive. Three `except Exception: log` blocks could each leave that count unreachable.

What stops it firing today is `_upload_doc` swallowing its own S3 exception and returning `None`. The callback puts that `None`, the count advances, and the document is yielded and counted in the "Finished writing N source documents" total. The two defects are a pair: removing the swallow alone turns a silent success into a hang.

## Changes

One invariant — every submitted document puts exactly one item on the queue.

- `_get_callback_fn` always puts, a failure marker when the upload raised, and releases the semaphore in a `finally`.
- `_submit_proxy` reports whether it submitted, so the publisher counts only what the consumer will see.
- `_doc_publisher` puts its count in a `finally` and catches `BaseException`, so a producer that dies still releases the consumer.
- `_upload_batch` breaks out when the queue is empty and the producer is gone, and raises the first failure once the batch drains.
- `_upload_doc` stops swallowing.

The queue poll drops from 60s to 1s. It paces the liveness check rather than the work, so a dead producer is noticed in about a second instead of a minute.

## Problem

Related issue (if any): #

Introduced in `4b8743c0` ("Improved batch extract and S3BasedDocs for large ingests") rather than by a targeted change. #418 is the same symptom in the same path from a different cause and is already fixed. Also fixes #519.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`) — 2,112 in `tests/unit`
- [x] Tested manually (describe below)

Five tests, red before green, covering a failing document mid-batch, a dead producer, and the all-succeed path. No test previously failed a document mid-batch, which is the gap that hid this.

Checked against a real boto3 S3 client rather than a mock: `put_object` returns a genuine `ClientError`, the error propagates to the caller, no document is reported as staged, and the call returns instead of hanging.

One pre-existing failure is unrelated and reproduces on a clean tree: `test_integ_dependency_compatibility.py` errors with `No module named pip` in this venv.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

A caller that relied on a failed upload being silently skipped will now see the exception. That is the intended change.
