### PR TITLE
[FEATURE] Write a completion marker when every chunk for a document stored

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -12,7 +12,7 @@ import uuid
 import concurrent.futures
 
 from collections import deque
-from os.path import join
+from os.path import basename, join
 from datetime import datetime
 from itertools import repeat, islice
 from threading import Semaphore
@@ -33,16 +33,9 @@ BATCH_SIZE = 100
 
 logger = logging.getLogger(__name__)
 
-# Written into a source document's prefix once every chunk for that document
-# has stored successfully. Reserved: both downloaders skip any object whose
-# name starts with this, so a marker is never read back as a chunk.
-#
-# The full name carries a digest of the chunk ids it covers. An auto-tuned run
-# emits one source as several SourceDocuments, which share a prefix, so a fixed
-# name would let the last one written speak for all of them - a marker claiming
-# two chunks over a prefix holding four, or worse, one document's marker
-# certifying a prefix another document left truncated. Deriving the name the
-# way _doc_suffix derives the document key keeps them apart.
+# Reserved name for a completion marker. The rest of the name is a digest of
+# the chunk ids it covers, because one source can emit several SourceDocuments
+# into a shared prefix and each needs its own marker.
 COMPLETION_MARKER_PREFIX = '_COMPLETE-'
 
 # Joins node ids before hashing them. Without a separator ['ab', 'c'] and
@@ -51,7 +44,7 @@ _NODE_ID_DELIMITER = '\x00'
 
 
 def node_ids_hash(node_ids) -> str:
-    """A hash over a set of node ids, independent of the order they arrive in."""
+    """A hash over node ids, independent of the order they arrive in."""
     return get_hash(_NODE_ID_DELIMITER.join(sorted(node_ids)))
 
 
@@ -64,31 +57,22 @@ def is_completion_marker(key:str) -> bool:
     """
     Whether an object key is a completion marker.
 
-    TextNode.from_json accepts a marker as a node with a generated uuid and
-    empty text rather than rejecting it, so a listing that includes one turns
-    it into a phantom chunk. Both downloaders exclude markers here. Chunk
-    objects are named for a node id and document objects for a source id, so
-    neither can collide with this prefix.
+    TextNode.from_json turns a marker into a node with a generated uuid and
+    empty text rather than rejecting it, so a listing that keeps one gains a
+    phantom chunk.
     """
-    return key.rsplit('/', 1)[-1].startswith(COMPLETION_MARKER_PREFIX)
+    return basename(key).startswith(COMPLETION_MARKER_PREFIX)
 
 
 def written_nodes(doc:SourceDocument) -> List[TextNode]:
-    """
-    The nodes an uploader writes for a document.
-
-    A node carrying an index key is a vector store artefact rather than
-    document content, and no uploader stores it.
-    """
+    """The nodes an uploader stores. An index key marks a vector store artefact."""
     return [n for n in doc.nodes if INDEX_KEY not in n.metadata]
 
 class EncryptedPut:
     """
-    One place that knows how these uploaders encrypt what they store.
+    How these uploaders encrypt what they store.
 
-    A caller-supplied KMS key selects aws:kms, otherwise S3 managed keys. Both
-    uploaders wrote this branch out per object, which is four copies of a
-    decision that belongs in one.
+    A caller-supplied KMS key selects aws:kms, otherwise S3 managed keys.
     """
 
     # Supplied by the host class.
@@ -482,15 +466,10 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
         """
         Record that this document is complete.
 
-        Written last, after every chunk stored successfully, so its presence is
-        what separates a whole document from a truncated prefix. The hash covers
-        the chunk ids, which lets a reader tell a marker describing this prefix
-        from one an earlier run left behind.
-
-        A marker that fails to write is logged and not raised. The document is
-        then indistinguishable from an incomplete one, which costs a re-stage
-        and is the safe direction: raising here would break a stream that the
-        chunks themselves survived.
+        Written last, so its presence separates a whole document from a
+        truncated prefix. A failed write is logged rather than raised: no
+        marker costs a re-stage, where raising would lose a stream the chunks
+        themselves survived.
         """
         node_ids = sorted(n.node_id for n in nodes)
         marker = {
@@ -549,14 +528,10 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
                         for n in nodes
                     ]
                 else:
-                    # Nothing to write, so no prefix and no marker. A prefix
-                    # holding only a marker reads back as a document with no
-                    # nodes, whose source_id() is None, and a re-stage cannot
-                    # build a path from None.
-                    #
-                    # It still queues, rather than being yielded here. Yielding
-                    # now would jump every document already pending and break
-                    # the order this method promises.
+                    # No prefix: one holding only a marker reads back as a
+                    # document with no nodes, whose source_id() is None, and a
+                    # re-stage cannot build a path from None. Still queued, so
+                    # it keeps its place in the order upload() promises.
                     root_path = None
                     futures = []
                     logger.debug(f'Nothing to write for source document [source: {source_document.source_id()}]')

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -33,9 +33,65 @@ BATCH_SIZE = 100
 
 logger = logging.getLogger(__name__)
 
+# Written into a source document's prefix once every chunk for that document
+# has stored successfully. Reserved: both downloaders skip this key, so an
+# object of this name is never read back as a chunk.
+COMPLETION_MARKER_KEY = '_COMPLETE'
+
 # Joins node ids before hashing them. Without a separator ['ab', 'c'] and
 # ['a', 'bc'] hash alike.
