### PR TITLE
[FIX]: make entity linking deterministic across runs

### DIFF
--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/byokg_query_engine.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/byokg_query_engine.py
@@ -225,8 +225,10 @@ class ByoKGQueryEngine:
             if "draft-answer-generation" in artifacts and artifacts["draft-answer-generation"]:
                 linked_answers = self.entity_linker.link(artifacts["draft-answer-generation"], return_dict=False)
 
-            # Retrieve triplets if we have source entities
-            source_entities = list(set(semantic_linked_entities + linked_entities + linked_answers))
+            # Retrieve triplets if we have source entities.
+            # dict.fromkeys dedups while preserving first-seen order, so the
+            # seed order is reproducible (plain set() ordering is not).
+            source_entities = list(dict.fromkeys(semantic_linked_entities + linked_entities + linked_answers))
 
             if source_entities and self.triplet_retriever:
                 triplet_context = self.triplet_retriever.retrieve(query, source_entities)
@@ -235,7 +237,9 @@ class ByoKGQueryEngine:
             # Process paths if available
             if "path-extraction" in artifacts and artifacts["path-extraction"] and explored_entities and self.path_retriever:
                 metapaths = [[component.strip() for component in path.split("->")] for path in artifacts["path-extraction"]]
-                path_context = self.path_retriever.retrieve(list(explored_entities), metapaths,linked_answers)
+                # sorted() so the path retriever gets a reproducible order;
+                # explored_entities is a set, whose iteration order is not stable.
+                path_context = self.path_retriever.retrieve(sorted(explored_entities), metapaths,linked_answers)
                 self._add_to_context(retrieved_context, path_context)
 
             # Process graph queries

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/graphstore/neptune.py
@@ -146,7 +146,7 @@ class BaseNeptuneGraphStore(GraphStore):
         :return: Dict[node_id:Str, Any] node details
         """
         if self.node_type_to_property_mapping:
-            sub_query = " OR ".join([f"n.`{_escape_cypher_label(prop)}` in $node_ids" for prop in set(self.node_type_to_property_mapping.values())])
+            sub_query = " OR ".join([f"n.`{_escape_cypher_label(prop)}` in $node_ids" for prop in sorted(set(self.node_type_to_property_mapping.values()))])
             query = f'''MATCH (n)
                     WHERE {sub_query}
                     OR ID(n) IN $node_ids
@@ -199,7 +199,7 @@ class BaseNeptuneGraphStore(GraphStore):
         :return: Dict[node_id:Str, Dict[edge_type:Str, edge_ids:List[Str]]] or Dict[node_id:Str, Dict[edge_type:Str, List[(node_id:Str, edge_type:Str, node_id:Str)]]]
         """
         if self.node_type_to_property_mapping:
