### PR TITLE
[FEATURE] Make Bedrock batch model dispatch extensible

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/batch_inference_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/batch_inference_utils.py
@@ -6,7 +6,8 @@ import asyncio
 import time
 import os
 import json
-from typing import Any, List, Dict
+from typing import Any, Callable, List, Dict
+from dataclasses import dataclass
 from os import stat, listdir
 from os.path import isfile, join
 
@@ -65,46 +66,140 @@ def split_nodes(nodes: List[Any], batch_size: int) -> List[List[Any]]:
    
     return results
 
-def get_request_body(llm:BedrockConverse, messages:List[ChatMessage], inference_parameters: dict):
-    
-    model_id = llm.model
-    
-    if 'amazon.nova' in model_id:
-        converse_messages, system_prompt = messages_to_converse_messages(messages)
-        request_body = {
-            'messages': converse_messages,
-            'inferenceConfig': {
-                'maxTokens': inference_parameters['max_tokens'],
-                'temperature': inference_parameters['temperature'],
-            }
-        }
-        if system_prompt:
-            request_body['system'] = [{'text': system_prompt}]
-        return request_body
-    elif 'anthropic.claude' in model_id:
-        anthropic_messages, system_prompt = messages_to_anthropic_messages(messages)
-        request_body = {
-            'anthropic_version': inference_parameters.get('anthropic_version', 'bedrock-2023-05-31'),
-            'messages': anthropic_messages,
-            'max_tokens': inference_parameters['max_tokens'],
-            'temperature': inference_parameters['temperature']
-        }
-        if system_prompt:
-            request_body['system'] = system_prompt
-        return request_body
-    elif 'meta.llama' in model_id:
-        converse_messages, system_prompt = messages_to_converse_messages(messages)
-        request_body = {
-            'messages': converse_messages,
-            'parameters': {
-                'max_new_tokens': inference_parameters['max_tokens'],
-                'temperature': inference_parameters['temperature'],
-            }
-        }
-        return request_body
-    else:
-        raise ValueError(f'Unrecognized model_id: batch extraction for {model_id} is not supported')
+# --- Bedrock batch (InvokeModel JSONL) provider registry -------------------
+#
+# Batch inference does not go through the Converse API; each record's
+# `modelInput`/`modelOutput` uses the provider-specific InvokeModel schema, so
+# each family is described by one BATCH_MODEL_PROVIDERS entry:
+#
+#   * build_request   - builds `modelInput` (the request body genuinely differs
+#                       per family, so this stays a small function)
+#   * output_path     - where the generated text lives in a record, walked from
+#                       the record root (so a family can read under 'modelOutput'
+#                       or at the top level)
+#   * output_mode     - 'blocks' joins a [{text: ...}] content list; 'text'
+#                       returns a scalar string node as-is
+#
+# To add a family, verify its InvokeModel request/response schema against the AWS
+# Bedrock docs and add one entry - no edits to get_request_body /
+# get_parse_output_text_fn. match_prefixes are substrings tested against
+# llm.model; they match through a cross-region inference-profile prefix (e.g.
+# 'us.anthropic.claude...' contains 'anthropic.claude') and across model versions
+# (Claude Opus 5, Nova 2, Llama 4).
 