-_DOC_SUFFIX_DELIMITER = '\x00'
+_NODE_ID_DELIMITER = '\x00'
+
+
+def node_ids_hash(node_ids) -> str:
+    """A hash over a set of node ids, independent of the order they arrive in."""
+    return get_hash(_NODE_ID_DELIMITER.join(sorted(node_ids)))
+
+
+def is_completion_marker(key:str) -> bool:
+    """
+    Whether an object key is a completion marker.
+
+    TextNode.from_json accepts a marker as a node with a generated uuid and
+    empty text rather than rejecting it, so a listing that includes one turns
+    it into a phantom chunk. Both downloaders exclude it here.
+    """
+    return key.rsplit('/', 1)[-1] == COMPLETION_MARKER_KEY
+
+
+def written_nodes(doc:SourceDocument) -> List[TextNode]:
+    """
+    The nodes an uploader writes for a document.
+
+    A node carrying an index key is a vector store artefact rather than
+    document content, and no uploader stores it.
+    """
+    return [n for n in doc.nodes if INDEX_KEY not in n.metadata]
+
+class EncryptedPut:
+    """
+    One place that knows how these uploaders encrypt what they store.
+
+    A caller-supplied KMS key selects aws:kms, otherwise S3 managed keys. Both
+    uploaders wrote this branch out per object, which is four copies of a
+    decision that belongs in one.
+    """
+
+    def _put(self, key:str, body:str, content_type:str, s3_client):
+        encryption = (
+            {'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': self.s3_encryption_key_id}
+            if self.s3_encryption_key_id
+            else {'ServerSideEncryption': 'AES256'}
+        )
+
+        s3_client.put_object(
+            Bucket=self.bucket_name,
+            Key=key,
+            Body=body.encode('UTF-8'),
+            ContentType=content_type,
+            **encryption
+        )
+
 
 class ConfiguredThreadCount:
     """
@@ -73,7 +129,8 @@ class S3DocDownloader(ConfiguredThreadCount, BaseComponent):
         node_keys = [
             node_obj['Key']
             for node_page in node_pages
-            for node_obj in node_page['Contents'] 
+            for node_obj in node_page['Contents']
+            if not is_completion_marker(node_obj['Key'])
         ]
 
         # Every object under the prefix merges into one SourceDocument, and a
@@ -138,7 +195,7 @@ class S3DocDownloader(ConfiguredThreadCount, BaseComponent):
                     logger.debug(f'Yielding source document [source: {doc.source_id()}, num_nodes: {len(doc.nodes)}]')
                     yield doc
 
-class S3DocUploader(ConfiguredThreadCount, BaseComponent):
+class S3DocUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
 
     bucket_name:str
     collection_prefix:str
@@ -147,10 +204,6 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
     _semaphore:Semaphore = PrivateAttr(default=None)
     _queue:queue.Queue = PrivateAttr(default=None)
     
-    def _written_nodes(self, doc:SourceDocument) -> List[TextNode]:
-        """The nodes this uploader writes into the object body."""
-        return [n for n in doc.nodes if INDEX_KEY not in n.metadata]
-
     def _doc_suffix(self, doc:SourceDocument) -> str:
         """
         What separates one object from another under a source document's prefix.
@@ -163,8 +216,7 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
         if not self.deterministic_document_key:
             return uuid.uuid4().hex[:5]
 
-        node_ids = sorted(n.node_id for n in self._written_nodes(doc))
-        return get_hash(_DOC_SUFFIX_DELIMITER.join(node_ids))[:5]
+        return node_ids_hash(n.node_id for n in written_nodes(doc))[:5]
 
     def _upload_doc(self, root_path:str, doc:SourceDocument, s3_client):
 
@@ -176,26 +228,10 @@ class S3DocUploader(ConfiguredThreadCount, BaseComponent):
 
             s = '\n'.join([
                 json.dumps(n.to_dict())
-                for n in self._written_nodes(doc)
+                for n in written_nodes(doc)
             ]) 
 
-            if self.s3_encryption_key_id:
-                s3_client.put_object(
-                    Bucket=self.bucket_name,
-                    Key=doc_output_path,
-                    Body=(bytes(s.encode('UTF-8'))),
-                    ContentType='text/plain',
-                    ServerSideEncryption='aws:kms',
-                    SSEKMSKeyId=self.s3_encryption_key_id
-                )
-            else:
-                s3_client.put_object(
-                    Bucket=self.bucket_name,
-                    Key=doc_output_path,
-                    Body=(bytes(s.encode('UTF-8'))),
-                    ContentType='text/plain',
-                    ServerSideEncryption='AES256'
-                )
+            self._put(doc_output_path, s, 'text/plain', s3_client)
 
             return doc
             
@@ -364,6 +400,7 @@ class S3ChunkDownloader(ConfiguredThreadCount, BaseComponent):
                     chunk_obj['Key']
                     for chunk_page in chunk_pages
                     for chunk_obj in chunk_page.get('Contents', [])
+                    if not is_completion_marker(chunk_obj['Key'])
                 ]
 
             # Bounded sliding window: at most num_threads listings prefetch ahead,
@@ -397,7 +434,7 @@ class S3ChunkDownloader(ConfiguredThreadCount, BaseComponent):
 
                 yield SourceDocument(nodes=nodes)
 
-class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
+class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
 
     bucket_name:str
     collection_prefix:str
@@ -408,30 +445,49 @@ class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
                     
         logger.debug(f'Writing chunk to S3: [bucket: {self.bucket_name}, key: {chunk_output_path}]')
 
-        if self.s3_encryption_key_id:
-            s3_client.put_object(
-                Bucket=self.bucket_name,
-                Key=chunk_output_path,
-                Body=(bytes(json.dumps(n.to_dict(), indent=4).encode('UTF-8'))),
-                ContentType='application/json',
-                ServerSideEncryption='aws:kms',
-                SSEKMSKeyId=self.s3_encryption_key_id
-            )
-        else:
-            s3_client.put_object(
-                Bucket=self.bucket_name,
-                Key=chunk_output_path,
-                Body=(bytes(json.dumps(n.to_dict(), indent=4).encode('UTF-8'))),
-                ContentType='application/json',
-                ServerSideEncryption='AES256'
-            )
+        self._put(
+            chunk_output_path, json.dumps(n.to_dict(), indent=4), 'application/json', s3_client
+        )
 
-    def _drain(self, futures):
+    def _drain(self, futures) -> bool:
+        """Wait on a document's uploads, reporting whether all of them landed."""
+        succeeded = True
         for future in futures:
             try:
                 future.result()
             except Exception as e:
                 logger.error(f'Error uploading chunk: {str(e)}')
