### PR TITLE
[FIX] Preserve configured LLM in non-batch fallback extractors

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_llm_proposition_extractor_sync.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_llm_proposition_extractor_sync.py
@@ -67,6 +67,7 @@ class BatchLLMPropositionExtractorSync(BatchExtractorBase):
         all_nodes = [node for node in nodes]
 
         extractor = LLMPropositionExtractor(
+            llm=self.llm,
             prompt_template=self.prompt_template, 
             source_metadata_field=self.source_metadata_field
         )

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_topic_extractor_sync.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/batch_topic_extractor_sync.py
@@ -80,6 +80,7 @@ class BatchTopicExtractorSync(BatchExtractorBase):
         all_nodes = [node for node in nodes]
 
         extractor = TopicExtractor( 
+            llm=self.llm,
             prompt_template=self.prompt_template, 
             source_metadata_field=self.source_metadata_field,
             entity_classification_provider=self.entity_classification_provider,

--- a/lexical-graph/tests/unit/indexing/extract/test_batch_llm_proposition_extractor_sync.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_batch_llm_proposition_extractor_sync.py
@@ -70,3 +70,44 @@ class TestBatchLLMPropositionExtractorSyncUpdateNode:
         result = extractor._update_node(node, node_metadata_map)
 
         assert result.metadata[PROPOSITIONS_KEY] == []
+
+
+class TestBatchLLMPropositionExtractorSyncRunNonBatchExtractor:
+    """Tests for _run_non_batch_extractor method.
+
+    Regression tests: when a node set falls below Bedrock's minimum batch
+    size, BatchLLMPropositionExtractorSync falls back to the non-batch
+    LLMPropositionExtractor. That fallback must reuse the configured LLM
+    (self.llm) rather than silently defaulting to
+    GraphRAGConfig.extraction_llm, which is a us.* inference profile and
+    is invalid in any other Bedrock region.
+    """
+
+    def _make_extractor(self, llm, prompt_template="prompt", source_metadata_field=None):
+        """Create a BatchLLMPropositionExtractorSync instance with fields
+        populated via model_construct, bypassing validation/__init__ so no
+        real BatchConfig or AWS setup is needed for this unit test."""
+        return BatchLLMPropositionExtractorSync.model_construct(
+            llm=llm,
+            prompt_template=prompt_template,
+            source_metadata_field=source_metadata_field,
+        )
+
+    @patch("graphrag_toolkit.lexical_graph.indexing.extract.batch_llm_proposition_extractor_sync.LLMPropositionExtractor")
+    def test_run_non_batch_extractor_passes_configured_llm(self, mock_extractor_cls):
+        """Verify the non-batch fallback is constructed with the extractor's
+        own configured llm, not left to default to GraphRAGConfig.extraction_llm."""
+        configured_llm = Mock(name="configured-llm")
+        extractor = self._make_extractor(llm=configured_llm)
+
+        mock_instance = mock_extractor_cls.return_value
+        mock_instance.extract.return_value = [{PROPOSITIONS_KEY: []}]
+
+        nodes = [TextNode(text="test", id_="node-1")]
+        extractor._run_non_batch_extractor(nodes)
+
+        mock_extractor_cls.assert_called_once_with(
+            llm=configured_llm,
+            prompt_template="prompt",
+            source_metadata_field=None,
+        )

--- a/lexical-graph/tests/unit/indexing/extract/test_batch_topic_extractor_sync.py
+++ b/lexical-graph/tests/unit/indexing/extract/test_batch_topic_extractor_sync.py
@@ -68,3 +68,54 @@ class TestBatchTopicExtractorSyncUpdateNode:
         result = extractor._update_node(node, node_metadata_map)
 
         assert result.metadata[TOPICS_KEY] == {'topics': []}
+
+
+class TestBatchTopicExtractorSyncRunNonBatchExtractor:
+    """Tests for _run_non_batch_extractor method.
+
+    Regression tests: when a node set falls below Bedrock's minimum batch
+    size, BatchTopicExtractorSync falls back to the non-batch
+    TopicExtractor. That fallback must reuse the configured LLM (self.llm)
+    rather than silently defaulting to GraphRAGConfig.extraction_llm, which
+    is a us.* inference profile and is invalid in any other Bedrock region.
+    """
+
+    def _make_extractor(self, llm, prompt_template="prompt", source_metadata_field=None,
+                         entity_classification_provider=None, topic_provider=None):
+        """Create a BatchTopicExtractorSync instance with fields populated
+        via model_construct, bypassing validation/__init__ so no real
+        BatchConfig or AWS setup is needed for this unit test."""
+        return BatchTopicExtractorSync.model_construct(
+            llm=llm,
+            prompt_template=prompt_template,
+            source_metadata_field=source_metadata_field,
+            entity_classification_provider=entity_classification_provider or Mock(),
+            topic_provider=topic_provider or Mock(),
+        )
+
+    @patch("graphrag_toolkit.lexical_graph.indexing.extract.batch_topic_extractor_sync.TopicExtractor")
+    def test_run_non_batch_extractor_passes_configured_llm(self, mock_extractor_cls):
+        """Verify the non-batch fallback is constructed with the extractor's
+        own configured llm, not left to default to GraphRAGConfig.extraction_llm."""
+        configured_llm = Mock(name="configured-llm")
+        entity_classification_provider = Mock(name="entity-classification-provider")
+        topic_provider = Mock(name="topic-provider")
+        extractor = self._make_extractor(
+            llm=configured_llm,
+            entity_classification_provider=entity_classification_provider,
+            topic_provider=topic_provider,
+        )
+
+        mock_instance = mock_extractor_cls.return_value
+        mock_instance.extract.return_value = [{TOPICS_KEY: {'topics': []}}]
+
+        nodes = [TextNode(text="test", id_="node-1")]
+        extractor._run_non_batch_extractor(nodes)
+
+        mock_extractor_cls.assert_called_once_with(
+            llm=configured_llm,
+            prompt_template="prompt",
+            source_metadata_field=None,
+            entity_classification_provider=entity_classification_provider,
+            topic_provider=topic_provider,
+        )


### PR DESCRIPTION
## Description

`_run_non_batch_extractor` in `BatchLLMPropositionExtractorSync` and `BatchTopicExtractorSync` builds its fallback extractor without passing the configured `llm`, so it silently defaults to `GraphRAGConfig.extraction_llm` (`us.anthropic.claude-sonnet-4-6`) instead of whatever LLM was explicitly configured.

Fixes #534.

## Changes

- `batch_llm_proposition_extractor_sync.py`: pass `llm=self.llm` to the fallback `LLMPropositionExtractor`
- `batch_topic_extractor_sync.py`: pass `llm=self.llm` to the fallback `TopicExtractor`
- Regression tests for both classes asserting the fallback extractor is constructed with the extractor's configured `llm`

## Problem

Related issue: #534

When a node set falls below Bedrock's minimum batch size (100 records), both batch extractors fall back to a non-batch extractor. That fallback ignores `self.llm` entirely, so it uses `GraphRAGConfig.extraction_llm` (`DEFAULT_EXTRACTION_MODEL = 'us.anthropic.claude-sonnet-4-6'`) regardless of what LLM was configured. Outside a region where that `us.*` profile resolves, this raises `ValidationException: The provided model identifier is invalid.` We hit this in `eu-west-2` with an explicitly configured `eu.anthropic.claude-sonnet-4-6` LLM.

This is a different mechanism from #344/#347 (pickled `BedrockConverse` losing `region_name` in a spawned worker) — here the configured LLM is never passed to the fallback at all, so the `global.*` inference profile workaround for #344 doesn't apply.

## Testing

- [x] Unit tests added/updated — one regression test per class, patching the target extractor class and asserting it's constructed with `llm=<the configured llm>`
- [ ] Integration tests added (as appropriate) — not applicable, this only affects extractor construction, no AWS call needed to reproduce
- [x] Existing tests pass (`pytest`) — ran `tests/unit/indexing/extract/test_batch_llm_proposition_extractor_sync.py` and `test_batch_topic_extractor_sync.py` (11 passed), and the full `tests/unit` suite (2137 passed; one pre-existing, unrelated error in `test_integ_dependency_compatibility.py` caused by no `pip` binary in my venv, reproduced identically on `main` without this change)
- [x] Tested manually (describe below)

Manually reproduced against a real `eu-west-2` account: a `BatchConfig`-configured `eu.anthropic.claude-sonnet-4-6` extraction, where one `ProcessPoolExecutor` worker's chunk count landed under 100 and hit this exact fallback path, raising the `ValidationException` quoted in #534.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files (no new files; existing headers preserved)
- [ ] Documentation updated (if applicable) — not applicable, internal fallback behavior only
- [x] No breaking changes (or clearly documented) — additive `llm=` kwarg passthrough only