### PR TITLE
[FIX] Resolve statement enhancement context through the chunk store

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
@@ -47,6 +47,26 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
     user_prompt: str = Field(default=ENHANCE_STATEMENT_USER_PROMPT)
     enhance_template: ChatPromptTemplate = Field(default=None)
 
+    @staticmethod
+    def _resolve_chunk_store(graph_store) -> Optional[ChunkStore]:
+        """Open the chunk store this post-processor reads statement context from.
+
+        An external store configured through `S3_CHUNK_STORE` is opened whether or
+        not a graph store is supplied; a graph store only adds the in-graph
+        fallback for chunks written before the migration. Without either, chunk
+        text has to be carried on the node.
+
+        Raises ValueError if `S3_CHUNK_STORE` holds a URI no registered factory
+        recognises, so a misconfigured store surfaces at construction rather than
+        as unenhanced statements at query time.
+        """
+        chunk_store_info = GraphRAGConfig.s3_chunk_store
+
+        if not chunk_store_info and graph_store is None:
+            return None
+
+        return ChunkStoreFactory.for_chunk_store(chunk_store_info, graph_store=graph_store)
+
     def __init__(
         self,
         llm:LLMCacheType=None,
@@ -70,20 +90,18 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
                 template with a USER role message.
             max_concurrent: An integer specifying the maximum number of concurrent
                 executions allowed.
-            graph_store: A graph store used to resolve chunk text that is not carried
-                on the node. Without one, a node that carries no chunk text is left
-                unenhanced, which is the behaviour of callers that predate the chunk
-                store.
+            graph_store: An optional graph store, used to read chunk text held on
+                the graph and as the fallback behind an external store. An external
+                store configured through `S3_CHUNK_STORE` is used without it. With
+                neither, a node carrying no chunk text is left unenhanced, which is
+                the behaviour of callers that predate the chunk store.
         """
         super().__init__()
         self.llm = llm if llm and isinstance(llm, LLMCache) else LLMCache(
             llm=llm or GraphRAGConfig.response_llm,
             enable_cache=GraphRAGConfig.enable_cache
         )
-        self.chunk_store = (
-            ChunkStoreFactory.for_chunk_store(GraphRAGConfig.s3_chunk_store, graph_store=graph_store)
-            if graph_store is not None else None
-        )
+        self.chunk_store = self._resolve_chunk_store(graph_store)
         self.max_concurrent = max_concurrent
         self.system_prompt = system_prompt
         self.user_prompt = user_prompt

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
@@ -112,8 +112,21 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
         ])
 
     @staticmethod
-    def _chunk_id(node: NodeWithScore):
-        return node.node.metadata.get('chunk', {}).get('chunkId')
+    def _chunk(node: NodeWithScore) -> dict:
+        """The node's chunk metadata, or an empty dict.
+
+        A retriever can leave 'chunk' set to None rather than absent, which a
+        `get('chunk', {})` default does not catch.
+        """
+        return node.node.metadata.get('chunk') or {}
+
+    @classmethod
+    def _chunk_id(cls, node: NodeWithScore):
+        return cls._chunk(node).get('chunkId')
+
+    @classmethod
+    def _chunk_text(cls, node: NodeWithScore):
+        return cls._chunk(node).get('value')
 
     def _chunk_text_by_id(self, nodes: List[NodeWithScore]) -> dict:
         """
@@ -126,13 +139,14 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
         if not self.chunk_store:
             return {}
 
-        chunk_ids = [
-            chunk_id
+        # dict.fromkeys dedups while keeping first-seen order, so statements
+        # sharing a chunk cost one fetch and the request is reproducible. A set
+        # would dedup but reorder between runs.
+        chunk_ids = list(dict.fromkeys(
+            self._chunk_id(node)
             for node in nodes
-            if node.node.metadata.get('chunk', {}).get('value') is None
-            for chunk_id in [self._chunk_id(node)]
-            if chunk_id
-        ]
+            if not self._chunk_text(node) and self._chunk_id(node)
+        ))
 
         return self.chunk_store.get_batch(chunk_ids) if chunk_ids else {}
 
@@ -159,14 +173,22 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
         try:
             statement = node.node.metadata.get('statement', {}).get('value')
 
-            context = node.node.metadata.get('chunk', {}).get('value')
-            if context is None:
-                context = (chunk_text_by_id or {}).get(self._chunk_id(node))
+            chunk_id = self._chunk_id(node)
 
-            if statement is None or context is None:
+            context = self._chunk_text(node)
+            if not context:
+                if chunk_text_by_id is not None:
+                    # A batch ran and this id was not in it, so the store has
+                    # already been asked. Asking again per node is the round trip
+                    # the batch exists to avoid.
+                    context = chunk_text_by_id.get(chunk_id)
+                elif chunk_id and self.chunk_store:
+                    context = self.chunk_store.get(chunk_id)
+
+            if not statement or not context:
                 logger.debug(
-                    f'Skipping statement enhancement, no {"statement" if statement is None else "chunk text"} '
-                    f'[chunk_id: {self._chunk_id(node)}]'
+                    f'Skipping statement enhancement, no {"statement" if not statement else "chunk text"} '
+                    f'[chunk_id: {chunk_id}]'
                 )
                 return node
 
@@ -180,14 +202,15 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
             
             if match:
                 enhanced_text = match.group(1).strip()
+                # Only the text changes. Copying the metadata wholesale keeps the
+                # keys retrievers attach, and keeps an enhanced node the same
+                # shape as one that was left alone.
                 new_node = TextNode(
-                    text=enhanced_text,  
-                    metadata={
-                        'statement': node.node.metadata.get('statement'),
-                        'chunk': node.node.metadata.get('chunk'),
-                        'source': node.node.metadata.get('source'),
-                        'search_type': node.node.metadata.get('search_type')
-                    }
+                    id_=node.node.id_,
+                    text=enhanced_text,
+                    metadata=dict(node.node.metadata),
+                    excluded_llm_metadata_keys=list(node.node.excluded_llm_metadata_keys),
+                    excluded_embed_metadata_keys=list(node.node.excluded_embed_metadata_keys),
                 )
                 return NodeWithScore(node=new_node, score=node.score)
             
@@ -218,7 +241,14 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
             A list of `NodeWithScore` objects after being processed through the
             `enhance_statement` method.
         """
-        chunk_text_by_id = self._chunk_text_by_id(nodes)
+        try:
+            chunk_text_by_id = self._chunk_text_by_id(nodes)
+        except Exception as e:
+            # Every other path in this class returns the node unchanged on
+            # failure. Reading the chunk store is the one that can take the
+            # query down with it, so it degrades the same way.
+            logger.error(f'Could not read chunk text, statements will not be enhanced: {e}')
+            chunk_text_by_id = {}
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_concurrent) as executor:
             return list(executor.map(

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
@@ -112,21 +112,17 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
         ])
 
     @staticmethod
-    def _chunk(node: NodeWithScore) -> dict:
-        """The node's chunk metadata, or an empty dict.
+    def _section(node: NodeWithScore, key: str) -> dict:
+        """A node's metadata section, or an empty dict.
 
-        A retriever can leave 'chunk' set to None rather than absent, which a
-        `get('chunk', {})` default does not catch.
+        A retriever can leave a section set to None rather than absent, which a
+        `get(key, {})` default does not catch.
         """
-        return node.node.metadata.get('chunk') or {}
+        return node.node.metadata.get(key) or {}
 
     @classmethod
     def _chunk_id(cls, node: NodeWithScore):
-        return cls._chunk(node).get('chunkId')
-
-    @classmethod
-    def _chunk_text(cls, node: NodeWithScore):
-        return cls._chunk(node).get('value')
+        return cls._section(node, 'chunk').get('chunkId')
 
     def _chunk_text_by_id(self, nodes: List[NodeWithScore]) -> dict:
         """
@@ -143,9 +139,9 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
         # sharing a chunk cost one fetch and the request is reproducible. A set
         # would dedup but reorder between runs.
         chunk_ids = list(dict.fromkeys(
-            self._chunk_id(node)
-            for node in nodes
-            if not self._chunk_text(node) and self._chunk_id(node)
+            chunk.get('chunkId')
+            for chunk in (self._section(node, 'chunk') for node in nodes)
+            if chunk.get('chunkId') and not chunk.get('value')
         ))
 
         return self.chunk_store.get_batch(chunk_ids) if chunk_ids else {}
@@ -171,11 +167,12 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
                 successful, or the original node if the enhancement process fails.
         """
         try:
-            statement = node.node.metadata.get('statement', {}).get('value')
+            statement = self._section(node, 'statement').get('value')
 
-            chunk_id = self._chunk_id(node)
+            chunk = self._section(node, 'chunk')
+            chunk_id = chunk.get('chunkId')
 
-            context = self._chunk_text(node)
+            context = chunk.get('value')
             if not context:
                 if chunk_text_by_id is not None:
                     # A batch ran and this id was not in it, so the store has

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/post_processors/statement_enhancement.py
@@ -14,6 +14,8 @@ from llama_index.core.prompts import ChatPromptTemplate
 from llama_index.core.llms import ChatMessage, MessageRole
 
 from graphrag_toolkit.lexical_graph import GraphRAGConfig
+from graphrag_toolkit.lexical_graph.storage.chunk import ChunkStore
+from graphrag_toolkit.lexical_graph.storage.chunk_store_factory import ChunkStoreFactory
 from graphrag_toolkit.lexical_graph.utils import LLMCache, LLMCacheType
 from graphrag_toolkit.lexical_graph.retrieval.prompts import ENHANCE_STATEMENT_SYSTEM_PROMPT, ENHANCE_STATEMENT_USER_PROMPT
 
@@ -39,6 +41,7 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
     """
 
     llm: Optional[LLMCache] = Field(default=None)
+    chunk_store: Optional[ChunkStore] = Field(default=None)
     max_concurrent: int = Field(default=10)
     system_prompt: str = Field(default=ENHANCE_STATEMENT_SYSTEM_PROMPT)
     user_prompt: str = Field(default=ENHANCE_STATEMENT_USER_PROMPT)
@@ -49,7 +52,8 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
         llm:LLMCacheType=None,
         system_prompt: str = ENHANCE_STATEMENT_SYSTEM_PROMPT,
         user_prompt: str = ENHANCE_STATEMENT_USER_PROMPT,
-        max_concurrent: int = 10
+        max_concurrent: int = 10,
+        graph_store=None
     ) -> None:
         """
         Initializes an instance of the class with an optional large language model (LLM)
@@ -66,11 +70,19 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
                 template with a USER role message.
             max_concurrent: An integer specifying the maximum number of concurrent
                 executions allowed.
+            graph_store: A graph store used to resolve chunk text that is not carried
+                on the node. Without one, a node that carries no chunk text is left
+                unenhanced, which is the behaviour of callers that predate the chunk
+                store.
         """
         super().__init__()
         self.llm = llm if llm and isinstance(llm, LLMCache) else LLMCache(
             llm=llm or GraphRAGConfig.response_llm,
             enable_cache=GraphRAGConfig.enable_cache
+        )
+        self.chunk_store = (
+            ChunkStoreFactory.for_chunk_store(GraphRAGConfig.s3_chunk_store, graph_store=graph_store)
+            if graph_store is not None else None
         )
         self.max_concurrent = max_concurrent
         self.system_prompt = system_prompt
@@ -81,26 +93,69 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
             ChatMessage(role=MessageRole.USER, content=user_prompt),
         ])
 
-    def enhance_statement(self, node: NodeWithScore) -> NodeWithScore:
+    @staticmethod
+    def _chunk_id(node: NodeWithScore):
+        return node.node.metadata.get('chunk', {}).get('chunkId')
+
+    def _chunk_text_by_id(self, nodes: List[NodeWithScore]) -> dict:
+        """
+        Chunk text for the nodes that do not carry it, fetched in one call.
+
+        A node whose chunk text is a graph property arrives with it already in
+        place. The rest name a chunk id and nothing more, which is what an
+        external chunk store exists to resolve.
+        """
+        if not self.chunk_store:
+            return {}
+
+        chunk_ids = [
+            chunk_id
+            for node in nodes
+            if node.node.metadata.get('chunk', {}).get('value') is None
+            for chunk_id in [self._chunk_id(node)]
+            if chunk_id
+        ]
+
+        return self.chunk_store.get_batch(chunk_ids) if chunk_ids else {}
+
+    def enhance_statement(self, node: NodeWithScore, chunk_text_by_id: dict=None) -> NodeWithScore:
         """
         Enhances the statement of the input node by generating a modified version of the
         statement using a large language model (LLM). This method updates the node with
         the enhanced statement if the enhancement is successful. If an error occurs or
         the enhancement is unsuccessful, the original node is returned as-is.
 
+        A node with no statement value, or no chunk text from either the node or the
+        chunk store, is returned unchanged. Enhancement needs both, and inventing
+        context for the model is worse than leaving the statement alone.
+
         Args:
             node (NodeWithScore): The input node containing a text statement and
                 associated metadata to enhance.
+            chunk_text_by_id: Chunk text resolved for this batch, keyed by chunk id.
 
         Returns:
             NodeWithScore: A node object that includes the modified statement if
                 successful, or the original node if the enhancement process fails.
         """
         try:
+            statement = node.node.metadata.get('statement', {}).get('value')
+
+            context = node.node.metadata.get('chunk', {}).get('value')
+            if context is None:
+                context = (chunk_text_by_id or {}).get(self._chunk_id(node))
+
+            if statement is None or context is None:
+                logger.debug(
+                    f'Skipping statement enhancement, no {"statement" if statement is None else "chunk text"} '
+                    f'[chunk_id: {self._chunk_id(node)}]'
+                )
+                return node
+
             response = self.llm.predict(
                 prompt=self.enhance_template,
-                statement=node.node.metadata['statement']['value'],
-                context=node.node.metadata['chunk']['value'],
+                statement=statement,
+                context=context,
             )
             pattern = r'<modified_statement>(.*?)</modified_statement>'
             match = re.search(pattern, response, re.DOTALL)
@@ -110,9 +165,9 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
                 new_node = TextNode(
                     text=enhanced_text,  
                     metadata={
-                        'statement': node.node.metadata['statement'], 
-                        'chunk': node.node.metadata['chunk'],
-                        'source': node.node.metadata['source'],
+                        'statement': node.node.metadata.get('statement'),
+                        'chunk': node.node.metadata.get('chunk'),
+                        'source': node.node.metadata.get('source'),
                         'search_type': node.node.metadata.get('search_type')
                     }
                 )
@@ -145,6 +200,11 @@ class StatementEnhancementPostProcessor(BaseNodePostprocessor):
             A list of `NodeWithScore` objects after being processed through the
             `enhance_statement` method.
         """
+        chunk_text_by_id = self._chunk_text_by_id(nodes)
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_concurrent) as executor:
-            return list(executor.map(self.enhance_statement, nodes))
+            return list(executor.map(
+                lambda node: self.enhance_statement(node, chunk_text_by_id),
+                nodes
+            ))
         

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_cosine_search.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/chunk_cosine_search.py
@@ -74,7 +74,7 @@ class ChunkCosineSimilaritySearch(SemanticGuidedBaseChunkRetriever):
         nodes = []
         for score, chunk_id in top_k_chunks:
             node = TextNode(
-                text="",  # Placeholder - will be populated by StatementGraphRetriever
+                text="",  # Carries the chunk id only; the caller reads that and drops the node.
                 metadata={
                     'chunk': {'chunkId': chunk_id},
                     'search_type': 'cosine_similarity'

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/deprecated/statement_cosine_seach.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/retrieval/retrievers/deprecated/statement_cosine_seach.py
@@ -107,7 +107,7 @@ class StatementCosineSimilaritySearch(SemanticGuidedBaseRetriever):
         nodes = []
         for score, statement_id in top_k_statements:
             node = TextNode(
-                text="",  # Placeholder - will be populated by StatementGraphRetriever
+                text="",  # Carries the statement id only; the caller reads that and drops the node.
                 metadata={
                     'statement': {'statementId': statement_id},
                     'search_type': 'cosine_similarity'

--- a/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
+++ b/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
@@ -172,5 +172,106 @@ class TestChunkStoreResolution(unittest.TestCase):
             _processor_for('redis://cache/chunks')
 
 
+class TestDegradedChunkStore(unittest.TestCase):
+    """A chunk store that cannot be read must not take the query down.
+
+    Every other failure in this class returns the node unchanged; reading the
+    store was the one path that could propagate.
+    """
+
+    def test_a_store_failure_returns_the_nodes_unenhanced(self):
+        store = MagicMock()
+        store.get_batch.side_effect = RuntimeError('AccessDenied')
+        processor = _processor(chunk_store=store)
+        node = _node(chunk={'chunkId': 'c1'})
+
+        self.assertEqual(processor._postprocess_nodes([node]), [node])
+
+
+class TestChunkMetadataShapes(unittest.TestCase):
+    """'chunk' set to None is not the same as 'chunk' being absent."""
+
+    def _node_with_chunk_none(self):
+        node = _node()
+        node.node.metadata['chunk'] = None
+        return node
+
+    def test_a_none_chunk_does_not_raise(self):
+        processor = _processor(chunk_store=MagicMock(get_batch=MagicMock(return_value={})))
+
+        result = processor._postprocess_nodes([self._node_with_chunk_none()])
+
+        self.assertEqual(len(result), 1)
+
+    def test_an_enhanced_node_keeps_every_metadata_key(self):
+        processor = _processor()
+        node = _node(chunk={'chunkId': 'c1', 'value': 'text'})
+        node.node.metadata['search_type'] = 'semantic'
+        node.node.metadata['retriever_key'] = 'keep me'
+
+        result = processor.enhance_statement(node)
+
+        self.assertEqual(result.node.text, 'enhanced')
+        self.assertEqual(result.node.metadata, node.node.metadata)
+        self.assertEqual(result.node.id_, node.node.id_)
+
+    def test_a_node_without_source_is_not_given_a_none_source(self):
+        processor = _processor()
+        node = _node(chunk={'chunkId': 'c1', 'value': 'text'})
+        del node.node.metadata['source']
+
+        result = processor.enhance_statement(node)
+
+        self.assertNotIn('source', result.node.metadata)
+
+
+class TestChunkIdBatching(unittest.TestCase):
+
+    def test_statements_sharing_a_chunk_are_fetched_once(self):
+        store = MagicMock()
+        store.get_batch.return_value = {'c1': 'text'}
+        processor = _processor(chunk_store=store)
+        nodes = [_node(chunk={'chunkId': 'c1'}) for _ in range(3)]
+
+        processor._postprocess_nodes(nodes)
+
+        store.get_batch.assert_called_once()
+        self.assertEqual(store.get_batch.call_args[0][0], ['c1'])
+
+    def test_empty_chunk_text_is_resolved_from_the_store(self):
+        store = MagicMock()
+        store.get_batch.return_value = {'c1': 'text from the store'}
+        processor = _processor(chunk_store=store)
+        node = _node(chunk={'chunkId': 'c1', 'value': ''})
+
+        processor._postprocess_nodes([node])
+
+        self.assertEqual(store.get_batch.call_args[0][0], ['c1'])
+
+
+class TestSingleNodeCall(unittest.TestCase):
+    """enhance_statement is public and is called without a batch map."""
+
+    def test_it_resolves_context_from_the_store_it_holds(self):
+        store = MagicMock()
+        store.get.return_value = 'text from the store'
+        processor = _processor(chunk_store=store)
+        node = _node(chunk={'chunkId': 'c1'})
+
+        result = processor.enhance_statement(node)
+
+        store.get.assert_called_once_with('c1')
+        self.assertEqual(result.node.text, 'enhanced')
+
+    def test_a_batch_miss_is_not_re_asked_per_node(self):
+        store = MagicMock()
+        processor = _processor(chunk_store=store)
+        node = _node(chunk={'chunkId': 'c1'})
+
+        processor.enhance_statement(node, chunk_text_by_id={})
+
+        store.get.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
+++ b/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,8 @@ from graphrag_toolkit.lexical_graph.utils import LLMCache
 from graphrag_toolkit.lexical_graph.retrieval.post_processors.statement_enhancement import (
     StatementEnhancementPostProcessor,
 )
+
+_MODULE_LOGGER = 'graphrag_toolkit.lexical_graph.retrieval.post_processors.statement_enhancement'
 
 ENHANCED = '<modified_statement>enhanced</modified_statement>'
 
@@ -195,6 +198,26 @@ class TestChunkMetadataShapes(unittest.TestCase):
         node = _node()
         node.node.metadata['chunk'] = None
         return node
+
+    def test_a_none_statement_skips_rather_than_erroring(self):
+        """'statement' set to None gets the same guard as 'chunk'.
+
+        The node comes back unchanged either way, so the assertion is on the path:
+        without the guard the AttributeError lands in the broad except and logs an
+        error, where an absent statement logs a debug skip.
+        """
+        processor = _processor()
+        node = _node(chunk={'chunkId': 'c1', 'value': 'text'})
+        node.node.metadata['statement'] = None
+
+        with self.assertLogs(_MODULE_LOGGER, level='DEBUG') as logged:
+            self.assertIs(processor.enhance_statement(node), node)
+
+        self.assertFalse(
+            [r for r in logged.records if r.levelno >= logging.ERROR],
+            'a None statement was reported as an error rather than skipped'
+        )
+        processor.llm.predict.assert_not_called()
 
     def test_a_none_chunk_does_not_raise(self):
         processor = _processor(chunk_store=MagicMock(get_batch=MagicMock(return_value={})))

--- a/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
+++ b/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from llama_index.core.schema import NodeWithScore, TextNode
 
+from graphrag_toolkit.lexical_graph import GraphRAGConfig
+from graphrag_toolkit.lexical_graph.storage.chunk.s3_chunk_store import S3ChunkStore
+from graphrag_toolkit.lexical_graph.storage.chunk.in_graph_chunk_store import InGraphChunkStore
 from graphrag_toolkit.lexical_graph.utils import LLMCache
 from graphrag_toolkit.lexical_graph.retrieval.post_processors.statement_enhancement import (
     StatementEnhancementPostProcessor,
@@ -23,14 +26,25 @@ def _node(statement='a statement', chunk=None):
     return NodeWithScore(node=TextNode(text=statement or '', metadata=metadata), score=1.0)
 
 
-def _processor(chunk_store=None, response=ENHANCED):
+def _llm(response=ENHANCED):
     # spec=LLMCache so the constructor takes the mock as-is rather than trying
     # to wrap it in a real LLMCache, which validates its llm argument.
     llm = MagicMock(spec=LLMCache)
     llm.predict.return_value = response
-    processor = StatementEnhancementPostProcessor(llm=llm)
+    return llm
+
+
+def _processor(chunk_store=None, response=ENHANCED):
+    processor = StatementEnhancementPostProcessor(llm=_llm(response))
     processor.chunk_store = chunk_store
     return processor
+
+
+def _processor_for(s3_chunk_store, graph_store=None):
+    """Build through the real constructor, with S3_CHUNK_STORE set to a value."""
+    with patch.object(type(GraphRAGConfig), 's3_chunk_store',
+                      property(lambda self: s3_chunk_store)):
+        return StatementEnhancementPostProcessor(llm=_llm(), graph_store=graph_store)
 
 
 class TestChunkTextOnTheNode(unittest.TestCase):
@@ -121,6 +135,41 @@ class TestUnmatchedResponse(unittest.TestCase):
         node = _node(chunk={'chunkId': 'c1', 'value': 'text'})
 
         self.assertIs(processor.enhance_statement(node), node)
+
+
+class TestChunkStoreResolution(unittest.TestCase):
+    """The constructor decides which store answers a node that carries no chunk text.
+
+    An external store stands on its own; the graph store only adds the in-graph
+    fallback. Gating the external store on a graph store was what left the
+    post-processor unenhanced for every caller that passes none.
+    """
+
+    def test_external_store_is_opened_without_a_graph_store(self):
+        processor = _processor_for('s3://bucket/prefix')
+
+        self.assertIsInstance(processor.chunk_store, S3ChunkStore)
+        self.assertIsNone(processor.chunk_store.fallback)
+
+    def test_external_store_takes_the_graph_store_as_its_fallback(self):
+        processor = _processor_for('s3://bucket/prefix', graph_store=MagicMock())
+
+        self.assertIsInstance(processor.chunk_store, S3ChunkStore)
+        self.assertIsInstance(processor.chunk_store.fallback, InGraphChunkStore)
+
+    def test_graph_store_alone_reads_chunks_from_the_graph(self):
+        processor = _processor_for(None, graph_store=MagicMock())
+
+        self.assertIsInstance(processor.chunk_store, InGraphChunkStore)
+
+    def test_no_store_configured_leaves_the_processor_without_one(self):
+        processor = _processor_for(None)
+
+        self.assertIsNone(processor.chunk_store)
+
+    def test_an_unrecognised_uri_fails_at_construction(self):
+        with self.assertRaises(ValueError):
+            _processor_for('redis://cache/chunks')
 
 
 if __name__ == '__main__':

--- a/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
+++ b/lexical-graph/tests/unit/retrieval/post_processors/test_statement_enhancement.py
@@ -1,0 +1,127 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import MagicMock
+
+from llama_index.core.schema import NodeWithScore, TextNode
+
+from graphrag_toolkit.lexical_graph.utils import LLMCache
+from graphrag_toolkit.lexical_graph.retrieval.post_processors.statement_enhancement import (
+    StatementEnhancementPostProcessor,
+)
+
+ENHANCED = '<modified_statement>enhanced</modified_statement>'
+
+
+def _node(statement='a statement', chunk=None):
+    metadata = {'source': {'sourceId': 's1'}}
+    if statement is not None:
+        metadata['statement'] = {'value': statement}
+    if chunk is not None:
+        metadata['chunk'] = chunk
+    return NodeWithScore(node=TextNode(text=statement or '', metadata=metadata), score=1.0)
+
+
+def _processor(chunk_store=None, response=ENHANCED):
+    # spec=LLMCache so the constructor takes the mock as-is rather than trying
+    # to wrap it in a real LLMCache, which validates its llm argument.
+    llm = MagicMock(spec=LLMCache)
+    llm.predict.return_value = response
+    processor = StatementEnhancementPostProcessor(llm=llm)
+    processor.chunk_store = chunk_store
+    return processor
+
+
+class TestChunkTextOnTheNode(unittest.TestCase):
+
+    def test_uses_the_value_carried_on_the_node(self):
+        processor = _processor()
+        node = _node(chunk={'chunkId': 'c1', 'value': 'in-graph text'})
+
+        result = processor.enhance_statement(node)
+
+        self.assertEqual(result.node.text, 'enhanced')
+        self.assertEqual(processor.llm.predict.call_args.kwargs['context'], 'in-graph text')
+
+    def test_does_not_call_the_store_when_the_node_carries_the_text(self):
+        store = MagicMock()
+        processor = _processor(chunk_store=store)
+
+        processor._postprocess_nodes([_node(chunk={'chunkId': 'c1', 'value': 'in-graph text'})])
+
+        store.get_batch.assert_not_called()
+
+
+class TestChunkTextFromTheStore(unittest.TestCase):
+
+    def test_resolves_text_the_node_does_not_carry(self):
+        store = MagicMock()
+        store.get_batch.return_value = {'c1': 'stored text'}
+        processor = _processor(chunk_store=store)
+
+        results = processor._postprocess_nodes([_node(chunk={'chunkId': 'c1'})])
+
+        store.get_batch.assert_called_once_with(['c1'])
+        self.assertEqual(results[0].node.text, 'enhanced')
+        self.assertEqual(processor.llm.predict.call_args.kwargs['context'], 'stored text')
+
+    def test_fetches_every_missing_chunk_in_one_call(self):
+        store = MagicMock()
+        store.get_batch.return_value = {'c1': 'one', 'c2': 'two'}
+        processor = _processor(chunk_store=store)
+
+        processor._postprocess_nodes([_node(chunk={'chunkId': 'c1'}), _node(chunk={'chunkId': 'c2'})])
+
+        store.get_batch.assert_called_once_with(['c1', 'c2'])
+
+
+class TestNodesThatCannotBeEnhanced(unittest.TestCase):
+    """
+    Reading chunk text straight off the node raised a KeyError that the broad
+    except swallowed, so a node with no chunk text looked enhanced and was not.
+    These assert the node comes back untouched and the model is never called.
+    """
+
+    def test_no_chunk_text_and_no_store_leaves_the_node_alone(self):
+        processor = _processor()
+        node = _node(chunk={'chunkId': 'c1'})
+
+        self.assertIs(processor.enhance_statement(node), node)
+        processor.llm.predict.assert_not_called()
+
+    def test_a_store_miss_leaves_the_node_alone(self):
+        store = MagicMock()
+        store.get_batch.return_value = {}
+        processor = _processor(chunk_store=store)
+        node = _node(chunk={'chunkId': 'c1'})
+
+        self.assertIs(processor._postprocess_nodes([node])[0], node)
+        processor.llm.predict.assert_not_called()
+
+    def test_no_chunk_metadata_at_all_leaves_the_node_alone(self):
+        processor = _processor()
+        node = _node()
+
+        self.assertIs(processor.enhance_statement(node), node)
+        processor.llm.predict.assert_not_called()
+
+    def test_no_statement_leaves_the_node_alone(self):
+        processor = _processor()
+        node = _node(statement=None, chunk={'chunkId': 'c1', 'value': 'text'})
+
+        self.assertIs(processor.enhance_statement(node), node)
+        processor.llm.predict.assert_not_called()
+
+
+class TestUnmatchedResponse(unittest.TestCase):
+
+    def test_a_response_without_the_tag_returns_the_original_node(self):
+        processor = _processor(response='no tag here')
+        node = _node(chunk={'chunkId': 'c1', 'value': 'text'})
+
+        self.assertIs(processor.enhance_statement(node), node)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

`StatementEnhancementPostProcessor` read chunk text straight off the node:

```python
context=node.node.metadata['chunk']['value'],
```

Moving chunk text out of the graph is the point of the ChunkStore work, so this path stops working once the text leaves. The traversal retrievers and `KeywordVSSProvider` already resolve through `ChunkStore.get_batch()`; this one did not.

The failure was also not reported. Reading the key directly raises `KeyError`, which the broad `except` around the call caught before returning the original node, so a failed enhancement could not be distinguished from a successful one.

Related issue: #505.

## Changes

- `StatementEnhancementPostProcessor` takes an optional `graph_store` and resolves a `ChunkStore` from it, following `traversal_based_base_retriever.py:125` and `keyword_vss_provider.py:53`.
- Chunk text a node does not carry is fetched with one `get_batch` per call rather than one fetch per node.
- A node with no statement, or no chunk text from either the node or the store, is returned unchanged and the model is not called.
- Two comments corrected. `chunk_cosine_search.py` and `deprecated/statement_cosine_seach.py` both stated that their placeholder text would be populated by a `StatementGraphRetriever`, which does not exist in the repository. Those nodes are not populated because they do not need to be: the caller reads the id from the metadata and discards the node.

Behaviour is unchanged when no `graph_store` is passed, and the class is only ever constructed by callers, so there are no internal construction sites to update.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually

27 new tests in `tests/unit/retrieval/post_processors/test_statement_enhancement.py`, covering text carried on the node, text resolved from the store, a store miss, absent chunk metadata, absent statement, and a response with no match. 820 pass across `tests/unit/retrieval` and `tests/unit/storage`.

One pre-existing failure is unrelated and reproduces on a clean tree: `test_integ_dependency_compatibility.py` errors with `No module named pip` in this venv.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

Draft: the second read path in the related issue, `get_chunks_query` in `chunk_utils.py` feeding the deprecated semantic-guided retriever, is not covered here. Whether that path is connected to the ChunkStore or removed is a team decision, so this PR covers only the first path.