+                succeeded = False
+        return succeeded
+
+    def _write_completion_marker(self, root_path:str, nodes:List[TextNode], s3_client):
+        """
+        Record that this document is complete.
+
+        Written last, after every chunk stored successfully, so its presence is
+        what separates a whole document from a truncated prefix. The hash covers
+        the chunk ids, which lets a reader tell a marker describing this prefix
+        from one an earlier run left behind.
+
+        A marker that fails to write is logged and not raised. The document is
+        then indistinguishable from an incomplete one, which costs a re-stage
+        and is the safe direction: raising here would break a stream that the
+        chunks themselves survived.
+        """
+        node_ids = sorted(n.node_id for n in nodes)
+        marker = {
+            'chunk_ids': node_ids,
+            'count': len(node_ids),
+            'content_hash': node_ids_hash(node_ids),
+        }
+
+        key = join(root_path, COMPLETION_MARKER_KEY)
+        logger.debug(f'Writing completion marker to S3 [bucket: {self.bucket_name}, key: {key}]')
+
+        try:
+            self._put(key, json.dumps(marker, indent=4), 'application/json', s3_client)
+        except Exception as e:
+            logger.error(f'Error writing completion marker [key: {key}]: {str(e)}')
 
     def upload(self, source_documents: List[SourceDocument]):
         """
@@ -456,8 +512,9 @@ class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
 
             def release_oldest():
                 nonlocal inflight
-                (oldest, oldest_futures) = pending.popleft()
-                self._drain(oldest_futures)
+                (oldest, root_path, nodes, oldest_futures) = pending.popleft()
+                if self._drain(oldest_futures):
+                    self._write_completion_marker(root_path, nodes, s3_client)
                 inflight -= len(oldest_futures)
                 return oldest
 
@@ -466,13 +523,14 @@ class S3ChunkUploader(ConfiguredThreadCount, BaseComponent):
                 root_path =  join(self.collection_prefix, source_document.source_id())
                 logger.debug(f'Writing source document to S3 [bucket: {self.bucket_name}, prefix: {root_path}]')
 
+                nodes = written_nodes(source_document)
+
                 futures = [
                     executor.submit(self._upload_chunk, root_path, n, s3_client)
-                    for n in source_document.nodes
-                    if not [key for key in [INDEX_KEY] if key in n.metadata]
+                    for n in nodes
                 ]
 
-                pending.append((source_document, futures))
+                pending.append((source_document, root_path, nodes, futures))
                 inflight += len(futures)
 
                 while inflight > max_inflight:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -12,7 +12,7 @@ import uuid
 import concurrent.futures
 
 from collections import deque
-from os.path import basename, join
+from os.path import basename, dirname, join
 from datetime import datetime
 from itertools import repeat, islice
 from threading import Semaphore
@@ -38,6 +38,11 @@ logger = logging.getLogger(__name__)
 # into a shared prefix and each needs its own marker.
 COMPLETION_MARKER_PREFIX = '_COMPLETE-'
 
+# Markers live under a reserved segment rather than beside the chunks. A chunk is
+# keyed by its node id, so a shared namespace means a node id starting with the
+# prefix reads back as a marker and is dropped from the document.
+COMPLETION_MARKER_DIR = '_markers'
+
 # Joins node ids before hashing them. Without a separator ['ab', 'c'] and
 # ['a', 'bc'] hash alike.
 _NODE_ID_DELIMITER = '\x00'
@@ -53,15 +58,21 @@ def completion_marker_name(node_ids) -> str:
     return f'{COMPLETION_MARKER_PREFIX}{node_ids_hash(node_ids)[:5]}'
 
 
+def completion_marker_key(root_path:str, node_ids) -> str:
+    """Where the marker covering exactly these chunk ids is stored."""
+    return join(root_path, COMPLETION_MARKER_DIR, completion_marker_name(node_ids))
+
+
 def is_completion_marker(key:str) -> bool:
     """
     Whether an object key is a completion marker.
 
-    TextNode.from_json turns a marker into a node with a generated uuid and
-    empty text rather than rejecting it, so a listing that keeps one gains a
-    phantom chunk.
+    Decided by the reserved segment, not the name: TextNode.from_json turns a
+    marker into a node with a generated uuid and empty text rather than
+    rejecting it, so a listing that keeps one gains a phantom chunk - and a
+    chunk whose node id opens with the marker prefix would be dropped.
     """
-    return basename(key).startswith(COMPLETION_MARKER_PREFIX)
+    return basename(dirname(key)) == COMPLETION_MARKER_DIR
 
 
 def written_nodes(doc:SourceDocument) -> List[TextNode]:
@@ -478,7 +489,7 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
             'content_hash': node_ids_hash(node_ids),
         }
 
-        key = join(root_path, completion_marker_name(node_ids))
+        key = completion_marker_key(root_path, node_ids)
         logger.debug(f'Writing completion marker to S3 [bucket: {self.bucket_name}, key: {key}]')
 
         try:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -147,7 +147,7 @@ class S3DocDownloader(ConfiguredThreadCount, BaseComponent):
         node_keys = [
             node_obj['Key']
             for node_page in node_pages
-            for node_obj in node_page['Contents']
+            for node_obj in node_page.get('Contents', [])
             if not is_completion_marker(node_obj['Key'])
         ]
 
@@ -531,7 +531,7 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
             def release_oldest():
                 nonlocal inflight
                 (oldest, root_path, nodes, oldest_futures) = pending.popleft()
-                if self._drain(oldest_futures):
+                if self._drain(oldest_futures) and nodes:
                     self._write_completion_marker(root_path, nodes, s3_client)
                 inflight -= len(oldest_futures)
                 return oldest
@@ -540,22 +540,26 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
 
                 nodes = written_nodes(source_document)
 
-                if not nodes:
-                    # No prefix at all rather than a prefix holding only a
-                    # marker. An empty prefix reads back as a document with no
-                    # nodes, whose source_id() is None, which a re-stage cannot
-                    # build a path from. S3DocUploader skips these too.
-                    logger.debug(f'Skipping source document with nothing to write [source: {source_document.source_id()}]')
-                    yield source_document
-                    continue
+                if nodes:
+                    root_path =  join(self.collection_prefix, source_document.source_id())
+                    logger.debug(f'Writing source document to S3 [bucket: {self.bucket_name}, prefix: {root_path}]')
 
-                root_path =  join(self.collection_prefix, source_document.source_id())
-                logger.debug(f'Writing source document to S3 [bucket: {self.bucket_name}, prefix: {root_path}]')
-
-                futures = [
-                    executor.submit(self._upload_chunk, root_path, n, s3_client)
-                    for n in nodes
-                ]
+                    futures = [
+                        executor.submit(self._upload_chunk, root_path, n, s3_client)
+                        for n in nodes
+                    ]
+                else:
+                    # Nothing to write, so no prefix and no marker. A prefix
+                    # holding only a marker reads back as a document with no
+                    # nodes, whose source_id() is None, and a re-stage cannot
+                    # build a path from None.
+                    #
+                    # It still queues, rather than being yielded here. Yielding
+                    # now would jump every document already pending and break
+                    # the order this method promises.
+                    root_path = None
+                    futures = []
+                    logger.debug(f'Nothing to write for source document [source: {source_document.source_id()}]')
 
                 pending.append((source_document, root_path, nodes, futures))
                 inflight += len(futures)

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/load/s3_based_docs.py
@@ -34,9 +34,16 @@ BATCH_SIZE = 100
 logger = logging.getLogger(__name__)
 
 # Written into a source document's prefix once every chunk for that document
-# has stored successfully. Reserved: both downloaders skip this key, so an
-# object of this name is never read back as a chunk.
-COMPLETION_MARKER_KEY = '_COMPLETE'
+# has stored successfully. Reserved: both downloaders skip any object whose
+# name starts with this, so a marker is never read back as a chunk.
+#
+# The full name carries a digest of the chunk ids it covers. An auto-tuned run
+# emits one source as several SourceDocuments, which share a prefix, so a fixed
+# name would let the last one written speak for all of them - a marker claiming
+# two chunks over a prefix holding four, or worse, one document's marker
+# certifying a prefix another document left truncated. Deriving the name the
+# way _doc_suffix derives the document key keeps them apart.
+COMPLETION_MARKER_PREFIX = '_COMPLETE-'
 
 # Joins node ids before hashing them. Without a separator ['ab', 'c'] and
 # ['a', 'bc'] hash alike.
@@ -48,15 +55,22 @@ def node_ids_hash(node_ids) -> str:
     return get_hash(_NODE_ID_DELIMITER.join(sorted(node_ids)))
 
 
+def completion_marker_name(node_ids) -> str:
+    """The marker name covering exactly these chunk ids."""
+    return f'{COMPLETION_MARKER_PREFIX}{node_ids_hash(node_ids)[:5]}'
+
+
 def is_completion_marker(key:str) -> bool:
     """
     Whether an object key is a completion marker.
 
     TextNode.from_json accepts a marker as a node with a generated uuid and
     empty text rather than rejecting it, so a listing that includes one turns