-            sub_query = " OR ".join([f"n.`{_escape_cypher_label(prop)}` in $node_ids" for prop in set(self.node_type_to_property_mapping.values())])
+            sub_query = " OR ".join([f"n.`{_escape_cypher_label(prop)}` in $node_ids" for prop in sorted(set(self.node_type_to_property_mapping.values()))])
             query = f'''MATCH (n) -[e]->(m)
                     WHERE {sub_query}
                     OR ID(n) IN $node_ids

--- a/byokg-rag/src/graphrag_toolkit/byokg_rag/indexing/fuzzy_string.py
+++ b/byokg-rag/src/graphrag_toolkit/byokg_rag/indexing/fuzzy_string.py
@@ -78,7 +78,10 @@ class FuzzyStringIndex(Index):
         :param vocab_list: list of vocab instances to add
 
         """
-        self.vocab = list(set(self.vocab) | set(vocab_list))
+        # sorted() gives a hash-independent vocab order; process.extract breaks
+        # equal-score ties by vocab position, so a stable order is what makes
+        # matching reproducible.
+        self.vocab = sorted(set(self.vocab) | set(vocab_list))
 
     def add_with_ids(self, ids, vocab_list):
         raise NotImplementedError(f"add_with_ids not implemented for {self.__class__.__name__}")

--- a/byokg-rag/tests/unit/graphstore/test_neptune.py
+++ b/byokg-rag/tests/unit/graphstore/test_neptune.py
@@ -191,13 +191,42 @@ class TestNeptuneAnalyticsGraphStore:
         )
         
         result = store.nodes()
-        
+
         assert isinstance(result, list)
         assert len(result) == 3
         assert 'n1' in result
         assert 'n2' in result
         assert 'n3' in result
-    
+
+    @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
+    def test_get_nodes_query_predicate_order_is_deterministic(self, mock_session, mock_neptune_client, mock_s3_client):
+        """get_nodes builds its OR predicates in sorted order, not set-iteration order.
+
+        The property set is iterated straight into the Cypher; without sorted()
+        the query text varies with the hash seed. Results are unaffected (OR
+        commutes) but the query string must be stable run to run.
+        """
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+        mock_session_instance.client.side_effect = lambda service, **kwargs: {
+            'neptune-graph': mock_neptune_client,
+            's3': mock_s3_client
+        }[service]
+
+        mock_neptune_client.execute_query.return_value = {
+            'payload': Mock(read=lambda: json.dumps({'results': []}).encode())
+        }
+
+        store = NeptuneAnalyticsGraphStore(graph_identifier='test-graph-id', region='us-west-2')
+        # distinct properties whose insertion order differs from sorted order
+        store.node_type_to_property_mapping = {'Person': 'name', 'Org': 'title', 'Loc': 'label'}
+
+        store.get_nodes(['n1'])
+
+        query = mock_neptune_client.execute_query.call_args[1]['queryString']
+        positions = [query.index(f'`{prop}`') for prop in ['label', 'name', 'title']]
+        assert positions == sorted(positions), f"predicates not in sorted order: {query}"
+
     @patch('graphrag_toolkit.byokg_rag.graphstore.neptune.boto3.Session')
     def test_neptune_store_get_linker_tasks(self, mock_session, mock_neptune_client, mock_s3_client):
         """Verify get_linker_tasks returns expected task list."""

--- a/byokg-rag/tests/unit/indexing/test_fuzzy_string.py
+++ b/byokg-rag/tests/unit/indexing/test_fuzzy_string.py
@@ -7,6 +7,7 @@ This module tests fuzzy string matching functionality including
 vocabulary management, exact matching, fuzzy matching, and topk retrieval.
 """
 
+import os
 import subprocess
 import sys
 
@@ -96,10 +97,14 @@ class TestFuzzyStringIndexDeterminism:
     """Regression tests for run-to-run reproducibility (nondeterminism fix)."""
 
     def _run_with_hashseed(self, seed):
+        # Inherit the parent env (PATH/VIRTUAL_ENV/PYTHONPATH) so the child can
+        # import the package; only override PYTHONHASHSEED. Replacing the whole
+        # env breaks import resolution in CI.
+        env = {**os.environ, 'PYTHONHASHSEED': str(seed)}
         out = subprocess.run(
             [sys.executable, '-c', _DETERMINISM_SNIPPET],
             capture_output=True, text=True, check=True,
-            env={'PYTHONHASHSEED': str(seed)},
+            env=env,
         )
         return out.stdout.strip()
 

--- a/byokg-rag/tests/unit/indexing/test_fuzzy_string.py
+++ b/byokg-rag/tests/unit/indexing/test_fuzzy_string.py
@@ -7,6 +7,9 @@ This module tests fuzzy string matching functionality including
 vocabulary management, exact matching, fuzzy matching, and topk retrieval.
 """
 
+import subprocess
+import sys
+
 import pytest
 from graphrag_toolkit.byokg_rag.indexing.fuzzy_string import FuzzyStringIndex
 
@@ -59,9 +62,78 @@ class TestFuzzyStringIndexAdd:
     def test_add_with_ids_not_implemented(self):
         """Verify add_with_ids raises NotImplementedError."""
         index = FuzzyStringIndex()
-        
+
         with pytest.raises(NotImplementedError):
             index.add_with_ids(['id1'], ['Amazon'])
+
+    def test_add_vocab_is_sorted(self):
+        """Vocab must be in a stable (sorted) order, not set-iteration order.
+
+        process.extract breaks equal-score ties by vocab position, so a
+        hash-dependent order makes matching nondeterministic across runs.
+        """
+        index = FuzzyStringIndex()
+        index.add(['Microsoft', 'Amazon', 'Google'])
+        index.add(['Apple', 'Amazon'])
+
+        assert index.vocab == sorted(index.vocab)
+        assert index.vocab == ['Amazon', 'Apple', 'Google', 'Microsoft']
+
+
+# Query that ties three candidates at score 100 (thefuzz lowercases before
+# scoring, so the casings are indistinguishable). With topk < 3 the tie must
+# be broken, which is exactly where hash-dependent vocab order used to leak.
+_DETERMINISM_SNIPPET = """
+from graphrag_toolkit.byokg_rag.indexing.fuzzy_string import FuzzyStringIndex
+index = FuzzyStringIndex()
+index.add(['Amazon', 'amazon', 'AMAZON', 'Google', 'Microsoft'])
+hits = index.query('amazon', topk=2)['hits']
+print('|'.join(h['document_id'] for h in hits))
+"""
+
+
+class TestFuzzyStringIndexDeterminism:
+    """Regression tests for run-to-run reproducibility (nondeterminism fix)."""
+
+    def _run_with_hashseed(self, seed):
+        out = subprocess.run(
+            [sys.executable, '-c', _DETERMINISM_SNIPPET],
+            capture_output=True, text=True, check=True,
+            env={'PYTHONHASHSEED': str(seed)},
+        )
+        return out.stdout.strip()
+
+    def test_matching_is_deterministic_across_hash_seeds(self):
+        """Same vocab + query + topk returns identical hits regardless of seed.
+
+        Runs in subprocesses because PYTHONHASHSEED only takes effect at
+        interpreter start; each seed shuffles set() iteration order differently.
+        Pre-fix this returned different candidates per seed among the tie group.
+
+        Note: the child imports the indexing package, which pulls faiss. That's
+        incidental to what we assert (only thefuzz matters here).
+        """
+        results = {self._run_with_hashseed(seed) for seed in range(5)}
+
+        assert len(results) == 1, f"nondeterministic hits across hash seeds: {results}"
+
+    def test_scores_independent_of_insertion_order(self):
+        """The fix only reorders vocab; per-candidate scores must not change.
+
+        Two indexes built with the same items in different insertion order must
+        return identical (document, score) pairs — pins the acceptance criterion
+        that scores are unchanged, only ordering/tie-breaks are made stable.
+        """
+        vocab = ['Amazon', 'Amazonian', 'Amazing', 'Google', 'Meta']
+        a = FuzzyStringIndex()
+        a.add(vocab)
+        b = FuzzyStringIndex()
+        b.add(list(reversed(vocab)))
+
+        hits_a = [(h['document_id'], h['match_score']) for h in a.query('Amazon', topk=5)['hits']]
+        hits_b = [(h['document_id'], h['match_score']) for h in b.query('Amazon', topk=5)['hits']]
+
+        assert hits_a == hits_b
 
 
 class TestFuzzyStringIndexQuery:

--- a/byokg-rag/tests/unit/test_byokg_query_engine.py
+++ b/byokg-rag/tests/unit/test_byokg_query_engine.py
@@ -159,6 +159,62 @@ class TestQueryEngineQuery:
             assert context.count('item2') == 1
 
 
+class TestQueryEngineSeedOrdering:
+    """Tests that seed sets fed to retrievers are deterministic (nondeterminism fix)."""
+
+    def test_source_entities_dedup_preserves_order(
+        self, mock_graph_store_with_schema, mock_llm_generator
+    ):
+        """source_entities must dedup while preserving first-seen order.
+
+        Guards the switch from list(set(...)) to list(dict.fromkeys(...)) at the
+        seed union, and sorted(explored_entities) for the path retriever.
+        """
+        mock_entity_linker = Mock()
+        # First call = extracted entities (has an internal duplicate),
+        # second call = draft answers (overlaps the first).
+        mock_entity_linker.link.side_effect = [
+            ['Organization', 'Portland', 'Organization'],
+            ['Portland', 'John Doe'],
+        ]
+
+        mock_kg_linker = Mock()
+        mock_kg_linker.task_prompts = "test"
+        mock_kg_linker.task_prompts_iterative = "test"
+        mock_kg_linker.generate_response.return_value = "<task-completion>FINISH</task-completion>"
+        mock_kg_linker.parse_response.return_value = {
+            'entity-extraction': ['Organization'],
+            'draft-answer-generation': ['Portland'],
+            'path-extraction': ['Organization->Portland'],
+        }
+
+        captured = {}
+        mock_triplet_retriever = Mock()
+        mock_triplet_retriever.retrieve.side_effect = (
+            lambda query, source_entities: captured.__setitem__('seeds', source_entities) or ['ctx']
+        )
+        mock_path_retriever = Mock()
+        mock_path_retriever.retrieve.side_effect = (
+            lambda entities, metapaths, answers: captured.__setitem__('path_entities', entities) or []
+        )
+
+        engine = ByoKGQueryEngine(
+            graph_store=mock_graph_store_with_schema,
+            llm_generator=mock_llm_generator,
+            entity_linker=mock_entity_linker,
+            triplet_retriever=mock_triplet_retriever,
+            path_retriever=mock_path_retriever,
+            kg_linker=mock_kg_linker,
+        )
+
+        engine.query("Who founded Organization?", iterations=1)
+
+        # deduped, first-seen order preserved (not set() ordering)
+        assert captured['seeds'] == ['Organization', 'Portland', 'John Doe']
+        # path retriever gets a stable sorted order
+        assert captured['path_entities'] == sorted({'Organization', 'Portland'})
+
+
 class TestQueryEngineGenerateResponse:
     """Tests for response generation."""
     


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Entity linking is nondeterministic. The same query on the same graph with the same `topk` returns different seed sets between runs — and sometimes a different *number* of seeds. On the demo KG, 5 identical runs produced 5 distinct seed sets.

## Changes

<!-- List the key changes made -->

- `fuzzy_string.py` — `sorted(set(...))` for a hash-independent vocab order
- `byokg_query_engine.py` — `list(dict.fromkeys(...))` for the seed union (order-preserving dedup) and `sorted(explored_entities)` for the path retriever input.

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