+
+def _build_nova_request(messages: List[ChatMessage], params: dict) -> dict:
+    converse_messages, system_prompt = messages_to_converse_messages(messages)
+    request_body = {
+        'messages': converse_messages,
+        'inferenceConfig': {
+            'maxTokens': params['max_tokens'],
+            'temperature': params['temperature'],
+        }
+    }
+    if system_prompt:
+        # messages_to_converse_messages already returns the system prompt as a
+        # list of {'text': ...} blocks, so assign it directly (wrapping it again
+        # would nest as [{'text': [{'text': ...}]}]).
+        request_body['system'] = system_prompt
+    return request_body
+
+
+def _build_claude_request(messages: List[ChatMessage], params: dict) -> dict:
+    anthropic_messages, system_prompt = messages_to_anthropic_messages(messages)
+    request_body = {
+        'anthropic_version': params.get('anthropic_version', 'bedrock-2023-05-31'),
+        'messages': anthropic_messages,
+        'max_tokens': params['max_tokens'],
+        'temperature': params['temperature']
+    }
+    if system_prompt:
+        request_body['system'] = system_prompt
+    return request_body
+
+
+def _build_llama_request(messages: List[ChatMessage], params: dict) -> dict:
+    converse_messages, system_prompt = messages_to_converse_messages(messages)
+    return {
+        'messages': converse_messages,
+        'parameters': {
+            'max_new_tokens': params['max_tokens'],
+            'temperature': params['temperature'],
+        }
+    }
+
+
+@dataclass(frozen=True)
+class BatchModelProvider:
+    """A model family's batch (InvokeModel JSONL) request builder and output spec."""
+    name: str
+    match_prefixes: tuple
+    build_request: Callable[[List[ChatMessage], dict], dict]
+    output_path: tuple
+    output_mode: str = 'blocks'
+
+
+BATCH_MODEL_PROVIDERS: List[BatchModelProvider] = [
+    BatchModelProvider(
+        name='amazon.nova',
+        match_prefixes=('amazon.nova',),
+        build_request=_build_nova_request,
+        output_path=('modelOutput', 'output', 'message', 'content'),
+    ),
+    BatchModelProvider(
+        name='anthropic.claude',
+        match_prefixes=('anthropic.claude',),
+        build_request=_build_claude_request,
+        output_path=('modelOutput', 'content'),
+    ),
+    BatchModelProvider(
+        name='meta.llama',
+        match_prefixes=('meta.llama',),
+        build_request=_build_llama_request,
+        output_path=('modelOutput', 'generation'),
+        output_mode='text',
+    ),
+]
+
+
+def _resolve_batch_model_provider(model_id: str) -> BatchModelProvider:
+    for provider in BATCH_MODEL_PROVIDERS:
+        if any(prefix in model_id for prefix in provider.match_prefixes):
+            return provider
+    supported = ', '.join(provider.name for provider in BATCH_MODEL_PROVIDERS)
+    raise ValueError(
+        f'Unrecognized model_id: batch extraction for {model_id} is not supported. '
+        f'Supported model families: {supported}'
+    )
+
+
+def _parse_output_text(json_data: dict, output_path: tuple, output_mode: str) -> str:
+    """Extract generated text from a batch output record per a provider's output spec.
+
+    'text' mode fails loud if the expected key is absent: a missing scalar means
+    the output schema is not what we expect, and silently returning '' would let
+    every record log as a successful-but-empty extraction (masking the failure).
+    'blocks' mode stays lenient - an empty/missing content list yields '', which
+    matches how nova/claude parsing behaved before the registry refactor.
+    """
+    node = json_data
+    for key in output_path:
+        if not isinstance(node, dict):
+            node = None
+            break
+        node = node.get(key)
+    if output_mode == 'text':
+        if not isinstance(node, str):
+            raise ValueError(
+                f"Expected a string at {'.'.join(output_path)!r} in the batch output "
+                f"record, got {type(node).__name__}; the model output schema may have changed"
+            )
+        return node
+    return ''.join(block.get('text', '') for block in (node or []))
+
+
+def get_request_body(llm:BedrockConverse, messages:List[ChatMessage], inference_parameters: dict):
+    return _resolve_batch_model_provider(llm.model).build_request(messages, inference_parameters)
 
 
 def create_inference_inputs_for_messages(llm:BedrockConverse, nodes: List[TextNode], messages_batch: List[List[ChatMessage]], **kwargs) -> List[Dict[str, Any]]:
@@ -238,23 +333,11 @@ def download_output_files(s3_client: Any, bucket_name:str, output_path:str, inpu
         s3_client.download_file(Bucket=bucket_name, Key=key, Filename=local_file_path)
         logger.debug(f'Finished downloading {key} to {local_file_path}')
 
-def get_parse_output_text_fn(model_id:str): 
-    if 'amazon.nova' in model_id:
-        def get_output_text(json_data):
-            contents = json_data.get('modelOutput', {}).get('output', {}).get('message', {}).get('content', [])
-            return ''.join([content.get('text', '') for content in contents])
-        return get_output_text
-    elif 'anthropic.claude' in model_id:
-        def get_output_text(json_data):
-            contents = json_data.get('modelOutput', {}).get('content', [])
-            return ''.join([content.get('text', '') for content in contents])
-        return get_output_text
-    elif 'meta.llama' in model_id:
-        def get_output_text(json_data):
-            return json_data['generation']
-        return get_output_text
-    else:
-        raise ValueError(f'Unrecognized model_id: batch extraction for {model_id} is not supported') 
+def get_parse_output_text_fn(model_id:str):
+    provider = _resolve_batch_model_provider(model_id)
+    def parse_output(json_data):
+        return _parse_output_text(json_data, provider.output_path, provider.output_mode)
+    return parse_output
 
 async def process_batch_output(local_output_directory:str, input_filename:str, llm:LLMCache) -> Dict[str, str]:
     """Process batch output files and return results."""

--- a/lexical-graph/tests/unit/indexing/utils/test_batch_inference_utils.py
+++ b/lexical-graph/tests/unit/indexing/utils/test_batch_inference_utils.py
@@ -19,9 +19,12 @@ from graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils import 
     create_inference_inputs_for_messages,
     create_inference_inputs,
     get_parse_output_text_fn,
+    BATCH_MODEL_PROVIDERS,
     BEDROCK_MIN_BATCH_SIZE,
     BEDROCK_MAX_BATCH_SIZE
 )