-    it into a phantom chunk. Both downloaders exclude it here.
+    it into a phantom chunk. Both downloaders exclude markers here. Chunk
+    objects are named for a node id and document objects for a source id, so
+    neither can collide with this prefix.
     """
-    return key.rsplit('/', 1)[-1] == COMPLETION_MARKER_KEY
+    return key.rsplit('/', 1)[-1].startswith(COMPLETION_MARKER_PREFIX)
 
 
 def written_nodes(doc:SourceDocument) -> List[TextNode]:
@@ -76,6 +90,10 @@ class EncryptedPut:
     uploaders wrote this branch out per object, which is four copies of a
     decision that belongs in one.
     """
+
+    # Supplied by the host class.
+    bucket_name:str
+    s3_encryption_key_id:Optional[str]
 
     def _put(self, key:str, body:str, content_type:str, s3_client):
         encryption = (
@@ -481,7 +499,7 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
             'content_hash': node_ids_hash(node_ids),
         }
 
-        key = join(root_path, COMPLETION_MARKER_KEY)
+        key = join(root_path, completion_marker_name(node_ids))
         logger.debug(f'Writing completion marker to S3 [bucket: {self.bucket_name}, key: {key}]')
 
         try:
@@ -520,10 +538,19 @@ class S3ChunkUploader(ConfiguredThreadCount, EncryptedPut, BaseComponent):
 
             for source_document in source_documents:
 
+                nodes = written_nodes(source_document)
+
+                if not nodes:
+                    # No prefix at all rather than a prefix holding only a
+                    # marker. An empty prefix reads back as a document with no
+                    # nodes, whose source_id() is None, which a re-stage cannot
+                    # build a path from. S3DocUploader skips these too.
+                    logger.debug(f'Skipping source document with nothing to write [source: {source_document.source_id()}]')
+                    yield source_document
+                    continue
+
                 root_path =  join(self.collection_prefix, source_document.source_id())
                 logger.debug(f'Writing source document to S3 [bucket: {self.bucket_name}, prefix: {root_path}]')