+
+CONVERSE_PATCH_TARGET = 'graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils.messages_to_converse_messages'
 
 
 class TestGetFileSize:
@@ -173,10 +176,12 @@ class TestGetRequestBody:
         inference_params = {'max_tokens': 500, 'temperature': 0.5}
         
         with patch('graphrag_toolkit.lexical_graph.indexing.utils.batch_inference_utils.messages_to_converse_messages') as mock_convert:
-            mock_convert.return_value = ([{'role': 'user', 'content': [{'text': 'User message'}]}], 'System prompt')
-            
+            # messages_to_converse_messages returns the system prompt as a list of
+            # {'text': ...} blocks, so the builder must pass it through unwrapped.
+            mock_convert.return_value = ([{'role': 'user', 'content': [{'text': 'User message'}]}], [{'text': 'System prompt'}])
+
             request_body = get_request_body(mock_llm, messages, inference_params)
-            
+
             assert 'system' in request_body
             assert request_body['system'] == [{'text': 'System prompt'}]
     
@@ -367,14 +372,24 @@ class TestGetParseOutputTextFn:
     def test_parse_output_llama_model(self):
         """Verify parsing function works for Llama model output."""
         parse_fn = get_parse_output_text_fn('meta.llama3-70b-instruct-v1:0')
-        
+
+        # Bedrock wraps the provider payload under 'modelOutput', same as nova/claude.
         json_data = {
-            'generation': 'Generated text response'
+            'modelOutput': {
+                'generation': 'Generated text response'
+            }
         }
-        
+
         result = parse_fn(json_data)
         assert result == 'Generated text response'
-    
+
+    def test_parse_output_text_mode_missing_key_raises(self):
+        """A missing scalar output must fail loud, not silently return ''."""
+        parse_fn = get_parse_output_text_fn('meta.llama3-70b-instruct-v1:0')
+
+        with pytest.raises(ValueError, match="model output schema may have changed"):
+            parse_fn({'modelOutput': {}})
+
     def test_parse_output_unsupported_model(self):
         """Verify error raised for unsupported model."""
         with pytest.raises(ValueError, match="Unrecognized model_id"):
@@ -383,7 +398,7 @@ class TestGetParseOutputTextFn:
     def test_parse_output_empty_content(self):
         """Verify parsing handles empty content."""
         parse_fn = get_parse_output_text_fn('amazon.nova-lite-v1:0')
-        
+
         json_data = {
             'modelOutput': {
                 'output': {
@@ -393,6 +408,107 @@ class TestGetParseOutputTextFn:
                 }
             }
         }
-        
+
         result = parse_fn(json_data)
         assert result == ''
+
+
+class TestBatchModelProviderRegistry:
+    """Tests for the extensible provider registry backing batch dispatch."""
+
+    def test_registry_contains_expected_families(self):
+        """Exact-set guard: fail if a family is dropped or an unexpected one appears.
+
+        Equality is intentional - it catches an accidental add/remove. Adding a
+        family is a deliberate change that should update this set too.
+        """
+        names = {provider.name for provider in BATCH_MODEL_PROVIDERS}
+        assert names == {'amazon.nova', 'anthropic.claude', 'meta.llama'}
+
+    def test_parse_output_cross_region_profile_prefix(self):
+        """Inference-profile prefixes (us./eu.) still resolve to the right family."""
+        claude_fn = get_parse_output_text_fn('us.anthropic.claude-sonnet-4-6')
+        assert claude_fn({'modelOutput': {'content': [{'text': 'hi'}]}}) == 'hi'
+
+        nova_fn = get_parse_output_text_fn('eu.amazon.nova-pro-v1:0')
+        assert nova_fn({'modelOutput': {'output': {'message': {'content': [{'text': 'yo'}]}}}}) == 'yo'
+
+    def test_request_body_cross_region_profile_prefix(self):
+        """get_request_body resolves the family through a cross-region profile prefix."""
+        mock_llm = Mock(spec=BedrockConverse)
+        mock_llm.model = 'us.meta.llama3-3-70b-instruct-v1:0'
+
+        messages = [ChatMessage(role=MessageRole.USER, content="Test")]
+
+        with patch(CONVERSE_PATCH_TARGET) as mock_convert:
+            mock_convert.return_value = ([{'role': 'user', 'content': [{'text': 'Test'}]}], None)
+
+            body = get_request_body(mock_llm, messages, {'max_tokens': 100, 'temperature': 0.2})
+
+            assert 'parameters' in body
+            assert body['parameters']['max_new_tokens'] == 100
+
+    def test_unsupported_model_error_lists_supported_families(self):
+        """The unsupported-model error names the families that are supported."""
+        with pytest.raises(ValueError, match="Supported model families"):
+            get_parse_output_text_fn('cohere.command-r-v1:0')
+
+
+class TestParseRealBedrockBatchOutput:
+    """Parse full, real-shaped Bedrock batch-output records.
+
+    The other parse tests use minimal fixtures; these use the complete
+    ``modelOutput`` envelope each provider actually emits from a batch job -
+    including the fields the parser ignores (usage, stopReason, token counts)
+    and the ``type`` key on Anthropic content blocks - so the extraction is
+    validated against realistic payloads, not just the happy-path minimum.
+
+    NOTE: these mirror the documented InvokeModel response shapes; they are not a
+    substitute for a live end-to-end Bedrock batch run (see PR discussion). A real
+    batch validation is tracked separately.
+    """
+
+    def test_nova_full_record(self):
+        parse_fn = get_parse_output_text_fn('amazon.nova-pro-v1:0')
+        record = {
+            'recordId': 'REC000001',
+            'modelOutput': {
+                'output': {'message': {'role': 'assistant',
+                                       'content': [{'text': 'Nova answer.'}]}},
+                'stopReason': 'end_turn',
+                'usage': {'inputTokens': 12, 'outputTokens': 4, 'totalTokens': 16},
+            },
+        }
+        assert parse_fn(record) == 'Nova answer.'
+
+    def test_claude_full_record(self):
+        parse_fn = get_parse_output_text_fn('anthropic.claude-3-5-sonnet-20241022-v2:0')
+        record = {
+            'recordId': 'REC000002',
+            'modelOutput': {
+                'id': 'msg_bdrk_01ABC',
+                'type': 'message',
+                'role': 'assistant',
+                'model': 'claude-3-5-sonnet-20241022',
+                # Real Anthropic content blocks carry a 'type' alongside 'text'.
+                'content': [{'type': 'text', 'text': 'Claude '},
+                            {'type': 'text', 'text': 'answer.'}],
+                'stop_reason': 'end_turn',
+                'stop_sequence': None,
+                'usage': {'input_tokens': 12, 'output_tokens': 4},
+            },
+        }
+        assert parse_fn(record) == 'Claude answer.'
+
+    def test_llama_full_record(self):
+        parse_fn = get_parse_output_text_fn('meta.llama3-70b-instruct-v1:0')
+        record = {
+            'recordId': 'REC000003',
+            'modelOutput': {
+                'generation': 'Llama answer.',
+                'prompt_token_count': 12,
+                'generation_token_count': 4,
+                'stop_reason': 'stop',
+            },
+        }
+        assert parse_fn(record) == 'Llama answer.'


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->
<!-- Title format: [FIX] / [FEATURE] / [CHORE] followed by description -->
Makes Bedrock batch-inference model dispatch extensible. Batch inference uses the provider-specific InvokeModel JSONL schema (not Converse), so each model family needs its own request body and output parsing. This replaces the two hardcoded `if/elif` chains with a single `BATCH_MODEL_PROVIDERS` registry, so qualifying a new family is a small, well-tested change.

## Changes

<!-- List the key changes made -->

- Registry (`BATCH_MODEL_PROVIDERS`): each family is one entry

## Problem

<!-- What issue does this fix? Link to GitHub issue if applicable -->

Related issue (if any): #

## Testing

<!-- How was this tested? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [ ] Existing tests pass (`pytest`)
- [ ] Tested manually (describe below)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] License headers present on new files
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