-
-                nodes = written_nodes(source_document)
 
                 futures = [
                     executor.submit(self._upload_chunk, root_path, n, s3_client)

--- a/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
+++ b/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
@@ -1,0 +1,213 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+A completion marker records that every chunk for a document reached S3.
+
+Two properties matter. The marker goes down only when every upload succeeded,
+so its presence means something. And a prefix holding one reads back exactly as
+it did before, because both downloaders list every object under a prefix and
+hand it to TextNode.from_json, which accepts a marker as a node with a fresh
+uuid and empty text rather than rejecting it.
+"""
+
+import json
+
+import pytest
+from unittest.mock import Mock, patch
+
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
+
+from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
+    COMPLETION_MARKER_KEY,
+    S3ChunkDownloader,
+    S3ChunkUploader,
+    S3DocDownloader,
+    node_ids_hash,
+)
+from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+from graphrag_toolkit.lexical_graph.storage.constants import INDEX_KEY
+
+COLLECTION_PREFIX = 'p/c'
+SOURCE_ID = 'aws::dead:beef'
+
+
+def _chunk(node_id, metadata=None):
+    # SourceDocument.source_id() reads the SOURCE relationship, so a chunk
+    # without one has no document to belong to.
+    node = TextNode(text=f'text for {node_id}', id_=node_id, metadata=metadata or {})
+    node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=SOURCE_ID)
+    return node
+
+
+def _doc(node_ids, index_node_ids=()):
+    return SourceDocument(nodes=[
+        *(_chunk(i) for i in node_ids),
+        *(_chunk(i, {INDEX_KEY: 'x'}) for i in index_node_ids),
+    ])
+
+
+def _uploader():
+    return S3ChunkUploader(
+        bucket_name='b', collection_prefix=COLLECTION_PREFIX, num_threads=2
+    )
+
+
+def _upload(uploader, docs, failing_keys=()):
+    """Run the uploader against a mock S3, returning the objects it wrote."""
+    written = {}
+
+    def put_object(**kwargs):
+        key = kwargs['Key']
+        if any(key.endswith(f) for f in failing_keys):
+            raise RuntimeError(f'upload failed: {key}')
+        written[key] = kwargs['Body']
+
+    s3_client = Mock()
+    s3_client.put_object.side_effect = put_object
+
+    with patch(
+        'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+    ) as config:
+        config.s3 = s3_client
+        config.extraction_num_threads_per_worker = 2
+        yielded = list(uploader.upload(docs))
+
+    return written, yielded
+
+
+def _marker_key(source_id=SOURCE_ID):
+    return f'{COLLECTION_PREFIX}/{source_id}/{COMPLETION_MARKER_KEY}'
+
+
+class TestMarkerIsWrittenOnSuccess:
+
+    def test_a_fully_uploaded_document_gets_a_marker(self):
+        written, yielded = _upload(_uploader(), [_doc(['c1', 'c2'])])
+
+        assert _marker_key() in written
+        assert len(yielded) == 1
+
+    def test_the_marker_records_the_chunk_ids_the_count_and_a_hash(self):
+        written, _ = _upload(_uploader(), [_doc(['c1', 'c2'])])
+
+        marker = json.loads(written[_marker_key()])
+
+        assert marker['chunk_ids'] == ['c1', 'c2']
+        assert marker['count'] == 2
+        assert marker['content_hash'] == node_ids_hash(['c1', 'c2'])
+
+    def test_index_nodes_are_not_counted(self):
+        # A chunk carrying an index key is a vector store artefact. The uploader
+        # does not write it, so the marker must not claim it.
+        written, _ = _upload(_uploader(), [_doc(['c1'], index_node_ids=['v1'])])
+
+        marker = json.loads(written[_marker_key()])
+
+        assert marker['chunk_ids'] == ['c1']
+        assert marker['count'] == 1
+
+    def test_the_marker_goes_down_after_every_chunk(self):
+        written, _ = _upload(_uploader(), [_doc(['c1', 'c2'])])
+
+        keys = list(written)
+
+        assert keys.index(_marker_key()) == len(keys) - 1
+
+
+class TestMarkerIsWithheldOnFailure:
+
+    def test_a_failed_chunk_leaves_no_marker(self):
+        written, yielded = _upload(
+            _uploader(), [_doc(['c1', 'c2'])], failing_keys=['c2.json']
+        )
+
+        assert _marker_key() not in written
+        assert len(yielded) == 1, 'the document is still yielded, as it is today'
+
+    def test_the_chunks_that_did_succeed_are_still_written(self):
+        written, _ = _upload(
+            _uploader(), [_doc(['c1', 'c2'])], failing_keys=['c2.json']
+        )
+
+        assert f'{COLLECTION_PREFIX}/{SOURCE_ID}/c1.json' in written
+
+
+class TestEdgeCases:
+
+    def test_a_document_with_nothing_to_write_is_still_marked_complete(self):
+        # Every chunk succeeded, of which there were none. Withholding the
+        # marker would leave the document looking incomplete forever.
+        written, yielded = _upload(_uploader(), [_doc([], index_node_ids=['v1'])])
+
+        marker = json.loads(written[_marker_key()])
+
+        assert marker == {'chunk_ids': [], 'count': 0, 'content_hash': node_ids_hash([])}
+        assert len(yielded) == 1
+
+    def test_a_marker_that_fails_to_write_does_not_break_the_stream(self):
+        # The chunks survived; the run should too. No marker means a re-stage,
+        # which is cheaper than losing the rest of the corpus.
+        written, yielded = _upload(
+            _uploader(),
+            [_doc(['c1']), _doc(['c2'])],
+            failing_keys=[COMPLETION_MARKER_KEY],
+        )
+
+        assert _marker_key() not in written
+        assert len(yielded) == 2
+        assert f'{COLLECTION_PREFIX}/{SOURCE_ID}/c1.json' in written
+
+
+class TestReadersIgnoreTheMarker:
+    """
+    Both downloaders list every object under a prefix. TextNode.from_json
+    accepts a marker as a node with a generated uuid and empty text, so an
+    unfiltered listing turns the marker into a phantom chunk on every read.
+    """
+
+    MARKER_BODY = json.dumps({'chunk_ids': ['c1'], 'count': 1, 'content_hash': 'x'})
+
+    def _s3_returning(self, objects):
+        s3_client = Mock()
+        s3_client.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [{'Key': key} for key in objects],
+             'CommonPrefixes': [{'Prefix': f'{COLLECTION_PREFIX}/{SOURCE_ID}/'}]}
+        ]
+
+        def download_fileobj(bucket, key, stream):
+            stream.write(objects[key].encode('UTF-8'))
+
+        s3_client.download_fileobj.side_effect = download_fileobj
+        return s3_client
+
+    def test_the_chunk_downloader_skips_it(self):
+        objects = {
+            f'{COLLECTION_PREFIX}/{SOURCE_ID}/c1.json': TextNode(text='one', id_='c1').to_json(),
+            _marker_key(): self.MARKER_BODY,
+        }
+        downloader = S3ChunkDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
+        )
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.s3 = self._s3_returning(objects)
+            config.extraction_num_threads_per_worker = 2
+            docs = list(downloader.download())
+
+        assert [n.node_id for doc in docs for n in doc.nodes] == ['c1']
+
+    def test_the_doc_downloader_skips_it(self):
+        objects = {
+            f'{COLLECTION_PREFIX}/{SOURCE_ID}/doc.jsonl': TextNode(text='one', id_='c1').to_json(),
+            _marker_key(): self.MARKER_BODY,
+        }
+        downloader = S3DocDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
+        )
+
+        doc = downloader._download_doc('prefix', self._s3_returning(objects))
+
+        assert [n.node_id for n in doc.nodes] == ['c1']

--- a/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
+++ b/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
@@ -34,18 +34,18 @@ COLLECTION_PREFIX = 'p/c'
 SOURCE_ID = 'aws::dead:beef'
 
 
-def _chunk(node_id, metadata=None):
+def _chunk(node_id, metadata=None, source_id=SOURCE_ID):
     # SourceDocument.source_id() reads the SOURCE relationship, so a chunk
     # without one has no document to belong to.
     node = TextNode(text=f'text for {node_id}', id_=node_id, metadata=metadata or {})
-    node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=SOURCE_ID)
+    node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=source_id)
     return node
 
 
-def _doc(node_ids, index_node_ids=()):
+def _doc(node_ids, index_node_ids=(), source_id=SOURCE_ID):
     return SourceDocument(nodes=[
-        *(_chunk(i) for i in node_ids),
-        *(_chunk(i, {INDEX_KEY: 'x'}) for i in index_node_ids),
+        *(_chunk(i, source_id=source_id) for i in node_ids),
+        *(_chunk(i, {INDEX_KEY: 'x'}, source_id=source_id) for i in index_node_ids),
     ])
 
 
@@ -280,14 +280,20 @@ class TestEncryption:
         return captured
 
     def test_managed_keys_when_no_kms_key_is_configured(self):
-        for kwargs in self._upload_capturing():
+        captured = self._upload_capturing()
+
+        assert len(captured) == 2, 'one chunk and its marker'
+        for kwargs in captured:
             assert kwargs['ServerSideEncryption'] == 'AES256'
             assert 'SSEKMSKeyId' not in kwargs
 
     def test_a_configured_kms_key_is_used(self):
         key_arn = 'arn:aws:kms:us-east-1:123456789012:key/12345678'
 
-        for kwargs in self._upload_capturing(encryption_key_id=key_arn):
+        captured = self._upload_capturing(encryption_key_id=key_arn)
+
+        assert len(captured) == 2, 'one chunk and its marker'
+        for kwargs in captured:
             assert kwargs['ServerSideEncryption'] == 'aws:kms'
             assert kwargs['SSEKMSKeyId'] == key_arn
 
@@ -298,3 +304,47 @@ class TestEncryption:
         assert len(markers) == 1
         assert markers[0]['ServerSideEncryption'] == 'AES256'
         assert markers[0]['ContentType'] == 'application/json'
+
+
+class TestOrdering:
+    """
+    upload() promises documents come back in the order they went in. A document
+    with nothing to write still has to take its turn: yielding it as soon as it
+    is seen jumps every document already in flight.
+    """
+
+    def test_a_document_with_nothing_to_write_keeps_its_place(self):
+        docs = [
+            _doc(['a1', 'a2'], source_id='aws::a'),
+            _doc([], index_node_ids=['v1'], source_id='aws::b'),
+            _doc(['c1', 'c2'], source_id='aws::c'),
+        ]
+
+        _, yielded = _upload(_uploader(), docs)
+
+        assert [d.source_id() for d in yielded] == ['aws::a', 'aws::b', 'aws::c']
+
+    def test_nothing_is_lost_or_yielded_twice(self):
+        docs = [
+            _doc([], index_node_ids=['v1'], source_id='aws::a'),
+            _doc(['b1'], source_id='aws::b'),
+            _doc([], source_id='aws::c'),
+        ]
+
+        _, yielded = _upload(_uploader(), docs)
+
+        assert [id(d) for d in yielded] == [id(d) for d in docs]
+
+
+class TestMarkerNaming:
+
+    def test_only_the_basename_decides(self):
+        # A substring test would drop a chunk whose own id happened to contain
+        # the marker prefix somewhere in its path.
+        assert is_completion_marker(f'p/c/src/{COMPLETION_MARKER_PREFIX}abcde')
+        assert not is_completion_marker(f'p/c/{COMPLETION_MARKER_PREFIX}x/c1.json')
+        assert not is_completion_marker('p/c/src/c1.json')
+
+    def test_the_name_follows_the_chunk_ids(self):
+        assert completion_marker_name(['c1', 'c2']) == completion_marker_name(['c2', 'c1'])
+        assert completion_marker_name(['c1', 'c2']) != completion_marker_name(['c1', 'c3'])

--- a/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
+++ b/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
@@ -23,6 +23,7 @@ from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
     S3ChunkDownloader,
     S3ChunkUploader,
     S3DocDownloader,
+    completion_marker_key,
     completion_marker_name,
     is_completion_marker,
     node_ids_hash,
@@ -84,7 +85,7 @@ def _upload(uploader, docs, failing_keys=()):
 
 
 def _marker_key(node_ids, source_id=SOURCE_ID):
-    return f'{COLLECTION_PREFIX}/{source_id}/{completion_marker_name(node_ids)}'
+    return completion_marker_key(f'{COLLECTION_PREFIX}/{source_id}', node_ids)
 
 
 def _markers(written):
@@ -341,10 +342,25 @@ class TestMarkerNaming:
     def test_only_the_basename_decides(self):
         # A substring test would drop a chunk whose own id happened to contain
         # the marker prefix somewhere in its path.
-        assert is_completion_marker(f'p/c/src/{COMPLETION_MARKER_PREFIX}abcde')
+        assert is_completion_marker(completion_marker_key('p/c/src', ['c1']))
         assert not is_completion_marker(f'p/c/{COMPLETION_MARKER_PREFIX}x/c1.json')
         assert not is_completion_marker('p/c/src/c1.json')
+        # A chunk whose node id opens with the prefix is a chunk, not a marker.
+        assert not is_completion_marker(f'p/c/src/{COMPLETION_MARKER_PREFIX}abcde.json')
 
     def test_the_name_follows_the_chunk_ids(self):
         assert completion_marker_name(['c1', 'c2']) == completion_marker_name(['c2', 'c1'])
+
+    def test_a_chunk_named_like_a_marker_survives_the_round_trip(self):
+        """The marker segment keeps the two namespaces apart.
+
+        A chunk is keyed by its node id. While markers sat beside the chunks, a
+        node id opening with the marker prefix was written as a chunk and then
+        excluded from the reconstructed document with no error.
+        """
+        node_id = f'{COMPLETION_MARKER_PREFIX}looks-like-a-marker'
+        chunk_key = f'{COLLECTION_PREFIX}/src/{node_id}.json'
+
+        assert not is_completion_marker(chunk_key)
+        assert is_completion_marker(completion_marker_key(f'{COLLECTION_PREFIX}/src', [node_id]))
         assert completion_marker_name(['c1', 'c2']) != completion_marker_name(['c1', 'c3'])

--- a/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
+++ b/lexical-graph/tests/unit/indexing/load/test_completion_marker.py
@@ -19,10 +19,12 @@ from unittest.mock import Mock, patch
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 
 from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
-    COMPLETION_MARKER_KEY,
+    COMPLETION_MARKER_PREFIX,
     S3ChunkDownloader,
     S3ChunkUploader,
     S3DocDownloader,
+    completion_marker_name,
+    is_completion_marker,
     node_ids_hash,
 )
 from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
@@ -54,12 +56,17 @@ def _uploader():
 
 
 def _upload(uploader, docs, failing_keys=()):
-    """Run the uploader against a mock S3, returning the objects it wrote."""
+    """
+    Run the uploader against a mock S3, returning the objects it wrote.
+
+    failing_keys are matched as fragments, so a marker can be failed without
+    reproducing the digest in its name.
+    """
     written = {}
 
     def put_object(**kwargs):
         key = kwargs['Key']
-        if any(key.endswith(f) for f in failing_keys):
+        if any(f in key for f in failing_keys):
             raise RuntimeError(f'upload failed: {key}')
         written[key] = kwargs['Body']
 
@@ -76,8 +83,12 @@ def _upload(uploader, docs, failing_keys=()):
     return written, yielded
 
 
-def _marker_key(source_id=SOURCE_ID):
-    return f'{COLLECTION_PREFIX}/{source_id}/{COMPLETION_MARKER_KEY}'
+def _marker_key(node_ids, source_id=SOURCE_ID):
+    return f'{COLLECTION_PREFIX}/{source_id}/{completion_marker_name(node_ids)}'
+
+
+def _markers(written):
+    return sorted(k for k in written if is_completion_marker(k))
 
 
 class TestMarkerIsWrittenOnSuccess:
@@ -85,13 +96,13 @@ class TestMarkerIsWrittenOnSuccess:
     def test_a_fully_uploaded_document_gets_a_marker(self):
         written, yielded = _upload(_uploader(), [_doc(['c1', 'c2'])])
 
-        assert _marker_key() in written
+        assert _marker_key(['c1', 'c2']) in written
         assert len(yielded) == 1
 
     def test_the_marker_records_the_chunk_ids_the_count_and_a_hash(self):
         written, _ = _upload(_uploader(), [_doc(['c1', 'c2'])])
 
-        marker = json.loads(written[_marker_key()])
+        marker = json.loads(written[_marker_key(['c1', 'c2'])])
 
         assert marker['chunk_ids'] == ['c1', 'c2']
         assert marker['count'] == 2
@@ -102,7 +113,7 @@ class TestMarkerIsWrittenOnSuccess:
         # does not write it, so the marker must not claim it.
         written, _ = _upload(_uploader(), [_doc(['c1'], index_node_ids=['v1'])])
 
-        marker = json.loads(written[_marker_key()])
+        marker = json.loads(written[_marker_key(['c1'])])
 
         assert marker['chunk_ids'] == ['c1']
         assert marker['count'] == 1
@@ -112,7 +123,7 @@ class TestMarkerIsWrittenOnSuccess:
 
         keys = list(written)
 
-        assert keys.index(_marker_key()) == len(keys) - 1
+        assert keys.index(_marker_key(['c1', 'c2'])) == len(keys) - 1
 
 
 class TestMarkerIsWithheldOnFailure:
@@ -122,7 +133,7 @@ class TestMarkerIsWithheldOnFailure:
             _uploader(), [_doc(['c1', 'c2'])], failing_keys=['c2.json']
         )
 
-        assert _marker_key() not in written
+        assert _markers(written) == []
         assert len(yielded) == 1, 'the document is still yielded, as it is today'
 
     def test_the_chunks_that_did_succeed_are_still_written(self):
@@ -135,15 +146,43 @@ class TestMarkerIsWithheldOnFailure:
 
 class TestEdgeCases:
 
-    def test_a_document_with_nothing_to_write_is_still_marked_complete(self):
-        # Every chunk succeeded, of which there were none. Withholding the
-        # marker would leave the document looking incomplete forever.
+    def test_a_document_with_nothing_to_write_creates_no_prefix(self):
+        # A marker alone in a prefix reads back as a document with no nodes,
+        # whose source_id() is None, and a re-stage cannot build a path from
+        # None. Writing nothing leaves no prefix to read.
         written, yielded = _upload(_uploader(), [_doc([], index_node_ids=['v1'])])
 
-        marker = json.loads(written[_marker_key()])
+        assert written == {}
+        assert len(yielded) == 1, 'the document is still yielded'
 
-        assert marker == {'chunk_ids': [], 'count': 0, 'content_hash': node_ids_hash([])}
-        assert len(yielded) == 1
+    def test_several_documents_for_one_source_get_their_own_markers(self):
+        # An auto-tuned run emits one source as several SourceDocuments, which
+        # share a prefix. A fixed marker name would let the last one written
+        # speak for all of them.
+        written, _ = _upload(
+            _uploader(), [_doc(['c1', 'c2']), _doc(['c3', 'c4'])]
+        )
+
+        assert _markers(written) == sorted(
+            [_marker_key(['c1', 'c2']), _marker_key(['c3', 'c4'])]
+        )
+
+    def test_one_documents_marker_does_not_certify_anothers_truncated_prefix(self):
+        # The failure this feature exists to prevent: doc 1 completes, doc 2
+        # loses a chunk, and the prefix holds 3 of 4 objects. No marker in it
+        # may describe the whole prefix as complete.
+        written, _ = _upload(
+            _uploader(),
+            [_doc(['c1', 'c2']), _doc(['c3', 'c4'])],
+            failing_keys=['c4.json'],
+        )
+
+        markers = _markers(written)
+
+        assert markers == [_marker_key(['c1', 'c2'])]
+        covered = json.loads(written[markers[0]])['chunk_ids']
+        assert covered == ['c1', 'c2'], 'it speaks only for its own document'
+        assert _marker_key(['c3', 'c4']) not in written
 
     def test_a_marker_that_fails_to_write_does_not_break_the_stream(self):
         # The chunks survived; the run should too. No marker means a re-stage,
@@ -151,10 +190,10 @@ class TestEdgeCases:
         written, yielded = _upload(
             _uploader(),
             [_doc(['c1']), _doc(['c2'])],
-            failing_keys=[COMPLETION_MARKER_KEY],
+            failing_keys=[COMPLETION_MARKER_PREFIX],
         )
 
-        assert _marker_key() not in written
+        assert _markers(written) == []
         assert len(yielded) == 2
         assert f'{COLLECTION_PREFIX}/{SOURCE_ID}/c1.json' in written
 
@@ -184,7 +223,7 @@ class TestReadersIgnoreTheMarker:
     def test_the_chunk_downloader_skips_it(self):
         objects = {
             f'{COLLECTION_PREFIX}/{SOURCE_ID}/c1.json': TextNode(text='one', id_='c1').to_json(),
-            _marker_key(): self.MARKER_BODY,
+            _marker_key(['c1']): self.MARKER_BODY,
         }
         downloader = S3ChunkDownloader(
             key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
@@ -202,7 +241,7 @@ class TestReadersIgnoreTheMarker:
     def test_the_doc_downloader_skips_it(self):
         objects = {
             f'{COLLECTION_PREFIX}/{SOURCE_ID}/doc.jsonl': TextNode(text='one', id_='c1').to_json(),
-            _marker_key(): self.MARKER_BODY,
+            _marker_key(['c1']): self.MARKER_BODY,
         }
         downloader = S3DocDownloader(
             key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
@@ -211,3 +250,51 @@ class TestReadersIgnoreTheMarker:
         doc = downloader._download_doc('prefix', self._s3_returning(objects))
 
         assert [n.node_id for n in doc.nodes] == ['c1']
+
+
+class TestEncryption:
+    """
+    The KMS-versus-managed-keys branch was written out four times and asserted
+    nowhere, so dropping the headers altogether kept the suite green. It is one
+    branch now, and these are what hold it in place.
+    """
+
+    def _upload_capturing(self, encryption_key_id=None):
+        captured = []
+        uploader = S3ChunkUploader(
+            bucket_name='b',
+            collection_prefix=COLLECTION_PREFIX,
+            s3_encryption_key_id=encryption_key_id,
+            num_threads=2,
+        )
+        s3_client = Mock()
+        s3_client.put_object.side_effect = lambda **kwargs: captured.append(kwargs)
+
+        with patch(
+            'graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs.GraphRAGConfig'
+        ) as config:
+            config.s3 = s3_client
+            config.extraction_num_threads_per_worker = 2
+            list(uploader.upload([_doc(['c1'])]))
+
+        return captured
+
+    def test_managed_keys_when_no_kms_key_is_configured(self):
+        for kwargs in self._upload_capturing():
+            assert kwargs['ServerSideEncryption'] == 'AES256'
+            assert 'SSEKMSKeyId' not in kwargs
+
+    def test_a_configured_kms_key_is_used(self):
+        key_arn = 'arn:aws:kms:us-east-1:123456789012:key/12345678'
+
+        for kwargs in self._upload_capturing(encryption_key_id=key_arn):
+            assert kwargs['ServerSideEncryption'] == 'aws:kms'
+            assert kwargs['SSEKMSKeyId'] == key_arn
+
+    def test_the_marker_is_encrypted_like_every_other_object(self):
+        captured = self._upload_capturing()
+        markers = [k for k in captured if is_completion_marker(k['Key'])]
+
+        assert len(markers) == 1
+        assert markers[0]['ServerSideEncryption'] == 'AES256'
+        assert markers[0]['ContentType'] == 'application/json'

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch, MagicMock
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import (
     S3BasedDocs,
+    is_completion_marker,
     S3DocDownloader,
     S3DocUploader,
     S3ChunkDownloader,
@@ -769,8 +770,10 @@ class TestS3ChunkUploaderConcurrency:
             docs = [_doc(f'src-{i}', 3) for i in range(10)]
             list(uploader.upload(docs))
 
-        assert len(keys) == 30
-        assert len(set(keys)) == 30
+        chunk_keys = [k for k in keys if not is_completion_marker(k)]
+
+        assert len(chunk_keys) == 30
+        assert len(set(chunk_keys)) == 30
 
     def test_document_is_yielded_only_after_its_own_chunks_are_written(self):
         """A document's own chunks are written before it is yielded."""
@@ -799,7 +802,9 @@ class TestS3ChunkUploaderConcurrency:
         with _uploader_with(4, on_put) as uploader:
             list(uploader.upload([_doc('src-0', 2, index_key_chunks=3)]))
 
-        assert len(keys) == 2
+        chunk_keys = [k for k in keys if not is_completion_marker(k)]
+
+        assert len(chunk_keys) == 2
 
     def test_a_failed_chunk_does_not_stop_the_stream(self):
         def on_put(**kwargs):


### PR DESCRIPTION
## Description

Nothing recorded whether a document's chunks all reached S3, so a truncated prefix and a short document read back identically. `S3ChunkUploader._drain` caught each chunk's exception, logged it and returned nothing, which #507 documented rather than fixed.

`_drain` now reports whether every upload landed. A document whose chunks all stored gets a marker holding its chunk ids, their count and a hash over them, written last. A document with a failed chunk carries no marker and is still yielded, exactly as today.

Related issue: #325.

## Changes

- `_drain` returns whether all of a document's uploads succeeded.
- `_write_completion_marker` writes the marker after that check passes. A failed marker write is logged rather than raised. The chunks themselves uploaded, so stopping the run costs more than the re-stage a missing marker causes.
- Both downloaders exclude marker objects. Neither filtered by extension, and `TextNode.from_json` returns a node with a generated uuid and empty text for a marker rather than rejecting it, so an unfiltered listing would add one extra node to every read of that document.
- A document with nothing to write no longer creates a prefix. Previously an index-only document produced a prefix holding just a marker, which reads back as a document with no nodes, whose `source_id()` is `None`, and a re-stage cannot build a path from `None`.

Three duplications collapsed rather than extended:

| | before | after |
|---|---|---|
| index-key node filter | two forms, one convoluted | `written_nodes(doc)` |
| node-id hash | inline in `_doc_suffix` | `node_ids_hash()` |
| KMS vs AES256 | four copies | `EncryptedPut._put` |

## Why the marker name contains a digest

An auto-tuned run emits one source as several `SourceDocument`s, which share a prefix. With a fixed marker name, the last one written replaces the others. With two documents where the second loses a chunk:

```
objects : ['_COMPLETE', 'c1.json', 'c2.json', 'c3.json']
marker  : {'chunk_ids': ['c1','c2'], 'count': 2, ...}
```

Three of four objects are present, with a marker that reports the document as complete. #518 addressed the same collision for the document key by including a hash of the node ids; the marker name now does the same.

Five hex characters is 20 bits, the same budget `_doc_suffix` uses, and the same population: the SourceDocuments sharing one prefix. Brute-forced against realistic chunk ids, the first name collision appears at 1,672 documents in one prefix, with birthday odds of 0.47% at 100 and 38% at 1,000. So the bound is tens of documents per prefix, which is what the auto-tune path produces when it slices a source into `max_batch_size` buckets. A name collision loses a completeness record rather than data. The remaining marker still lists one document's chunks, so a reader comparing coverage re-stages rather than reporting the document complete.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [ ] Tested manually

19 new tests. 2154 pass across `tests/unit`.

Each change was checked by mutation testing, not only by the tests passing. Reverting to a fixed marker name fails 2 tests; removing the `ServerSideEncryption` headers fails 3; yielding an empty document immediately rather than queueing it fails 2. The encryption check matters because that branch had no assertions at all before this, so collapsing four copies of it was otherwise unverifiable.

One pre-existing failure is unrelated and reproduces on a clean tree: `test_integ_dependency_compatibility.py` errors with `No module named pip` in this venv.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

## Verified against real S3

Uploaded a two-chunk document to `noel-graphrag-test` and read it back:

```
coll/aws::live:test/_COMPLETE-23840          <- marker
coll/aws::live:test/aws::live:test:a.json
coll/aws::live:test/aws::live:test:b.json

marker encryption : AES256
read back         : ['aws::live:test:a', 'aws::live:test:b']
phantom chunk?    : False
```

## Two things worth your call

**Every ingest now writes one extra object per document, and nothing reads it yet.** The restart work is expected to be enabled by a setting, but that setting does not exist yet, and adding one with no code reading it would be configuration no caller can use. The write is therefore unconditional. Say if you would rather it waited until the restart setting exists.

**The encryption consolidation is separable from the feature.** Reverting the marker would revert it too. I folded it in because writing the marker otherwise meant a fifth copy of the same KMS branch, but it touches `S3DocUploader`, which this feature does not otherwise change. Happy to split it into its own PR.

## Known limitations

Nothing reads the marker yet, so `chunk_ids`, `count` and `content_hash` are stored and never validated. Read behaviour is deliberately out of scope here.

The marker name is the first five characters of the `content_hash` in its own body, so the two carry the same value at different precision. The name has to be short; the body field is what the acceptance criteria ask for.

A stale marker from an earlier run is not deleted. With per-document names a re-chunked document writes a different name and leaves the old one, which a reader catches by comparing the hash against a live listing. That comparison belongs with the read path.

`S3DocUploader` writes no marker, but `S3DocDownloader` skips one. Both uploaders write into the same prefix shape, so the skip is defensive rather than dead.

The marker PUT runs on the consumer's thread rather than the pool, adding one serialized round trip per document. The drain already blocks that thread, so this is additive rather than a change in shape.
