### PR TITLE
[FEATURE] Keep each graph at the source id width it was written with

### DIFF
--- a/benchmarks/tests/test_key_collisions.py
+++ b/benchmarks/tests/test_key_collisions.py
@@ -3,6 +3,9 @@
 
 import unittest
 
+import numpy as np
+
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
 
 from benchmarks.utils.key_collisions import (
@@ -10,6 +13,7 @@ from benchmarks.utils.key_collisions import (
     count_collisions,
     create_chunk_id,
     create_source_id,
+    discriminating_bits,
     duplicate_pairs,
     expected_pairs,
     source_keys,
@@ -23,18 +27,27 @@ class TestIdFidelity(unittest.TestCase):
     produces describes a key the toolkit does not write.
     """
 
-    def test_source_id_matches_the_id_generator(self):
-        generator = IdGenerator()
+    def test_source_id_matches_the_id_generator_at_every_width(self):
+        for width in SourceIdWidth:
+            generator = IdGenerator(source_id_width=width)
+            for text, metadata_str in [('hello world', ''), ('', ''), ('doc 1', 'file_path:a.txt')]:
+                self.assertEqual(
+                    create_source_id(text, metadata_str, width),
+                    generator.create_source_id(text, metadata_str),
+                )
 
-        for text, metadata_str in [('hello world', ''), ('', ''), ('doc 1', 'file_path:a.txt')]:
-            self.assertEqual(
-                create_source_id(text, metadata_str),
-                generator.create_source_id(text, metadata_str),
-            )
+    def test_the_default_matches_a_bare_id_generator(self):
+        # The module's default has to track IdGenerator's, or every number below
+        # describes a key the toolkit no longer writes.
+        self.assertEqual(create_source_id('hello world', ''),
+                         IdGenerator().create_source_id('hello world', ''))
 
     def test_source_id_shape(self):
         # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
-        self.assertEqual(create_source_id('hello world', ''), 'aws::5eb63bbb:d41d')
+        self.assertEqual(create_source_id('hello world', '', SourceIdWidth.LEGACY),
+                         'aws::5eb63bbb:d41d')
+        self.assertEqual(create_source_id('hello world', '', SourceIdWidth.FULL),
+                         'aws::5eb63bbbe01eeed093cb22bb8f5acdc3:d41d')
 
     def test_chunk_id_matches_the_id_generator(self):
         source_id = create_source_id('hello world', '')
@@ -48,7 +61,7 @@ class TestIdFidelity(unittest.TestCase):
                 )
 
     def test_chunk_id_appends_to_the_source_id(self):
-        source_id = create_source_id('hello world', '')
+        source_id = create_source_id('hello world', '', SourceIdWidth.LEGACY)
 
         self.assertEqual(
             create_chunk_id(source_id, 'hello world', ''),
@@ -119,3 +132,34 @@ class TestExpectedPairs(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestDiscriminatingBits(unittest.TestCase):
+
+    def test_absent_metadata_counts_only_the_text_digest(self):
+        self.assertEqual(discriminating_bits(SourceIdWidth.LEGACY, with_metadata=False), 32)
+        self.assertEqual(discriminating_bits(SourceIdWidth.FULL, with_metadata=False), 128)
+
+    def test_present_metadata_adds_the_fixed_second_component(self):
+        self.assertEqual(discriminating_bits(SourceIdWidth.LEGACY, with_metadata=True), 48)
+        self.assertEqual(discriminating_bits(SourceIdWidth.FULL, with_metadata=True), 144)
+
+
+class TestSourceKeysAtWidth(unittest.TestCase):
+
+    def test_keys_within_uint64_stay_in_a_numpy_array(self):
+        self.assertIsInstance(
+            source_keys(synthetic_texts(8), False, SourceIdWidth.LEGACY), np.ndarray)
+
+    def test_keys_wider_than_uint64_come_back_as_a_list(self):
+        self.assertIsInstance(
+            source_keys(synthetic_texts(8), False, SourceIdWidth.FULL), list)
+
+    def test_the_full_width_removes_the_collision_the_legacy_width_produces(self):
+        texts = synthetic_texts(100_000)
+
+        at_legacy = count_collisions(source_keys(texts, False, SourceIdWidth.LEGACY))
+        at_full = count_collisions(source_keys(texts, False, SourceIdWidth.FULL))
+
+        self.assertGreater(at_legacy['colliding_pairs'], 0)
+        self.assertEqual(at_full['colliding_pairs'], 0)

--- a/benchmarks/utils/key_collisions.py
+++ b/benchmarks/utils/key_collisions.py
@@ -4,11 +4,13 @@
 """
 Measure storage-key collisions for the ids `IdGenerator` produces.
 
-`create_source_id` returns `aws::{md5(text)[:8]}:{md5(metadata_str)[:4]}`, so a
-source id discriminates on 48 bits. `IdRewriter` passes `''` when a node carries
-no metadata, which makes the second component constant and leaves 32 bits. Both
-S3 storage prefixes are built from the bare source id, so two documents sharing
-one share a prefix.
+`create_source_id` returns `aws::{md5(text)[:w]}:{md5(metadata_str)[:4]}`, where
+`w` is the configured `SourceIdWidth`. `IdRewriter` passes `''` when a node
+carries no metadata, which makes the second component constant and leaves `4w`
+bits to discriminate. Both S3 storage prefixes are built from the bare source id,
+so two documents sharing one share a prefix.
+
+Pass `--widths` to compare widths against the same corpus.
 
 Keys are generated synthetically. Running extraction to produce them would cost
 Bedrock time and measure nothing this question needs.
@@ -26,6 +28,8 @@ from collections import Counter
 
 import numpy as np
 
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
+
 
 CHUNK_ID_DELIMITER = '\x00'
 
@@ -35,9 +39,15 @@ def get_hash(s: str) -> str:
     return hashlib.md5(s.encode('utf-8'), usedforsecurity=False).digest().hex()
 
 
-def create_source_id(text: str, metadata_str: str) -> str:
-    """Reproduces IdGenerator.create_source_id (indexing/id_generator.py:84)."""
-    return f'aws::{get_hash(text)[:8]}:{get_hash(metadata_str)[:4]}'
+# The metadata component is a fixed four hex characters in IdGenerator.
+METADATA_HASH_CHARS = 4
+METADATA_HASH_BITS = METADATA_HASH_CHARS * 4
+
+
+def create_source_id(text: str, metadata_str: str,
+                     width: SourceIdWidth = SourceIdWidth.FULL) -> str:
+    """Reproduces IdGenerator.create_source_id (indexing/id_generator.py)."""
+    return f'aws::{get_hash(text)[:width]}:{get_hash(metadata_str)[:METADATA_HASH_CHARS]}'
 
 
 def create_chunk_id(source_id: str, text: str, metadata_str: str,
@@ -75,23 +85,48 @@ def _pairs(counts):
     return sum(c * (c - 1) // 2 for c in counts)
 
 
-def source_keys(texts, with_metadata):
+def discriminating_bits(width: SourceIdWidth = SourceIdWidth.FULL,
+                        with_metadata: bool = False) -> int:
+    """
+    Bits that actually separate two documents.
+
+    Each hex character carries four bits. Without metadata the second component is
+    constant, so only the text digest discriminates.
+    """
+    bits = width * 4
+    return bits + METADATA_HASH_BITS if with_metadata else bits
+
+
+def source_keys(texts, with_metadata, width: SourceIdWidth = SourceIdWidth.FULL):
     """
     with_metadata False reproduces a corpus loaded without metadata, where every
-    document gets md5('')[:4] as its second component and 32 bits discriminate.
+    document gets md5('')[:4] as its second component and only the text digest
+    discriminates.
+
+    A key is the whole id, both components, so it is wider than the discriminating
+    width. Past 64 bits it no longer fits a uint64 and the keys come back as a list
+    for the Counter path in count_collisions.
     """
+    keys = (
+        _key_of(create_source_id(text, _metadata_for(i, with_metadata), width))
+        for i, text in enumerate(texts)
+    )
+    if width * 4 + METADATA_HASH_BITS > 64:
+        return list(keys)
+
     out = np.empty(len(texts), dtype=np.uint64)
-    for i, text in enumerate(texts):
-        out[i] = _key_of(create_source_id(text, _metadata_for(i, with_metadata)))
+    for i, key in enumerate(keys):
+        out[i] = key
     return out
 
 
-def chunk_keys(texts, with_metadata, chunks_per_doc=3, use_chunk_id_delimiter=False):
+def chunk_keys(texts, with_metadata, chunks_per_doc=3, use_chunk_id_delimiter=False,
+               width: SourceIdWidth = SourceIdWidth.FULL):
     """Composite source+chunk keys, to test whether chunk width rescues the prefix."""
     out = []
     for i, text in enumerate(texts):
         metadata_str = _metadata_for(i, with_metadata)
-        source_id = create_source_id(text, metadata_str)
+        source_id = create_source_id(text, metadata_str, width)
         for c in range(chunks_per_doc):
             chunk_id = create_chunk_id(source_id, f'{text}::chunk{c}', metadata_str,
                                        use_chunk_id_delimiter)
@@ -146,7 +181,7 @@ def p_any_collision(n, bits):
 
 def _row(label, stats, bits):
     n = stats['n']
-    return (f"{label:<26} {n:>12,} {stats['colliding_pairs']:>10,} "
+    return (f"{label:<34} {n:>12,} {stats['colliding_pairs']:>10,} "
             f"{expected_pairs(n, bits):>14.3f} {stats['max_group']:>6} "
             f"{p_any_collision(n, bits) * 100:>9.2f}%")
 
@@ -154,29 +189,37 @@ def _row(label, stats, bits):
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--scales', default='100000,1000000,10000000')
+    parser.add_argument('--widths', default=','.join(w.name for w in SourceIdWidth),
+                        help='source id widths to compare, by name (LEGACY, FULL)')
     parser.add_argument('--corpus', help='one document per line, to measure duplicates')
     args = parser.parse_args(argv)
+
+    widths = [SourceIdWidth.parse(w) for w in args.widths.split(',')]
 
     if args.corpus:
         texts = corpus_texts(args.corpus)
         unique_texts = len(set(texts))
-        keys = source_keys(texts, with_metadata=False)
-        stats = count_collisions(keys)
         dup_pairs = duplicate_pairs(texts)
         print(f'corpus: {len(texts):,} documents, {unique_texts:,} distinct texts')
         print(f'  pairs sharing text (deduplication, by design): {dup_pairs:,}')
-        print(f'  pairs sharing a key: {stats["colliding_pairs"]:,}')
-        print(f'  hash collisions: {stats["colliding_pairs"] - dup_pairs:,}')
+        for width in widths:
+            stats = count_collisions(source_keys(texts, False, width))
+            print(f'  {width.name}: {stats["colliding_pairs"]:,} pairs sharing a key, '
+                  f'{stats["colliding_pairs"] - dup_pairs:,} hash collisions')
         return 0
 
-    header = (f"{'case':<26} {'documents':>12} {'collided':>10} "
+    header = (f"{'case':<34} {'documents':>12} {'collided':>10} "
               f"{'expected':>14} {'worst':>6} {'P(any)':>10}")
     print(header)
     print('-' * len(header))
     for n in [int(s) for s in args.scales.split(',')]:
         texts = synthetic_texts(n)
-        print(_row('metadata absent (32 bit)', count_collisions(source_keys(texts, False)), 32))
-        print(_row('metadata present (48 bit)', count_collisions(source_keys(texts, True)), 48))
+        for width in widths:
+            for with_metadata in (False, True):
+                bits = discriminating_bits(width, with_metadata)
+                label = (f"{width.name}, "
+                         f"{'metadata' if with_metadata else 'no metadata'} ({bits} bit)")
+                print(_row(label, count_collisions(source_keys(texts, with_metadata, width)), bits))
     return 0
 
 

--- a/docs-site/src/content/docs/lexical-graph/configuration.mdx
+++ b/docs-site/src/content/docs/lexical-graph/configuration.mdx
@@ -44,7 +44,7 @@ The configuration includes the following parameters:
 | `embed_dimensions` | Number of dimensions in each vector | `1024` | `EMBEDDINGS_DIMENSIONS` |
 | `extraction_num_workers` | The number of parallel processes to use when running the extract stage | `2` | `EXTRACTION_NUM_WORKERS` |
 | `extraction_num_threads_per_worker` | The number of threads used by each process in the extract stage | `4` | `EXTRACTION_NUM_THREADS_PER_WORKER` |
-| `source_id_width` | Characters of the text digest used in a source id. `LEGACY` (8) is what existing graphs were written with; `FULL` (32) separates documents that would otherwise share an id. Changes every source and chunk id, so a graph written at one width cannot be read at another | `LEGACY` | `SOURCE_ID_WIDTH` |
+| `source_id_width` | Characters of the text digest used in a source id. `FULL` (32) separates documents that would otherwise share an id; `LEGACY` (8) is what graphs written before 3.20 carry. A graph keeps the width it was first written at: leave this unset and `LexicalGraphIndex` uses the width of the graph it writes to. An extract that can't read the target graph (a dummy graph store, or `ExtractionPipeline` used directly) takes `FULL`, so set `LEGACY` when extracting for a pre-3.20 graph. A set value that contradicts the graph's width stops the run | `FULL` | `SOURCE_ID_WIDTH` |
 | `extraction_batch_size` | The number of input nodes to be processed in parallel across all workers in the extract stage | `4` | `EXTRACTION_BATCH_SIZE` |
 | `build_num_workers` | The number of parallel processes to use when running the build stage | `2` | `BUILD_NUM_WORKERS` |
 | `build_batch_size` | The number of input nodes to be processed in parallel across all workers in the build stage | `4` | `BUILD_BATCH_SIZE` |

--- a/docs-site/src/content/docs/lexical-graph/configuration.mdx
+++ b/docs-site/src/content/docs/lexical-graph/configuration.mdx
@@ -44,7 +44,7 @@ The configuration includes the following parameters:
 | `embed_dimensions` | Number of dimensions in each vector | `1024` | `EMBEDDINGS_DIMENSIONS` |
 | `extraction_num_workers` | The number of parallel processes to use when running the extract stage | `2` | `EXTRACTION_NUM_WORKERS` |
 | `extraction_num_threads_per_worker` | The number of threads used by each process in the extract stage | `4` | `EXTRACTION_NUM_THREADS_PER_WORKER` |
-| `source_id_hash_length` | Characters of the text digest used in a source id. Widening it separates documents that would otherwise share an id, and changes every source and chunk id, so a graph written at one width cannot be read at another | `8` | `SOURCE_ID_HASH_LENGTH` |
+| `source_id_width` | Characters of the text digest used in a source id. `LEGACY` (8) is what existing graphs were written with; `FULL` (32) separates documents that would otherwise share an id. Changes every source and chunk id, so a graph written at one width cannot be read at another | `LEGACY` | `SOURCE_ID_WIDTH` |
 | `extraction_batch_size` | The number of input nodes to be processed in parallel across all workers in the extract stage | `4` | `EXTRACTION_BATCH_SIZE` |
 | `build_num_workers` | The number of parallel processes to use when running the build stage | `2` | `BUILD_NUM_WORKERS` |
 | `build_batch_size` | The number of input nodes to be processed in parallel across all workers in the build stage | `4` | `BUILD_BATCH_SIZE` |

--- a/integration-tests/env.template
+++ b/integration-tests/env.template
@@ -30,6 +30,7 @@ export BENCHMARK_S3_JSONL=<OPTIONAL: With BENCHMARK_DOC_STORE=s3, store one JSON
 export BENCHMARK_USE_BATCH=<OPTIONAL: Inference mode for the extract benchmarks, true (Bedrock batch) or false (on demand), default: true>
 export EXTRACTION_NUM_WORKERS=<OPTIONAL: Extraction worker processes, default: 2>
 export EXTRACTION_BATCH_SIZE=<OPTIONAL: Extraction batch size, default: 15000>
+export SOURCE_ID_WIDTH=<OPTIONAL: Source id text digest width, FULL or LEGACY, default: FULL>
 
 export EXISTING_VPC_ID=<OPTIONAL: Existing VPC ID to reuse instead of creating a new VPC, default: Empty>
 export EXISTING_SUBNET_IDS=<OPTIONAL: Comma-delimited existing subnet IDs to reuse (min 2 across 2 AZs, must be provided with EXISTING_VPC_ID), default: Empty>

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -42,7 +42,7 @@ DEFAULT_EMBEDDINGS_DIMENSIONS = 1024
 DEFAULT_EXTRACTION_NUM_WORKERS = 2
 DEFAULT_EXTRACTION_BATCH_SIZE = 4
 DEFAULT_EXTRACTION_NUM_THREADS_PER_WORKER = 4
-DEFAULT_SOURCE_ID_WIDTH = 'LEGACY'
+DEFAULT_SOURCE_ID_WIDTH = 'FULL'
 # botocore's own default. Not a chosen value - it's the floor the S3 pool is
 # never sized below. Distinct from DEFAULT_MAX_POOL_CONNECTIONS in
 # neptune_graph_stores, which is that client's chosen size.
@@ -733,13 +733,22 @@ class _GraphRAGConfig:
         """
         Characters of the text digest that go into a source id.
 
-        LEGACY is what every existing graph was written with. FULL is the whole
-        digest, which separates documents that would otherwise share an id. A graph
-        written at one width cannot be read at another, so this is fixed per graph.
+        LEGACY is what every graph written before 3.20 carries. FULL is the whole
+        digest, which separates documents that would otherwise share an id, and is
+        the default for new graphs. A graph keeps the width it was first written
+        at: LexicalGraphIndex uses the graph's width when it has one.
+        """
+        return self.source_id_width_setting or SourceIdWidth.parse(DEFAULT_SOURCE_ID_WIDTH)
+
+    @property
+    def source_id_width_setting(self) -> Optional['SourceIdWidth']:
+        """
+        The width set through the setter or SOURCE_ID_WIDTH, or None when unset.
+        Unset lets an existing graph keep its width. A set width must match the
+        width of the graph being written to.
         """
         if self._source_id_width is None:
-            self._source_id_width = SourceIdWidth.parse(
-                os.environ.get('SOURCE_ID_WIDTH', DEFAULT_SOURCE_ID_WIDTH))
+            self._source_id_width = SourceIdWidth.parse(os.environ.get('SOURCE_ID_WIDTH'))
 
         return self._source_id_width
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/config.py
@@ -42,10 +42,7 @@ DEFAULT_EMBEDDINGS_DIMENSIONS = 1024
 DEFAULT_EXTRACTION_NUM_WORKERS = 2
 DEFAULT_EXTRACTION_BATCH_SIZE = 4
 DEFAULT_EXTRACTION_NUM_THREADS_PER_WORKER = 4
-# Characters of the text digest that go into a source id. Eight is what every
-# existing graph was written with; an md5 hex digest is 32, which is the ceiling.
-DEFAULT_SOURCE_ID_HASH_LENGTH = 8
-MAX_SOURCE_ID_HASH_LENGTH = 32
+DEFAULT_SOURCE_ID_WIDTH = 'LEGACY'
 # botocore's own default. Not a chosen value - it's the floor the S3 pool is
 # never sized below. Distinct from DEFAULT_MAX_POOL_CONNECTIONS in
 # neptune_graph_stores, which is that client's chosen size.
@@ -131,6 +128,35 @@ class OpenSearchServerlessGeneration(str, Enum):
             raise ValueError(
                 f"Invalid OpenSearch Serverless generation '{value}'. Expected one of {valid} "
                 f"(case-insensitive), or unset for auto-detection."
+            ) from e
+
+
+class SourceIdWidth(int, Enum):
+    """Characters of the text digest that go into a source id. Values are the digest
+    length itself, so a member can be used directly where a width is expected."""
+    LEGACY = 8
+    FULL = 32
+
+    @classmethod
+    def parse(cls, value):
+        """Coerce a value to a width. ``None`` or ``''`` means unset. Accepts an enum
+        member, a case-insensitive name (``'legacy'``/``'full'``), or the digest length
+        itself (``8``/``32``). Raises ValueError for anything else."""
+        if value is None or value == '':
+            return None
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(int(value))
+        except (TypeError, ValueError):
+            pass
+        try:
+            return cls[str(value).strip().upper()]
+        except KeyError as e:
+            valid = ', '.join(f'{m.name} ({m.value})' for m in cls)
+            raise ValueError(
+                f"Invalid source id width '{value}'. Expected one of {valid}, "
+                f"case-insensitive, or unset."
             ) from e
 
 
@@ -338,7 +364,7 @@ class _GraphRAGConfig:
     _bedrock_reranking_model: Optional[str] = None
     _extraction_num_workers: Optional[int] = None
     _extraction_num_threads_per_worker: Optional[int] = None
-    _source_id_hash_length: Optional[int] = None
+    _source_id_width: Optional['SourceIdWidth'] = None
     _extraction_batch_size: Optional[int] = None
     _build_num_workers: Optional[int] = None
     _build_batch_size: Optional[int] = None
@@ -703,42 +729,23 @@ class _GraphRAGConfig:
         self._extraction_num_threads_per_worker = num_threads
 
     @property
-    def source_id_hash_length(self) -> int:
+    def source_id_width(self) -> 'SourceIdWidth':
         """
         Characters of the text digest that go into a source id.
 
-        Eight is what every existing graph was written with. A wider setting
-        separates documents that would otherwise share an id, and changes every
-        source id and chunk id, so a graph written at one length cannot be read
-        at another.
-
-        Returns:
-            int: The number of digest characters used in a source id.
+        LEGACY is what every existing graph was written with. FULL is the whole
+        digest, which separates documents that would otherwise share an id. A graph
+        written at one width cannot be read at another, so this is fixed per graph.
         """
-        if self._source_id_hash_length is None:
-            self.source_id_hash_length = int(
-                os.environ.get('SOURCE_ID_HASH_LENGTH', DEFAULT_SOURCE_ID_HASH_LENGTH))
+        if self._source_id_width is None:
+            self._source_id_width = SourceIdWidth.parse(
+                os.environ.get('SOURCE_ID_WIDTH', DEFAULT_SOURCE_ID_WIDTH))
 
-        return self._source_id_hash_length
+        return self._source_id_width
 
-    @source_id_hash_length.setter
-    def source_id_hash_length(self, hash_length: int) -> None:
-        """
-        Sets the number of digest characters used in a source id.
-
-        Args:
-            hash_length (int): The number of digest characters.
-
-        Raises:
-            ValueError: If hash_length falls outside the md5 digest.
-        """
-        if hash_length is not None and not 1 <= hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
-            raise ValueError(
-                f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '
-                f'[source_id_hash_length: {hash_length}]'
-            )
-
-        self._source_id_hash_length = hash_length
+    @source_id_width.setter
+    def source_id_width(self, source_id_width) -> None:
+        self._source_id_width = SourceIdWidth.parse(source_id_width)
 
     @property
     def extraction_batch_size(self) -> int:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -255,7 +255,7 @@ class ExtractionPipeline():
         id_generator=IdGenerator(
             tenant_id=tenant_id, 
             include_classification_in_entity_id=include_classification_in_entity_id,
-            source_id_hash_length=GraphRAGConfig.source_id_hash_length
+            source_id_width=GraphRAGConfig.source_id_width
         )
         
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/extract/extraction_pipeline.py
@@ -243,6 +243,7 @@ class ExtractionPipeline():
         batch_size = coalesce(batch_size, GraphRAGConfig.extraction_batch_size)
         include_classification_in_entity_id = coalesce(include_classification_in_entity_id, GraphRAGConfig.include_classification_in_entity_id)
         extract_timestamp = kwargs.pop('extract_timestamp', None)
+        source_id_width = kwargs.pop('source_id_width', None)
 
         if num_workers > multiprocessing.cpu_count():
             num_workers = multiprocessing.cpu_count()
@@ -255,7 +256,7 @@ class ExtractionPipeline():
         id_generator=IdGenerator(
             tenant_id=tenant_id, 
             include_classification_in_entity_id=include_classification_in_entity_id,
-            source_id_width=GraphRAGConfig.source_id_width
+            source_id_width=source_id_width
         )
         
 

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -4,7 +4,7 @@
 from typing import Optional
 
 from graphrag_toolkit.lexical_graph import TenantId, GraphRAGConfig
-from graphrag_toolkit.lexical_graph.config import DEFAULT_SOURCE_ID_HASH_LENGTH, MAX_SOURCE_ID_HASH_LENGTH
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
 from graphrag_toolkit.lexical_graph.indexing.utils.hash_utils import get_hash
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
@@ -29,9 +29,9 @@ class IdGenerator(BaseModel):
     tenant_id:TenantId
     include_classification_in_entity_id:bool
     use_chunk_id_delimiter:bool
-    source_id_hash_length:int
+    source_id_width:SourceIdWidth
 
-    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_hash_length:int=None):
+    def __init__(self, tenant_id:TenantId=None, include_classification_in_entity_id:bool=None, use_chunk_id_delimiter:bool=False, source_id_width=None):
         """
         Initialize the IdGenerator.
 
@@ -41,26 +41,20 @@ class IdGenerator(BaseModel):
             use_chunk_id_delimiter: Whether to use delimiter in chunk ID hashing to prevent
                 boundary collisions. Defaults to False for backward compatibility with existing
                 graphs. Set to True for new graphs to enable collision-resistant hashing.
-            source_id_hash_length: Characters of the text digest used in a source ID.
-                Defaults to the configured value. Eight is what existing graphs were
-                written with; widening it changes every source and chunk ID.
+            source_id_width: Characters of the text digest used in a source ID.
+                Defaults to the configured width. LEGACY is what existing graphs were
+                written with; FULL changes every source and chunk ID.
 
         Raises:
-            ValueError: If the resolved width falls outside the digest.
+            ValueError: If the width is not a SourceIdWidth.
         """
-        source_id_hash_length = coalesce(source_id_hash_length, GraphRAGConfig.source_id_hash_length)
-
-        if not 1 <= source_id_hash_length <= MAX_SOURCE_ID_HASH_LENGTH:
-            raise ValueError(
-                f'source_id_hash_length must be between 1 and {MAX_SOURCE_ID_HASH_LENGTH} '
-                f'[source_id_hash_length: {source_id_hash_length}]'
-            )
+        source_id_width = coalesce(SourceIdWidth.parse(source_id_width), GraphRAGConfig.source_id_width)
 
         super().__init__(
             tenant_id=tenant_id or TenantId(),
             include_classification_in_entity_id=coalesce(include_classification_in_entity_id, GraphRAGConfig.include_classification_in_entity_id),
             use_chunk_id_delimiter=use_chunk_id_delimiter,
-            source_id_hash_length=source_id_hash_length
+            source_id_width=source_id_width
         )
 
     def _get_hash(self, s):
@@ -98,7 +92,7 @@ class IdGenerator(BaseModel):
             hashed substrings derived from the input text and metadata.
 
         """
-        return f"aws::{self._get_hash(text)[:self.source_id_hash_length]}:{self._get_hash(metadata_str)[:4]}"
+        return f"aws::{self._get_hash(text)[:self.source_id_width]}:{self._get_hash(metadata_str)[:4]}"
 
     # Delimiter used to separate text and metadata in chunk ID hashing.
     # Using null byte as it cannot appear in valid UTF-8 text strings.

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -10,6 +10,11 @@ from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 
 from llama_index.core.bridge.pydantic import BaseModel
 
+SOURCE_ID_PREFIX = 'aws'
+METADATA_DIGEST_LENGTH = 4
+
+_HEX_DIGITS = frozenset('0123456789abcdef')
+
 class IdGenerator(BaseModel):
     """
     A class responsible for generating unique and tenant-specific identifiers.
@@ -92,7 +97,27 @@ class IdGenerator(BaseModel):
             hashed substrings derived from the input text and metadata.
 
         """
-        return f"aws::{self._get_hash(text)[:self.source_id_width]}:{self._get_hash(metadata_str)[:4]}"
+        return f"{SOURCE_ID_PREFIX}::{self._get_hash(text)[:self.source_id_width]}:{self._get_hash(metadata_str)[:METADATA_DIGEST_LENGTH]}"
+
+    @staticmethod
+    def width_of_source_id(source_id:str) -> Optional[SourceIdWidth]:
+        """
+        The width a source id was written at. A source id is ``aws::<text>:<metadata>``,
+        or ``aws:<tenant>:<text>:<metadata>`` once rewritten for a tenant, so the text
+        digest is the third field in both. Returns None for an id this generator did
+        not write: IdRewriter keeps any id starting ``aws:`` as given, and a build
+        accepts nodes whose source is any id at all.
+        """
+        parts = source_id.split(':')
+        if len(parts) != 4 or parts[0] != SOURCE_ID_PREFIX or len(parts[3]) != METADATA_DIGEST_LENGTH:
+            return None
+        digest = parts[2]
+        if not digest or not set(digest) <= _HEX_DIGITS:
+            return None
+        try:
+            return SourceIdWidth(len(digest))
+        except ValueError:
+            return None
 
     # Delimiter used to separate text and metadata in chunk ID hashing.
     # Using null byte as it cannot appear in valid UTF-8 text strings.

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/id_generator.py
@@ -107,11 +107,17 @@ class IdGenerator(BaseModel):
         digest is the third field in both. Returns None for an id this generator did
         not write: IdRewriter keeps any id starting ``aws:`` as given, and a build
         accepts nodes whose source is any id at all.
+
+        Both digests are checked for hex, not just length. A caller-supplied id of
+        the same shape, ``aws:docs:deadbeef:2024``, otherwise reads as a width and
+        either stamps an empty collection or blocks a build.
         """
         parts = source_id.split(':')
-        if len(parts) != 4 or parts[0] != SOURCE_ID_PREFIX or len(parts[3]) != METADATA_DIGEST_LENGTH:
+        if len(parts) != 4 or parts[0] != SOURCE_ID_PREFIX:
             return None
-        digest = parts[2]
+        digest, metadata_digest = parts[2], parts[3]
+        if len(metadata_digest) != METADATA_DIGEST_LENGTH or not set(metadata_digest) <= _HEX_DIGITS:
+            return None
         if not digest or not set(digest) <= _HEX_DIGITS:
             return None
         try:
@@ -147,7 +153,9 @@ class IdGenerator(BaseModel):
             # New behavior: Use delimiter to prevent boundary collisions
             hash_input = text + self._CHUNK_ID_DELIMITER + metadata_str
         else:
-            # Old behavior: Direct concatenation (preserves existing chunk IDs)
+            # Old behavior: direct concatenation. It preserves an existing chunk id
+            # only where the source id is also unchanged, which on a graph written
+            # before 3.20 means the LEGACY source id width.
             hash_input = text + metadata_str
 
         return f'{source_id}:{self._get_hash(hash_input)[:8]}'

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/source_id_width.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/source_id_width.py
@@ -59,40 +59,68 @@ def resolve_source_id_width(stored_widths:Iterable[Optional[SourceIdWidth]], con
     return stored
 
 
-def graph_source_id_width(graph_store:GraphStore) -> Optional[SourceIdWidth]:
+def recorded_source_id_width(graph_store:GraphStore) -> Optional[SourceIdWidth]:
     """
-    The width a graph was written at: its recorded width, else the width of a
-    sample of stored source ids, else None when the graph holds none the
-    generator wrote.
+    The width recorded on the collection, or None when it holds no record.
 
-    The sample is the first SOURCE_ID_SAMPLE_SIZE source ids the store returns, so
-    a graph whose widths diverge beyond that window reads as whichever width the
-    sample holds. Every graph written from here on records its width, which is
-    read in full, and the guard rejects a document at any other width.
+    Every record is read rather than the first one. Nothing constrains a store to
+    a single __SYS_Config__ node, so two first runs at different widths can each
+    create one, and two records that disagree are an error rather than whichever
+    the store happens to return first.
     """
     results = graph_store.execute_query(
         'MATCH (c:`__SYS_Config__`) WHERE c.sourceIdWidth IS NOT NULL '
-        'RETURN c.sourceIdWidth AS width LIMIT 1'
+        'RETURN c.sourceIdWidth AS width'
     )
-    if results:
-        return SourceIdWidth.parse(results[0]['width'])
+    widths = sorted({SourceIdWidth.parse(r['width']) for r in results} - {None})
+    if not widths:
+        return None
+    if len(widths) > 1:
+        raise SourceIdWidthMismatchError(
+            f'This collection records a source id width more than once, and the '
+            f'records disagree: {" and ".join(_describe(w) for w in widths)}.'
+        )
 
+    return widths[0]
+
+
+def sampled_source_id_width(graph_store:GraphStore) -> Optional[SourceIdWidth]:
+    """
+    The width of a sample of stored source ids, or None when the sample holds none
+    the generator wrote.
+
+    The sample is the first SOURCE_ID_SAMPLE_SIZE source ids the store returns, so
+    a collection whose widths already diverge beyond that window reads as whichever
+    width the sample holds. The guard records the width it resolves, so a
+    collection is sampled once and read from its record on every run after that.
+    """
     results = graph_store.execute_query(
         f'MATCH (s:`__Source__`) RETURN {graph_store.node_id("s.sourceId")} AS sourceId '
         f'LIMIT {SOURCE_ID_SAMPLE_SIZE}'
     )
-    widths = sorted({IdGenerator.width_of_source_id(r['sourceId']) for r in results} - {None})
+    widths = sorted({
+        IdGenerator.width_of_source_id(r['sourceId'])
+        for r in results if r['sourceId']
+    } - {None})
     if not widths:
         return None
     logger.debug(f'Read the source id width from stored ids [sampled: {len(results)}]')
     if len(widths) > 1:
         raise SourceIdWidthMismatchError(
-            f'This graph already holds source ids at more than one width: '
+            f'This collection already holds source ids at more than one width: '
             f'{" and ".join(_describe(w) for w in widths)}. Nothing can be written '
             f'to it until they agree.'
         )
 
     return widths[0]
+
+
+def graph_source_id_width(graph_store:GraphStore) -> Optional[SourceIdWidth]:
+    """
+    The width a collection was written at: its recorded width, else the width of a
+    sample of stored source ids, else None when it holds none the generator wrote.
+    """
+    return recorded_source_id_width(graph_store) or sampled_source_id_width(graph_store)
 
 
 def record_graph_source_id_width(graph_store:GraphStore, tenant_id:TenantId, width:SourceIdWidth) -> None:
@@ -119,23 +147,29 @@ def record_graph_source_id_width(graph_store:GraphStore, tenant_id:TenantId, wid
         return
 
     recorded = SourceIdWidth.parse(results[0]['width'])
-    if recorded != width:
+    if recorded is not None and recorded != width:
         raise SourceIdWidthMismatchError(
-            f'This graph already records source id width {_describe(recorded)}; '
+            f'This collection already records source id width {_describe(recorded)}; '
             f'cannot record {_describe(width)}.'
         )
 
 
 class SourceIdWidthGuard:
     """
-    Checks that every document entering a build carries the graph's source id
-    width, and records the width on a graph that has none when the first
-    document arrives.
+    Checks that every document entering a build carries the collection's source id
+    width, and records that width whenever the collection holds no record.
+
+    `configured` is the explicit SOURCE_ID_WIDTH setting, or None when it is
+    unset. A build is the one entry point that takes documents it did not extract,
+    so an empty collection is stamped with the width of the documents arriving at
+    it, and the setting has to be checked here rather than only where extraction
+    resolves it.
     """
 
-    def __init__(self, graph_store:GraphStore, tenant_id:TenantId):
+    def __init__(self, graph_store:GraphStore, tenant_id:TenantId, configured:Optional[SourceIdWidth]=None):
         self.graph_store = graph_store
         self.tenant_id = tenant_id
+        self.configured = configured
 
     @staticmethod
     def _source_id(item:SourceType) -> Optional[str]:
@@ -152,7 +186,8 @@ class SourceIdWidthGuard:
         return source.node_id if source else None
 
     def _check(self, inputs:Iterable[SourceType]):
-        graph_width = graph_source_id_width(self.graph_store)
+        recorded = recorded_source_id_width(self.graph_store)
+        graph_width = recorded or sampled_source_id_width(self.graph_store)
 
         for item in inputs:
             source_id = self._source_id(item)
@@ -160,15 +195,24 @@ class SourceIdWidthGuard:
 
             if width is not None:
                 if graph_width is None:
+                    if self.configured is not None and width != self.configured:
+                        raise SourceIdWidthMismatchError(
+                            f'Document {source_id} has a source id at width {_describe(width)}, '
+                            f'but SOURCE_ID_WIDTH is set to {_describe(self.configured)}. Extract '
+                            f'these documents at the set width, or unset it, to build them.'
+                        )
                     graph_width = width
-                    record_graph_source_id_width(self.graph_store, self.tenant_id, width)
-                    logger.debug(f'Recorded source id width [width: {width.name}]')
                 elif width != graph_width:
                     raise SourceIdWidthMismatchError(
                         f'Document {source_id} has a source id at width {_describe(width)}, '
-                        f'but this graph is written at {_describe(graph_width)}. Extract '
-                        f'with SOURCE_ID_WIDTH={graph_width.name} to write to this graph.'
+                        f'but this collection is written at {_describe(graph_width)}. Extract '
+                        f'with SOURCE_ID_WIDTH={graph_width.name} to write to this collection.'
                     )
+
+                if recorded is None:
+                    record_graph_source_id_width(self.graph_store, self.tenant_id, graph_width)
+                    recorded = graph_width
+                    logger.debug(f'Recorded source id width [width: {graph_width.name}]')
             yield item
 
     def __call__(self, inputs:Iterable[SourceType]):

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/source_id_width.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/source_id_width.py
@@ -1,0 +1,180 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Iterable, Optional
+
+from llama_index.core.schema import NodeRelationship
+
+from graphrag_toolkit.lexical_graph.tenant_id import TenantId
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
+from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+from graphrag_toolkit.lexical_graph.indexing.model import SourceType, SourceDocument
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
+
+logger = logging.getLogger(__name__)
+
+SOURCE_ID_WIDTH_CONFIG_ID = 'source_id_width'
+SOURCE_ID_SAMPLE_SIZE = 100
+
+
+class SourceIdWidthMismatchError(ValueError):
+    """Raised when one collection would hold source ids of two widths."""
+
+
+def _describe(width:SourceIdWidth) -> str:
+    return f'{width.name} ({width.value})'
+
+
+def resolve_source_id_width(stored_widths:Iterable[Optional[SourceIdWidth]], configured:Optional[SourceIdWidth], default:Optional[SourceIdWidth]) -> Optional[SourceIdWidth]:
+    """
+    The width a run must use. A collection that already holds ids keeps the width
+    they were written at; an empty one takes the explicit setting, or the default
+    when there is none. Unknown widths (None) are ignored.
+
+    Raises:
+        SourceIdWidthMismatchError: If the stored widths disagree, or an explicit
+            setting contradicts them.
+    """
+    widths = sorted({w for w in stored_widths if w is not None})
+
+    if len(widths) > 1:
+        raise SourceIdWidthMismatchError(
+            f'This collection would hold source ids at more than one width: '
+            f'{" and ".join(_describe(w) for w in widths)}.'
+        )
+
+    if not widths:
+        return configured or default
+
+    stored = widths[0]
+
+    if configured is not None and configured != stored:
+        raise SourceIdWidthMismatchError(
+            f'This collection was written at source id width {_describe(stored)}, but '
+            f'SOURCE_ID_WIDTH is set to {_describe(configured)}. Unset it, or set it '
+            f'to {stored.name}, to keep writing to this collection.'
+        )
+
+    return stored
+
+
+def graph_source_id_width(graph_store:GraphStore) -> Optional[SourceIdWidth]:
+    """
+    The width a graph was written at: its recorded width, else the width of a
+    sample of stored source ids, else None when the graph holds none the
+    generator wrote.
+
+    The sample is the first SOURCE_ID_SAMPLE_SIZE source ids the store returns, so
+    a graph whose widths diverge beyond that window reads as whichever width the
+    sample holds. Every graph written from here on records its width, which is
+    read in full, and the guard rejects a document at any other width.
+    """
+    results = graph_store.execute_query(
+        'MATCH (c:`__SYS_Config__`) WHERE c.sourceIdWidth IS NOT NULL '
+        'RETURN c.sourceIdWidth AS width LIMIT 1'
+    )
+    if results:
+        return SourceIdWidth.parse(results[0]['width'])
+
+    results = graph_store.execute_query(
+        f'MATCH (s:`__Source__`) RETURN {graph_store.node_id("s.sourceId")} AS sourceId '
+        f'LIMIT {SOURCE_ID_SAMPLE_SIZE}'
+    )
+    widths = sorted({IdGenerator.width_of_source_id(r['sourceId']) for r in results} - {None})
+    if not widths:
+        return None
+    logger.debug(f'Read the source id width from stored ids [sampled: {len(results)}]')
+    if len(widths) > 1:
+        raise SourceIdWidthMismatchError(
+            f'This graph already holds source ids at more than one width: '
+            f'{" and ".join(_describe(w) for w in widths)}. Nothing can be written '
+            f'to it until they agree.'
+        )
+
+    return widths[0]
+
+
+def record_graph_source_id_width(graph_store:GraphStore, tenant_id:TenantId, width:SourceIdWidth) -> None:
+    """
+    Records the width on the graph. Sets it only when the record is created, so a
+    concurrent writer that loses the race reads back the winner's width.
+
+    Raises:
+        SourceIdWidthMismatchError: If the graph already records another width.
+    """
+    results = graph_store.execute_query(
+        f'MERGE (c:`__SYS_Config__`{{{graph_store.node_id("sysConfigId")}: $configId}}) '
+        'ON CREATE SET c.sourceIdWidth = $width '
+        'RETURN c.sourceIdWidth AS width',
+        {
+            'configId': tenant_id.format_id('sys_config', SOURCE_ID_WIDTH_CONFIG_ID),
+            'width': width.value
+        }
+    )
+    if not results:
+        # A store that writes but returns nothing, the dummy store among them,
+        # leaves nothing to check against.
+        logger.debug(f'Graph returned no width after recording [width: {width.name}]')
+        return
+
+    recorded = SourceIdWidth.parse(results[0]['width'])
+    if recorded != width:
+        raise SourceIdWidthMismatchError(
+            f'This graph already records source id width {_describe(recorded)}; '
+            f'cannot record {_describe(width)}.'
+        )
+
+
+class SourceIdWidthGuard:
+    """
+    Checks that every document entering a build carries the graph's source id
+    width, and records the width on a graph that has none when the first
+    document arrives.
+    """
+
+    def __init__(self, graph_store:GraphStore, tenant_id:TenantId):
+        self.graph_store = graph_store
+        self.tenant_id = tenant_id
+
+    @staticmethod
+    def _source_id(item:SourceType) -> Optional[str]:
+        """The source id an input carries, or None when it carries none: a build
+        takes documents and bare nodes, and a node need not have a source."""
+        if isinstance(item, SourceDocument):
+            if not item.nodes:
+                return None
+            node = item.nodes[0]
+        else:
+            node = item
+
+        source = node.relationships.get(NodeRelationship.SOURCE)
+        return source.node_id if source else None
+
+    def _check(self, inputs:Iterable[SourceType]):
+        graph_width = graph_source_id_width(self.graph_store)
+
+        for item in inputs:
+            source_id = self._source_id(item)
+            width = IdGenerator.width_of_source_id(source_id) if source_id else None
+
+            if width is not None:
+                if graph_width is None:
+                    graph_width = width
+                    record_graph_source_id_width(self.graph_store, self.tenant_id, width)
+                    logger.debug(f'Recorded source id width [width: {width.name}]')
+                elif width != graph_width:
+                    raise SourceIdWidthMismatchError(
+                        f'Document {source_id} has a source id at width {_describe(width)}, '
+                        f'but this graph is written at {_describe(graph_width)}. Extract '
+                        f'with SOURCE_ID_WIDTH={graph_width.name} to write to this graph.'
+                    )
+            yield item
+
+    def __call__(self, inputs:Iterable[SourceType]):
+        """
+        Yields the inputs unchanged. A sized input comes back as a list so the
+        build pipeline can still report batch totals.
+        """
+        checked = self._check(inputs)
+        return list(checked) if hasattr(inputs, '__len__') else checked

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
@@ -36,6 +36,7 @@ from graphrag_toolkit.lexical_graph.indexing.build.delete_sources import DeleteS
 from graphrag_toolkit.lexical_graph.utils.arg_utils import coalesce
 from graphrag_toolkit.lexical_graph.utils.llm_cache import LLMCache
 from graphrag_toolkit.lexical_graph.indexing.progress_monitor import ProgressMonitor
+from graphrag_toolkit.lexical_graph.indexing.source_id_width import SourceIdWidthGuard, graph_source_id_width, resolve_source_id_width
 
 from llama_index.core.node_parser import SentenceSplitter, NodeParser
 from llama_index.core.schema import BaseNode
@@ -423,6 +424,17 @@ class LexicalGraphIndex():
 
         return (pre_processors, components)
 
+    def _source_id_width(self):
+        """The source id width extraction must use to keep writing to this graph."""
+        return resolve_source_id_width(
+            [graph_source_id_width(self.graph_store)],
+            configured=GraphRAGConfig.source_id_width_setting,
+            default=GraphRAGConfig.source_id_width
+        )
+
+    def _source_id_width_guard(self) -> Pipe:
+        return Pipe(SourceIdWidthGuard(graph_store=self.graph_store, tenant_id=self.tenant_id))
+
     def extract(
             self,
             nodes: List[BaseNode] = [],
@@ -477,6 +489,7 @@ class LexicalGraphIndex():
             checkpoint=checkpoint,
             tenant_id=DEFAULT_TENANT_ID,
             extraction_filters=self.indexing_config.extraction.extraction_filters,
+            source_id_width=self._source_id_width(),
             **kwargs
         )
 
@@ -567,7 +580,7 @@ class LexicalGraphIndex():
         )
 
         sink_fn = sink if not handler else Pipe(handler)
-        nodes | build_pipeline | sink_fn
+        nodes | self._source_id_width_guard() | build_pipeline | sink_fn
 
     def extract_and_build(
             self,
@@ -606,6 +619,7 @@ class LexicalGraphIndex():
             checkpoint=checkpoint,
             tenant_id=DEFAULT_TENANT_ID,
             extraction_filters=self.indexing_config.extraction.extraction_filters,
+            source_id_width=self._source_id_width(),
             **kwargs
         )
 
@@ -639,9 +653,9 @@ class LexicalGraphIndex():
         sink_fn = sink if not handler else Pipe(handler)
         if progress_monitor:
             extraction_monitor = self._create_extraction_monitor_pipe(progress_monitor)
-            nodes | extraction_pipeline | extraction_monitor | build_pipeline | sink_fn
+            nodes | extraction_pipeline | extraction_monitor | self._source_id_width_guard() | build_pipeline | sink_fn
         else:
-            nodes | extraction_pipeline | build_pipeline | sink_fn
+            nodes | extraction_pipeline | self._source_id_width_guard() | build_pipeline | sink_fn
 
     @staticmethod
     def _create_extraction_monitor_pipe(progress_monitor: ProgressMonitor) -> Pipe:

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/lexical_graph_index.py
@@ -433,7 +433,11 @@ class LexicalGraphIndex():
         )
 
     def _source_id_width_guard(self) -> Pipe:
-        return Pipe(SourceIdWidthGuard(graph_store=self.graph_store, tenant_id=self.tenant_id))
+        return Pipe(SourceIdWidthGuard(
+            graph_store=self.graph_store,
+            tenant_id=self.tenant_id,
+            configured=GraphRAGConfig.source_id_width_setting
+        ))
 
     def extract(
             self,

--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/constants.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/storage/constants.py
@@ -13,6 +13,7 @@ LEXICAL_GRAPH_LABELS = [
     '__Entity__',
     '__SYS_SV__EntityClassification__',
     '__SYS_SV__StatementTopic__',
-    '__SYS_Class__'
+    '__SYS_Class__',
+    '__SYS_Config__'
 ]
 

--- a/lexical-graph/tests/integration/indexing/test_source_id_width_live.py
+++ b/lexical-graph/tests/integration/indexing/test_source_id_width_live.py
@@ -39,6 +39,7 @@ from graphrag_toolkit.lexical_graph.indexing.source_id_width import (
     SourceIdWidthMismatchError,
     graph_source_id_width,
     record_graph_source_id_width,
+    recorded_source_id_width,
 )
 from graphrag_toolkit.lexical_graph.storage.graph import MultiTenantGraphStore
 from graphrag_toolkit.lexical_graph.storage.graph_store_factory import GraphStoreFactory
@@ -170,3 +171,45 @@ class TestGuard:
         guard([source_document(FULL_ID)])
 
         assert graph_source_id_width(store) is SourceIdWidth.FULL
+
+
+class TestASampledWidthIsRecorded:
+    """
+    A collection written before the record existed is sampled once and recorded,
+    so the sampling window closes on the next run rather than staying open for
+    the life of the collection.
+    """
+
+    def test_the_guard_records_a_width_it_sampled(self, graph):
+        store, tenant = graph
+        write_source(store, LEGACY_ID)
+        assert recorded_source_id_width(store) is None
+
+        list(SourceIdWidthGuard(graph_store=store, tenant_id=tenant)
+             ([source_document(LEGACY_ID)]))
+
+        assert recorded_source_id_width(store) is SourceIdWidth.LEGACY
+
+    def test_a_second_run_reads_the_record_rather_than_the_sample(self, graph):
+        store, tenant = graph
+        write_source(store, LEGACY_ID)
+        guard = SourceIdWidthGuard(graph_store=store, tenant_id=tenant)
+        list(guard([source_document(LEGACY_ID)]))
+
+        # Sources gone, record kept: the width must still resolve.
+        store.execute_query('MATCH (n:`__Source__`) DETACH DELETE n')
+
+        assert graph_source_id_width(store) is SourceIdWidth.LEGACY
+
+
+class TestTheGuardHonoursAnExplicitWidth:
+
+    def test_documents_contradicting_the_setting_stop_an_empty_collection(self, graph):
+        store, tenant = graph
+        guard = SourceIdWidthGuard(graph_store=store, tenant_id=tenant,
+                                   configured=SourceIdWidth.FULL)
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            list(guard([source_document(LEGACY_ID)]))
+
+        assert recorded_source_id_width(store) is None

--- a/lexical-graph/tests/integration/indexing/test_source_id_width_live.py
+++ b/lexical-graph/tests/integration/indexing/test_source_id_width_live.py
@@ -1,0 +1,172 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live checks for source id width resolution against a real graph.
+
+Mocked tests can't catch a Cypher clause a store rejects, a property that comes
+back as text rather than a number, or an id column that is `~id` on one store
+and a property on another. The width is read and written through all three of
+those, so it needs a real graph.
+
+Skipped unless a graph is configured. To run locally against Neo4j:
+
+    finch run -d --name source-id-width-test -p 7687:7687 \\
+        -e NEO4J_AUTH=neo4j/testpassword123 neo4j:5
+    NEO4J_TEST_URI=bolt://neo4j:testpassword123@localhost:7687 \\
+        pytest tests/integration/indexing/test_source_id_width_live.py
+    finch stop source-id-width-test && finch rm source-id-width-test
+
+Or against Neptune Analytics, with credentials for the account that holds it:
+
+    NEPTUNE_GRAPH_TEST_ID=g-abc123 AWS_REGION=us-west-2 \\
+        pytest tests/integration/indexing/test_source_id_width_live.py
+
+Each run uses its own tenant, so every node it writes carries a tenant-suffixed
+label and is deleted afterwards. Nothing else in the graph is touched.
+"""
+
+import os
+import uuid
+
+import pytest
+
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
+
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
+from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+from graphrag_toolkit.lexical_graph.indexing.source_id_width import (
+    SourceIdWidthGuard,
+    SourceIdWidthMismatchError,
+    graph_source_id_width,
+    record_graph_source_id_width,
+)
+from graphrag_toolkit.lexical_graph.storage.graph import MultiTenantGraphStore
+from graphrag_toolkit.lexical_graph.storage.graph_store_factory import GraphStoreFactory
+from graphrag_toolkit.lexical_graph.tenant_id import TenantId
+
+NEO4J_TEST_URI = os.environ.get('NEO4J_TEST_URI')
+NEPTUNE_GRAPH_TEST_ID = os.environ.get('NEPTUNE_GRAPH_TEST_ID')
+
+GRAPHS = {}
+if NEO4J_TEST_URI:
+    GRAPHS['neo4j'] = NEO4J_TEST_URI
+if NEPTUNE_GRAPH_TEST_ID:
+    GRAPHS['neptune-graph'] = f'neptune-graph://{NEPTUNE_GRAPH_TEST_ID}'
+
+pytestmark = pytest.mark.skipif(
+    not GRAPHS,
+    reason='set NEO4J_TEST_URI or NEPTUNE_GRAPH_TEST_ID to run these live tests',
+)
+
+LEGACY_ID = 'aws::5eb63bbb:d41d'
+FULL_ID = 'aws::5eb63bbbe01eeed093cb22bb8f5acdc3:d41d'
+
+
+@pytest.fixture(params=list(GRAPHS.values()), ids=list(GRAPHS.keys()))
+def graph(request):
+    """An empty per-tenant view of a real graph, emptied again afterwards."""
+    tenant = TenantId(f't{uuid.uuid4().hex[:8]}')
+    store = MultiTenantGraphStore.wrap(
+        GraphStoreFactory.for_graph_store(request.param), tenant
+    )
+    try:
+        yield store, tenant
+    finally:
+        # The wrapper rewrites these to the tenant's own labels, so this deletes
+        # only what the test wrote.
+        for label in ('__SYS_Config__', '__Source__'):
+            store.execute_query(f'MATCH (n:`{label}`) DETACH DELETE n')
+
+
+def write_source(store, source_id):
+    store.execute_query(
+        f'MERGE (s:`__Source__`{{{store.node_id("sourceId")}: $sourceId}})',
+        {'sourceId': source_id},
+    )
+
+
+def source_document(source_id):
+    node = TextNode(text='chunk')
+    node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=source_id)
+    return SourceDocument(nodes=[node])
+
+
+class TestGraphWidth:
+
+    def test_an_empty_graph_has_no_width(self, graph):
+        store, _ = graph
+
+        assert graph_source_id_width(store) is None
+
+    def test_the_width_is_read_back_from_a_stored_source_id(self, graph):
+        store, _ = graph
+        write_source(store, LEGACY_ID)
+
+        assert graph_source_id_width(store) is SourceIdWidth.LEGACY
+
+    def test_a_graph_already_holding_two_widths_raises(self, graph):
+        store, _ = graph
+        write_source(store, LEGACY_ID)
+        write_source(store, FULL_ID)
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            graph_source_id_width(store)
+
+    def test_a_recorded_width_is_read_back(self, graph):
+        store, tenant = graph
+
+        record_graph_source_id_width(store, tenant, SourceIdWidth.FULL)
+
+        assert graph_source_id_width(store) is SourceIdWidth.FULL
+
+    def test_recording_the_same_width_again_is_accepted(self, graph):
+        store, tenant = graph
+        record_graph_source_id_width(store, tenant, SourceIdWidth.FULL)
+
+        record_graph_source_id_width(store, tenant, SourceIdWidth.FULL)
+
+        assert graph_source_id_width(store) is SourceIdWidth.FULL
+
+    def test_recording_another_width_raises(self, graph):
+        store, tenant = graph
+        record_graph_source_id_width(store, tenant, SourceIdWidth.LEGACY)
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            record_graph_source_id_width(store, tenant, SourceIdWidth.FULL)
+
+    def test_the_record_wins_over_stored_ids(self, graph):
+        store, tenant = graph
+        write_source(store, LEGACY_ID)
+        store.execute_query(
+            f'MERGE (c:`__SYS_Config__`{{{store.node_id("sysConfigId")}: $id}}) '
+            'ON CREATE SET c.sourceIdWidth = 32',
+            {'id': tenant.format_id('sys_config', 'source_id_width')},
+        )
+
+        assert graph_source_id_width(store) is SourceIdWidth.FULL
+
+
+class TestGuard:
+
+    def test_documents_at_the_graph_width_pass_through(self, graph):
+        store, tenant = graph
+        record_graph_source_id_width(store, tenant, SourceIdWidth.LEGACY)
+        guard = SourceIdWidthGuard(graph_store=store, tenant_id=tenant)
+
+        assert len(guard([source_document(LEGACY_ID)])) == 1
+
+    def test_documents_at_another_width_stop_the_build(self, graph):
+        store, tenant = graph
+        record_graph_source_id_width(store, tenant, SourceIdWidth.LEGACY)
+        guard = SourceIdWidthGuard(graph_store=store, tenant_id=tenant)
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            guard([source_document(FULL_ID)])
+
+    def test_the_first_document_records_the_width(self, graph):
+        store, tenant = graph
+        guard = SourceIdWidthGuard(graph_store=store, tenant_id=tenant)
+
+        guard([source_document(FULL_ID)])
+
+        assert graph_source_id_width(store) is SourceIdWidth.FULL

--- a/lexical-graph/tests/unit/conftest.py
+++ b/lexical-graph/tests/unit/conftest.py
@@ -3,8 +3,10 @@
 
 import pytest
 from unittest.mock import Mock, patch, MagicMock
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+from graphrag_toolkit.lexical_graph.indexing.load.s3_based_docs import S3DocDownloader
 
 
 @pytest.fixture
@@ -75,3 +77,46 @@ def custom_id_gen(custom_tenant):
     Fixture for custom ID generator (backward compatible mode, no delimiter).
     '''
     return IdGenerator(tenant_id=custom_tenant, include_classification_in_entity_id=True, use_chunk_id_delimiter=False)
+
+
+@pytest.fixture
+def chunk_node():
+    '''
+    Factory for a chunk node belonging to a source document.
+
+    The SOURCE relationship is what SourceDocument.source_id() reads, so a node
+    built without it has no document identity.
+    '''
+    def _chunk_node(node_id, source_id):
+        node = TextNode(text=f'text for {node_id}', id_=node_id)
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=source_id)
+        return node
+
+    return _chunk_node
+
+
+@pytest.fixture
+def download_source_prefix():
+    '''
+    Factory that reads one source prefix through S3DocDownloader against a mock
+    client, given a mapping of object key to the nodes that object holds.
+
+    Every object under the prefix merges into one SourceDocument, so this is how
+    a test observes what a prefix reads back as.
+    '''
+    def _download_source_prefix(objects):
+        downloader = S3DocDownloader(
+            key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
+        )
+        s3_client = Mock()
+        s3_client.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [{'Key': key} for key in objects]}
+        ]
+
+        def download_fileobj(bucket, key, stream):
+            stream.write('\n'.join(n.to_json() for n in objects[key]).encode('UTF-8'))
+
+        s3_client.download_fileobj.side_effect = download_fileobj
+        return downloader._download_doc('prefix', s3_client)
+
+    return _download_source_prefix

--- a/lexical-graph/tests/unit/indexing/conftest.py
+++ b/lexical-graph/tests/unit/indexing/conftest.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from graphrag_toolkit.lexical_graph import GraphRAGConfig
+
+
+@pytest.fixture
+def isolated_source_id_width(monkeypatch):
+    """
+    The width is env-backed and cached on the config, so a value left in either
+    place changes ids for every test that follows.
+    """
+    monkeypatch.delenv('SOURCE_ID_WIDTH', raising=False)
+    GraphRAGConfig.source_id_width = None
+    yield
+    GraphRAGConfig.source_id_width = None

--- a/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
+++ b/lexical-graph/tests/unit/indexing/load/test_s3_based_docs.py
@@ -1023,40 +1023,22 @@ class TestDownloadDeduplicatesNodeIds:
     the same node id can arrive twice.
     """
 
-    def _download(self, objects):
-        downloader = S3DocDownloader(
-            key_prefix='p', collection_id='c', bucket_name='b', fn=lambda n: n
-        )
-        s3_client = Mock()
-        s3_client.get_paginator.return_value.paginate.return_value = [
-            {'Contents': [{'Key': key} for key in objects]}
-        ]
+    SOURCE_ID = 'aws::dead:beef'
 
-        def download_fileobj(bucket, key, stream):
-            stream.write('\n'.join(n.to_json() for n in objects[key]).encode('UTF-8'))
+    def test_a_node_id_in_two_objects_is_returned_once(self, download_source_prefix, chunk_node):
+        node = lambda node_id: chunk_node(node_id, self.SOURCE_ID)
 
-        s3_client.download_fileobj.side_effect = download_fileobj
-        return downloader._download_doc('prefix', s3_client)
-
-    def _node(self, node_id):
-        node = TextNode(text=f'text for {node_id}', id_=node_id)
-        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id='aws::dead:beef')
-        return node
-
-    def test_a_node_id_in_two_objects_is_returned_once(self):
-        overlapping = {
-            'round-a.jsonl': [self._node('c1'), self._node('c2')],
-            'round-b.jsonl': [self._node('c2'), self._node('c3')],
-        }
-
-        doc = self._download(overlapping)
+        doc = download_source_prefix({
+            'round-a.jsonl': [node('c1'), node('c2')],
+            'round-b.jsonl': [node('c2'), node('c3')],
+        })
 
         assert [n.node_id for n in doc.nodes] == ['c1', 'c2', 'c3']
 
-    def test_distinct_objects_are_all_kept(self):
-        doc = self._download({
-            'a.jsonl': [self._node('c1')],
-            'b.jsonl': [self._node('c2')],
+    def test_distinct_objects_are_all_kept(self, download_source_prefix, chunk_node):
+        doc = download_source_prefix({
+            'a.jsonl': [chunk_node('c1', self.SOURCE_ID)],
+            'b.jsonl': [chunk_node('c2', self.SOURCE_ID)],
         })
 
         assert len(doc.nodes) == 2

--- a/lexical-graph/tests/unit/indexing/test_id_generator.py
+++ b/lexical-graph/tests/unit/indexing/test_id_generator.py
@@ -7,7 +7,7 @@ import pytest
 from graphrag_toolkit.lexical_graph.tenant_id import TenantId
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.schema import Document, NodeRelationship
-from graphrag_toolkit.lexical_graph.config import GraphRAGConfig
+from graphrag_toolkit.lexical_graph.config import GraphRAGConfig, SourceIdWidth
 from graphrag_toolkit.lexical_graph.indexing.extract.id_rewriter import IdRewriter
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
 from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
@@ -471,55 +471,55 @@ def isolated_hash_length(monkeypatch):
     The width is env-backed and cached on the config, so a value left in either
     place changes ids for every test that follows.
     """
-    monkeypatch.delenv('SOURCE_ID_HASH_LENGTH', raising=False)
-    GraphRAGConfig.source_id_hash_length = None
+    monkeypatch.delenv('SOURCE_ID_WIDTH', raising=False)
+    GraphRAGConfig.source_id_width = None
     yield
-    GraphRAGConfig.source_id_hash_length = None
+    GraphRAGConfig.source_id_width = None
 
 
-class TestSourceIdHashLength:
+class TestSourceIdWidth:
     """
     A source id discriminates on 48 bits, and on 32 when a document carries no
-    metadata, so distinct documents collide at scale. The text component's width
-    is configurable so the collision rate can be set to the corpus, and it
-    defaults to today's 8 characters because widening it changes every id.
+    metadata, so distinct documents collide at scale. Two widths are meaningful:
+    LEGACY is what existing graphs carry, FULL is the whole digest. It defaults
+    to LEGACY because changing it changes every id.
     """
 
-    def test_defaults_to_eight_characters(self):
+    def test_defaults_to_the_legacy_width(self):
         generator = IdGenerator()
 
-        assert generator.source_id_hash_length == 8
+        assert generator.source_id_width is SourceIdWidth.LEGACY
 
     def test_default_matches_the_shipped_id_exactly(self):
         # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
         assert IdGenerator().create_source_id('hello world', '') == 'aws::5eb63bbb:d41d'
 
     def test_a_wider_setting_lengthens_the_text_component(self):
-        generator = IdGenerator(source_id_hash_length=16)
+        generator = IdGenerator(source_id_width=SourceIdWidth.FULL)
 
         source_id = generator.create_source_id('hello world', '')
 
-        assert source_id == 'aws::5eb63bbbe01eeed0:d41d'
+        assert source_id == 'aws::5eb63bbbe01eeed093cb22bb8f5acdc3:d41d'
 
     def test_the_metadata_component_is_unchanged_by_the_setting(self):
-        wide = IdGenerator(source_id_hash_length=32).create_source_id('hello world', 'k:v')
+        wide = IdGenerator(source_id_width=SourceIdWidth.FULL).create_source_id('hello world', 'k:v')
         narrow = IdGenerator().create_source_id('hello world', 'k:v')
 
         assert wide.split(':')[-1] == narrow.split(':')[-1]
 
-    def test_widening_separates_texts_that_collide_at_a_narrow_width(self):
-        narrow, wide = IdGenerator(source_id_hash_length=2), IdGenerator(source_id_hash_length=32)
-        a, b = self._colliding_texts(width=2)
+    def test_full_separates_texts_that_collide_at_the_legacy_width(self):
+        legacy, full = IdGenerator(), IdGenerator(source_id_width=SourceIdWidth.FULL)
+        a, b = self._colliding_texts(width=SourceIdWidth.LEGACY)
 
-        assert narrow.create_source_id(a, '') == narrow.create_source_id(b, '')
-        assert wide.create_source_id(a, '') != wide.create_source_id(b, '')
+        assert legacy.create_source_id(a, '') == legacy.create_source_id(b, '')
+        assert full.create_source_id(a, '') != full.create_source_id(b, '')
 
     @staticmethod
     def _colliding_texts(width):
         """Two different texts whose digests agree on the first `width` characters."""
         seen = {}
         for i in range(100000):
-            text = f'document {i}'
+            text = f'document {i} body text'
             prefix = hashlib.md5(text.encode('utf-8')).hexdigest()[:width]
             if prefix in seen:
                 return seen[prefix], text
@@ -527,25 +527,39 @@ class TestSourceIdHashLength:
         raise AssertionError(f'no collision found at width {width}')
 
     def test_chunk_ids_follow_the_wider_source_id(self):
-        generator = IdGenerator(source_id_hash_length=32)
+        generator = IdGenerator(source_id_width=SourceIdWidth.FULL)
 
         source_id = generator.create_source_id('hello world', '')
 
         assert generator.create_chunk_id(source_id, 'hello world', '').startswith(source_id)
 
-    @pytest.mark.parametrize('length', [0, -1, 33])
-    def test_rejects_a_length_outside_the_digest(self, length):
-        # An md5 hex digest is 32 characters, so anything past it silently
-        # truncates and anything below 1 produces a keyless id.
+    @pytest.mark.parametrize('width', [0, -1, 16, 33, 'wide'])
+    def test_rejects_anything_that_is_not_a_width(self, width):
+        # Two widths are meaningful. An arbitrary number is not a choice a caller
+        # can reason about, so it is refused rather than silently truncating.
         with pytest.raises(ValueError):
-            IdGenerator(source_id_hash_length=length)
+            IdGenerator(source_id_width=width)
+
+    @pytest.mark.parametrize('value,expected', [
+        (8, SourceIdWidth.LEGACY),
+        (32, SourceIdWidth.FULL),
+        ('legacy', SourceIdWidth.LEGACY),
+        ('FULL', SourceIdWidth.FULL),
+        (SourceIdWidth.FULL, SourceIdWidth.FULL),
+    ])
+    def test_accepts_a_member_a_name_or_the_digest_length(self, value, expected):
+        assert SourceIdWidth.parse(value) is expected
+
+    @pytest.mark.parametrize('value', [None, ''])
+    def test_unset_parses_to_none(self, value):
+        assert SourceIdWidth.parse(value) is None
 
 
-class TestSourceIdHashLengthReachesTheIds:
+class TestSourceIdWidthReachesTheIds:
     """Covers the path from configuration to the ids a run writes."""
 
-    def _ids(self, hash_length):
-        generator = IdGenerator(source_id_hash_length=hash_length)
+    def _ids(self, width):
+        generator = IdGenerator(source_id_width=width)
         rewriter = IdRewriter(
             inner=SentenceSplitter(chunk_size=256, chunk_overlap=25),
             id_generator=generator,
@@ -555,35 +569,35 @@ class TestSourceIdHashLengthReachesTheIds:
         return chunks
 
     def test_config_default_leaves_ids_where_they_are(self):
-        assert GraphRAGConfig.source_id_hash_length == 8
+        assert GraphRAGConfig.source_id_width is SourceIdWidth.LEGACY
 
     def test_config_reads_the_environment(self, monkeypatch):
-        monkeypatch.setenv('SOURCE_ID_HASH_LENGTH', '32')
+        monkeypatch.setenv('SOURCE_ID_WIDTH', 'full')
 
-        assert GraphRAGConfig.source_id_hash_length == 32
+        assert GraphRAGConfig.source_id_width is SourceIdWidth.FULL
 
     def test_widening_changes_ids_but_not_chunk_text(self):
-        narrow, wide = self._ids(8), self._ids(32)
+        narrow, wide = self._ids(SourceIdWidth.LEGACY), self._ids(SourceIdWidth.FULL)
 
         assert [c.text for c in narrow] == [c.text for c in wide]
         assert [c.id_ for c in narrow] != [c.id_ for c in wide]
 
     def test_widening_separates_the_source_relationship(self):
-        narrow, wide = self._ids(8), self._ids(32)
+        narrow, wide = self._ids(SourceIdWidth.LEGACY), self._ids(SourceIdWidth.FULL)
         source_of = lambda c: c.relationships[NodeRelationship.SOURCE].node_id
 
         assert len(source_of(wide[0])) > len(source_of(narrow[0]))
         assert source_of(narrow[0]) != source_of(wide[0])
 
 
-class TestSourceIdHashLengthConfig:
+class TestSourceIdWidthConfig:
 
     def test_a_bare_generator_takes_the_configured_width(self):
-        GraphRAGConfig.source_id_hash_length = 16
+        GraphRAGConfig.source_id_width = SourceIdWidth.FULL
 
-        assert IdGenerator().source_id_hash_length == 16
+        assert IdGenerator().source_id_width is SourceIdWidth.FULL
 
-    @pytest.mark.parametrize('length', [0, -1, 33])
-    def test_the_config_rejects_a_width_outside_the_digest(self, length):
+    @pytest.mark.parametrize('width', [0, -1, 16, 33, 'wide'])
+    def test_the_config_rejects_anything_that_is_not_a_width(self, width):
         with pytest.raises(ValueError):
-            GraphRAGConfig.source_id_hash_length = length
+            GraphRAGConfig.source_id_width = width

--- a/lexical-graph/tests/unit/indexing/test_id_generator.py
+++ b/lexical-graph/tests/unit/indexing/test_id_generator.py
@@ -466,33 +466,28 @@ def test_id_generator_tenant_isolation_property(tenant_id1, tenant_id2):
 
 
 @pytest.fixture(autouse=True)
-def isolated_hash_length(monkeypatch):
-    """
-    The width is env-backed and cached on the config, so a value left in either
-    place changes ids for every test that follows.
-    """
-    monkeypatch.delenv('SOURCE_ID_WIDTH', raising=False)
-    GraphRAGConfig.source_id_width = None
+def isolated_width(isolated_source_id_width):
     yield
-    GraphRAGConfig.source_id_width = None
 
 
 class TestSourceIdWidth:
     """
     A source id discriminates on 48 bits, and on 32 when a document carries no
     metadata, so distinct documents collide at scale. Two widths are meaningful:
-    LEGACY is what existing graphs carry, FULL is the whole digest. It defaults
-    to LEGACY because changing it changes every id.
+    LEGACY is what graphs written before 3.20 carry, FULL is the whole digest
+    and the default for new graphs.
     """
 
-    def test_defaults_to_the_legacy_width(self):
+    def test_defaults_to_the_full_width(self):
         generator = IdGenerator()
 
-        assert generator.source_id_width is SourceIdWidth.LEGACY
+        assert generator.source_id_width is SourceIdWidth.FULL
 
-    def test_default_matches_the_shipped_id_exactly(self):
+    def test_legacy_matches_the_shipped_id_exactly(self):
         # md5('hello world') starts 5eb63bbb; md5('') starts d41d.
-        assert IdGenerator().create_source_id('hello world', '') == 'aws::5eb63bbb:d41d'
+        generator = IdGenerator(source_id_width=SourceIdWidth.LEGACY)
+
+        assert generator.create_source_id('hello world', '') == 'aws::5eb63bbb:d41d'
 
     def test_a_wider_setting_lengthens_the_text_component(self):
         generator = IdGenerator(source_id_width=SourceIdWidth.FULL)
@@ -503,12 +498,13 @@ class TestSourceIdWidth:
 
     def test_the_metadata_component_is_unchanged_by_the_setting(self):
         wide = IdGenerator(source_id_width=SourceIdWidth.FULL).create_source_id('hello world', 'k:v')
-        narrow = IdGenerator().create_source_id('hello world', 'k:v')
+        narrow = IdGenerator(source_id_width=SourceIdWidth.LEGACY).create_source_id('hello world', 'k:v')
 
         assert wide.split(':')[-1] == narrow.split(':')[-1]
 
     def test_full_separates_texts_that_collide_at_the_legacy_width(self):
-        legacy, full = IdGenerator(), IdGenerator(source_id_width=SourceIdWidth.FULL)
+        legacy = IdGenerator(source_id_width=SourceIdWidth.LEGACY)
+        full = IdGenerator(source_id_width=SourceIdWidth.FULL)
         a, b = self._colliding_texts(width=SourceIdWidth.LEGACY)
 
         assert legacy.create_source_id(a, '') == legacy.create_source_id(b, '')
@@ -555,6 +551,31 @@ class TestSourceIdWidth:
         assert SourceIdWidth.parse(value) is None
 
 
+class TestWidthOfSourceId:
+    """The parser lives beside create_source_id so the format is defined once."""
+
+    @pytest.mark.parametrize('width', list(SourceIdWidth))
+    def test_reads_back_the_width_the_generator_wrote(self, width):
+        source_id = IdGenerator(source_id_width=width).create_source_id('hello world', 'k:v')
+
+        assert IdGenerator.width_of_source_id(source_id) is width
+
+    @pytest.mark.parametrize('width', list(SourceIdWidth))
+    def test_tenant_rewriting_does_not_change_the_parse(self, width):
+        generator = IdGenerator(tenant_id=TenantId('tenant1'), source_id_width=width)
+
+        source_id = generator.rewrite_id_for_tenant(generator.create_source_id('hello world', ''))
+
+        assert IdGenerator.width_of_source_id(source_id) is width
+
+    @pytest.mark.parametrize('value', [
+        'aws::5eb6:d41d', 'not-a-source-id', 'aws::5eb63bbb', 'aws:custom-id',
+        '0f8fad5b-d9cb-469f-a165-70867728950e', 'aws::5eb63bbbzzzzzzzz:d41d',
+    ])
+    def test_an_id_the_generator_did_not_write_has_no_width(self, value):
+        assert IdGenerator.width_of_source_id(value) is None
+
+
 class TestSourceIdWidthReachesTheIds:
     """Covers the path from configuration to the ids a run writes."""
 
@@ -568,8 +589,8 @@ class TestSourceIdWidthReachesTheIds:
         chunks = rewriter.handle_source_docs([SourceDocument(nodes=[document])])[0].nodes
         return chunks
 
-    def test_config_default_leaves_ids_where_they_are(self):
-        assert GraphRAGConfig.source_id_width is SourceIdWidth.LEGACY
+    def test_config_defaults_to_the_full_digest(self):
+        assert GraphRAGConfig.source_id_width is SourceIdWidth.FULL
 
     def test_config_reads_the_environment(self, monkeypatch):
         monkeypatch.setenv('SOURCE_ID_WIDTH', 'full')

--- a/lexical-graph/tests/unit/indexing/test_source_id_collision.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_collision.py
@@ -17,7 +17,11 @@ case these tests use.
 
 import pytest
 
+from unittest.mock import Mock
+
+from graphrag_toolkit.lexical_graph.indexing.build.source_graph_builder import SourceGraphBuilder
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
 
 # md5(TEXT_A) and md5(TEXT_B) agree on their first eight hex characters, a4439cdb.
 TEXT_A = 'document 27347 body text'
@@ -105,6 +109,66 @@ class TestCollisionConsequences:
         })
 
         assert len(doc.nodes) == 2
+
+
+class TestCollisionReachesTheGraph:
+    """
+    The graph half of the defect. `SourceGraphBuilder` MERGEs on the source id,
+    so two documents carrying one id bind one merge key.
+
+    Against a mock, so these observe what the builder sends, not what a store
+    does with it. Whether the nodes actually collapse needs a real graph.
+    """
+
+    @staticmethod
+    def _graph_client():
+        client = Mock(spec=GraphStore)
+        client.node_id = Mock(side_effect=lambda field: field)
+        client.property_assigment_fn = Mock(side_effect=lambda key, value: (lambda x: x))
+        client.execute_query_with_retry = Mock()
+        return client
+
+    @staticmethod
+    def _source_node(text):
+        """A source node carrying the id the pipeline would derive from `text`."""
+        node = Mock()
+        node.metadata = {
+            'source': {
+                'sourceId': source_id_as_configured(text),
+                'metadata': {'file_path': f'{text}.txt'},
+            }
+        }
+        return node
+
+    def _merge_calls(self, *texts):
+        client = self._graph_client()
+        for text in texts:
+            SourceGraphBuilder().build(self._source_node(text), client)
+        return client.execute_query_with_retry.call_args_list
+
+    def test_both_documents_merge_on_one_source_id(self):
+        # The builder binds the id it is given, unchanged, so two documents that
+        # collide bind one key. Fails once the default width is widened, which
+        # is the point; update it then rather than deleting it.
+        calls = self._merge_calls(TEXT_A, TEXT_B)
+
+        assert len(calls) == 2
+        bound = [call[0][1]['params'][0]['sourceId'] for call in calls]
+        assert bound[0] == bound[1]
+
+    def test_the_merge_key_is_the_source_id(self):
+        query = self._merge_calls(TEXT_A)[0][0][0]
+
+        assert 'MERGE (source:`__Source__`{sourceId: params.sourceId})' in query
+
+    def test_their_differing_metadata_lands_on_the_one_node(self):
+        # Both builds set metadata under one key, and the query overwrites on
+        # match. Which document's metadata survives is the store's to decide.
+        calls = self._merge_calls(TEXT_A, TEXT_B)
+
+        paths = [call[0][1]['params'][0]['file_path'] for call in calls]
+        assert paths[0] != paths[1]
+        assert 'ON MATCH SET' in calls[1][0][0]
 
 
 @pytest.mark.xfail(

--- a/lexical-graph/tests/unit/indexing/test_source_id_collision.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_collision.py
@@ -19,6 +19,7 @@ import pytest
 
 from unittest.mock import Mock
 
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
 from graphrag_toolkit.lexical_graph.indexing.build.source_graph_builder import SourceGraphBuilder
 from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
 from graphrag_toolkit.lexical_graph.storage.graph import GraphStore
@@ -31,17 +32,16 @@ COLLIDING_SOURCE_ID = 'aws::a4439cdb:d41d'
 
 NO_METADATA = ''
 
-# The width every existing graph was written with, pinned rather than read from
-# config so the facts below hold whatever a run is configured to use.
-LEGACY_WIDTH = 8
-
-# The width under consideration for the fix. 64 discriminating bits.
-CANDIDATE_WIDTH = 16
+# Pinned rather than read from config, so the facts below hold whatever a run is
+# configured to use. LEGACY is what every existing graph was written with; FULL is
+# the whole digest.
+LEGACY_WIDTH = SourceIdWidth.LEGACY
+WIDENED = SourceIdWidth.FULL
 
 
 def source_id_at(text, width, metadata_str=NO_METADATA):
     """The id this text would get at an explicit width."""
-    return IdGenerator(source_id_hash_length=width).create_source_id(text, metadata_str)
+    return IdGenerator(source_id_width=width).create_source_id(text, metadata_str)
 
 
 def source_id_as_configured(text, metadata_str=NO_METADATA):
@@ -65,7 +65,7 @@ class TestCollidingPair:
                 == COLLIDING_SOURCE_ID)
 
     def test_a_wider_text_digest_separates_them(self):
-        assert source_id_at(TEXT_A, CANDIDATE_WIDTH) != source_id_at(TEXT_B, CANDIDATE_WIDTH)
+        assert source_id_at(TEXT_A, WIDENED) != source_id_at(TEXT_B, WIDENED)
 
     def test_metadata_separates_them_only_when_it_differs(self):
         # The second component is a digest of the metadata, so it discriminates

--- a/lexical-graph/tests/unit/indexing/test_source_id_collision.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_collision.py
@@ -50,12 +50,8 @@ def source_id_as_configured(text, metadata_str=NO_METADATA):
 class TestCollidingPair:
     """
     Preconditions. These are arithmetic about md5, not statements about any
-    configuration. If one stops holding, the pair needs regenerating.
+    configuration.
     """
-
-    def test_the_two_documents_are_different(self):
-        # Guards the rest: every assertion below is worthless if these converge.
-        assert TEXT_A != TEXT_B
 
     def test_they_share_one_source_id_at_the_legacy_width(self):
         assert (source_id_at(TEXT_A, LEGACY_WIDTH)
@@ -115,7 +111,7 @@ class TestCollisionReachesTheGraph:
     so two documents carrying one id bind one merge key.
 
     Against a mock, so these observe what the builder sends, not what a store
-    does with it. Whether the nodes actually collapse needs a real graph.
+    does with it.
     """
 
     @staticmethod

--- a/lexical-graph/tests/unit/indexing/test_source_id_collision.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_collision.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Two distinct documents whose source ids collide are indistinguishable downstream.
+
+The pair below was found by hashing sequentially numbered documents until two
+shared the first eight characters of their md5 digest, which took 30,059 of them.
+That is the problem in one number: the default width discriminates on 32 bits, so
+a corpus reaches even odds of a collision far below the scale anyone designs for.
+
+`IdRewriter` passes `''` for the metadata component when a node carries no
+metadata, which makes that component constant and leaves only the text digest to
+separate two documents. That is the case measured in the collision spike and the
+case these tests use.
+"""
+
+import pytest
+
+from graphrag_toolkit.lexical_graph.indexing.id_generator import IdGenerator
+
+# md5(TEXT_A) and md5(TEXT_B) agree on their first eight hex characters, a4439cdb.
+TEXT_A = 'document 27347 body text'
+TEXT_B = 'document 30059 body text'
+
+COLLIDING_SOURCE_ID = 'aws::a4439cdb:d41d'
+
+NO_METADATA = ''
+
+# The width every existing graph was written with, pinned rather than read from
+# config so the facts below hold whatever a run is configured to use.
+LEGACY_WIDTH = 8
+
+# The width under consideration for the fix. 64 discriminating bits.
+CANDIDATE_WIDTH = 16
+
+
+def source_id_at(text, width, metadata_str=NO_METADATA):
+    """The id this text would get at an explicit width."""
+    return IdGenerator(source_id_hash_length=width).create_source_id(text, metadata_str)
+
+
+def source_id_as_configured(text, metadata_str=NO_METADATA):
+    """The id this text gets at whatever width the run is configured to use."""
+    return IdGenerator().create_source_id(text, metadata_str)
+
+
+class TestCollidingPair:
+    """
+    Preconditions. These are arithmetic about md5, not statements about any
+    configuration. If one stops holding, the pair needs regenerating.
+    """
+
+    def test_the_two_documents_are_different(self):
+        # Guards the rest: every assertion below is worthless if these converge.
+        assert TEXT_A != TEXT_B
+
+    def test_they_share_one_source_id_at_the_legacy_width(self):
+        assert (source_id_at(TEXT_A, LEGACY_WIDTH)
+                == source_id_at(TEXT_B, LEGACY_WIDTH)
+                == COLLIDING_SOURCE_ID)
+
+    def test_a_wider_text_digest_separates_them(self):
+        assert source_id_at(TEXT_A, CANDIDATE_WIDTH) != source_id_at(TEXT_B, CANDIDATE_WIDTH)
+
+    def test_metadata_separates_them_only_when_it_differs(self):
+        # The second component is a digest of the metadata, so it discriminates
+        # only across documents whose metadata is not identical. A corpus loaded
+        # without metadata, or with the same metadata throughout, gets no help
+        # from it however wide it is.
+        shared = 'file_path:corpus.txt'
+        assert (source_id_at(TEXT_A, LEGACY_WIDTH, shared)
+                == source_id_at(TEXT_B, LEGACY_WIDTH, shared))
+        assert (source_id_at(TEXT_A, LEGACY_WIDTH, 'file_path:a.txt')
+                != source_id_at(TEXT_B, LEGACY_WIDTH, 'file_path:b.txt'))
+
+
+class TestCollisionConsequences:
+    """
+    What the shared id costs at the storage layer. These pass today: they
+    characterise the damage rather than assert the fix.
+    """
+
+    def test_one_prefix_reads_back_as_one_document_holding_both(
+        self, download_source_prefix, chunk_node
+    ):
+        # The S3 prefix is the bare source id, so a shared id is a shared prefix
+        # and each document's object lands beside the other's.
+        doc = download_source_prefix({
+            f'{COLLIDING_SOURCE_ID}-aaaaa.jsonl': [chunk_node('a1', COLLIDING_SOURCE_ID)],
+            f'{COLLIDING_SOURCE_ID}-bbbbb.jsonl': [chunk_node('b1', COLLIDING_SOURCE_ID)],
+        })
+
+        # Two documents went in; one comes out, carrying a chunk from each.
+        assert {n.node_id for n in doc.nodes} == {'a1', 'b1'}
+        assert doc.source_id() == COLLIDING_SOURCE_ID
+
+    def test_nothing_reports_the_collision(self, download_source_prefix, chunk_node):
+        # No error, no warning, no marker. A reader cannot tell this document
+        # from one that genuinely had two chunks, which is what makes the
+        # failure silent rather than something a run surfaces.
+        doc = download_source_prefix({
+            f'{COLLIDING_SOURCE_ID}-aaaaa.jsonl': [chunk_node('a1', COLLIDING_SOURCE_ID)],
+            f'{COLLIDING_SOURCE_ID}-bbbbb.jsonl': [chunk_node('b1', COLLIDING_SOURCE_ID)],
+        })
+
+        assert len(doc.nodes) == 2
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Source ids discriminate on 32 bits at the default width. Remove this '
+           'marker when the default is widened; strict=True fails the run once the '
+           'assertions start passing, so the marker cannot outlive the fix.',
+)
+class TestSourceIdUniqueness:
+    """
+    RED. Two distinct documents must be distinguishable by id alone, because
+    every downstream identity derives from it: the S3 prefix above, the
+    `__Source__` node the graph MERGEs on, and every chunk, topic, statement
+    and fact id.
+
+    These read the configured width rather than a pinned one, so they assert
+    that the default is wide enough rather than anything about a given width.
+    """
+
+    def test_distinct_documents_get_distinct_source_ids(self):
+        assert source_id_as_configured(TEXT_A) != source_id_as_configured(TEXT_B)
+
+    def test_distinct_documents_get_distinct_chunk_id_prefixes(self):
+        generator = IdGenerator()
+
+        chunk_a = generator.create_chunk_id(source_id_as_configured(TEXT_A), TEXT_A, NO_METADATA)
+        chunk_b = generator.create_chunk_id(source_id_as_configured(TEXT_B), TEXT_B, NO_METADATA)
+
+        assert chunk_a.rsplit(':', 1)[0] != chunk_b.rsplit(':', 1)[0]

--- a/lexical-graph/tests/unit/indexing/test_source_id_collision.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_collision.py
@@ -15,8 +15,6 @@ separate two documents. That is the case measured in the collision spike and the
 case these tests use.
 """
 
-import pytest
-
 from unittest.mock import Mock
 
 from graphrag_toolkit.lexical_graph.config import SourceIdWidth
@@ -130,11 +128,11 @@ class TestCollisionReachesTheGraph:
 
     @staticmethod
     def _source_node(text):
-        """A source node carrying the id the pipeline would derive from `text`."""
+        """A source node carrying the id `text` gets in a graph written at the legacy width."""
         node = Mock()
         node.metadata = {
             'source': {
-                'sourceId': source_id_as_configured(text),
+                'sourceId': source_id_at(text, LEGACY_WIDTH),
                 'metadata': {'file_path': f'{text}.txt'},
             }
         }
@@ -148,8 +146,8 @@ class TestCollisionReachesTheGraph:
 
     def test_both_documents_merge_on_one_source_id(self):
         # The builder binds the id it is given, unchanged, so two documents that
-        # collide bind one key. Fails once the default width is widened, which
-        # is the point; update it then rather than deleting it.
+        # collide bind one key. Graphs written before the default widened still
+        # carry the legacy width, so they still merge these two.
         calls = self._merge_calls(TEXT_A, TEXT_B)
 
         assert len(calls) == 2
@@ -171,15 +169,9 @@ class TestCollisionReachesTheGraph:
         assert 'ON MATCH SET' in calls[1][0][0]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='Source ids discriminate on 32 bits at the default width. Remove this '
-           'marker when the default is widened; strict=True fails the run once the '
-           'assertions start passing, so the marker cannot outlive the fix.',
-)
 class TestSourceIdUniqueness:
     """
-    RED. Two distinct documents must be distinguishable by id alone, because
+    Two distinct documents must be distinguishable by id alone, because
     every downstream identity derives from it: the S3 prefix above, the
     `__Source__` node the graph MERGEs on, and every chunk, topic, statement
     and fact id.

--- a/lexical-graph/tests/unit/indexing/test_source_id_width.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_width.py
@@ -1,0 +1,281 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+A collection keeps the source id width it was first written with.
+
+Every chunk, topic and statement id is built from the source id, so the same
+document written at two widths becomes two unrelated sets of nodes. A graph
+records its width on first write; a graph written before the record existed
+has its width read back from a sample of stored source ids.
+"""
+
+import pytest
+
+from unittest.mock import Mock, patch
+
+from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo
+
+from graphrag_toolkit.lexical_graph import TenantId, GraphRAGConfig
+from graphrag_toolkit.lexical_graph.config import SourceIdWidth
+from graphrag_toolkit.lexical_graph.indexing.model import SourceDocument
+from graphrag_toolkit.lexical_graph.indexing.source_id_width import (
+    SourceIdWidthMismatchError,
+    SourceIdWidthGuard,
+    graph_source_id_width,
+    record_graph_source_id_width,
+    resolve_source_id_width,
+)
+
+LEGACY, FULL = SourceIdWidth.LEGACY, SourceIdWidth.FULL
+
+LEGACY_ID = 'aws::5eb63bbb:d41d'
+FULL_ID = 'aws::5eb63bbbe01eeed093cb22bb8f5acdc3:d41d'
+
+
+pytestmark = pytest.mark.usefixtures('isolated_source_id_width')
+
+
+class TestResolveSourceIdWidth:
+
+    def test_a_new_collection_takes_the_default(self):
+        assert resolve_source_id_width([], configured=None, default=FULL) is FULL
+
+    def test_a_new_collection_takes_an_explicit_setting(self):
+        assert resolve_source_id_width([], configured=LEGACY, default=FULL) is LEGACY
+
+    def test_an_existing_legacy_collection_stays_legacy(self):
+        assert resolve_source_id_width([LEGACY], configured=None, default=FULL) is LEGACY
+
+    def test_unknown_widths_are_ignored(self):
+        assert resolve_source_id_width([None, LEGACY], configured=None, default=FULL) is LEGACY
+
+    def test_mixed_widths_raise(self):
+        with pytest.raises(SourceIdWidthMismatchError):
+            resolve_source_id_width([LEGACY, FULL], configured=None, default=FULL)
+
+    def test_a_setting_that_contradicts_the_collection_raises(self):
+        # Silently using the stored width would give the caller ids they did
+        # not ask for; silently using the setting would duplicate the collection.
+        with pytest.raises(SourceIdWidthMismatchError):
+            resolve_source_id_width([LEGACY], configured=FULL, default=FULL)
+
+    def test_the_error_names_both_widths(self):
+        with pytest.raises(SourceIdWidthMismatchError, match=r'LEGACY \(8\).*FULL \(32\)'):
+            resolve_source_id_width([LEGACY, FULL], configured=None, default=FULL)
+
+
+def graph_store(record=None, source_id=None, written=None, source_ids=None):
+    """A graph store answering the three queries the width needs."""
+    store = Mock()
+    store.node_id = Mock(side_effect=lambda name: name)
+
+    def execute_query(cypher, parameters={}, **kwargs):
+        if 'MERGE' in cypher:
+            store.recorded = parameters
+            return [{'width': written if written is not None else parameters['width']}]
+        if '__SYS_Config__' in cypher:
+            return [{'width': record}] if record is not None else []
+        if '__Source__' in cypher:
+            ids = source_ids if source_ids is not None else ([source_id] if source_id else [])
+            return [{'sourceId': i} for i in ids]
+        raise AssertionError(f'unexpected query: {cypher}')
+
+    store.execute_query = Mock(side_effect=execute_query)
+    return store
+
+
+class TestGraphSourceIdWidth:
+
+    def test_an_empty_graph_has_no_width(self):
+        assert graph_source_id_width(graph_store()) is None
+
+    def test_the_record_is_authoritative(self):
+        store = graph_store(record=8, source_id=FULL_ID)
+
+        assert graph_source_id_width(store) is LEGACY
+        assert store.execute_query.call_count == 1
+
+    def test_a_record_a_store_returns_as_text_still_parses(self):
+        assert graph_source_id_width(graph_store(record='32')) is FULL
+
+    def test_a_graph_without_a_record_is_read_from_a_stored_source_id(self):
+        assert graph_source_id_width(graph_store(source_id=LEGACY_ID)) is LEGACY
+
+    def test_stored_ids_the_generator_did_not_write_are_skipped(self):
+        store = graph_store(source_ids=['aws:custom-id', LEGACY_ID])
+
+        assert graph_source_id_width(store) is LEGACY
+
+    def test_a_graph_already_holding_two_widths_raises(self):
+        store = graph_store(source_ids=[LEGACY_ID, FULL_ID])
+
+        with pytest.raises(SourceIdWidthMismatchError, match='already holds'):
+            graph_source_id_width(store)
+
+    def test_a_graph_holding_only_foreign_ids_has_no_width(self):
+        assert graph_source_id_width(graph_store(source_ids=['aws:custom-id'])) is None
+
+    def test_recording_writes_the_digest_length(self):
+        store = graph_store()
+
+        record_graph_source_id_width(store, TenantId(), FULL)
+
+        assert store.recorded['width'] == 32
+
+    def test_the_record_is_scoped_to_the_tenant(self):
+        store = graph_store()
+
+        record_graph_source_id_width(store, TenantId('tenant1'), FULL)
+
+        assert 'tenant1' in store.recorded['configId']
+
+    def test_a_record_written_concurrently_at_another_width_raises(self):
+        # MERGE sets the width only on create, so a losing writer reads back
+        # the winner's width rather than overwriting it.
+        with pytest.raises(SourceIdWidthMismatchError):
+            record_graph_source_id_width(graph_store(written=8), TenantId(), FULL)
+
+
+def source_document(source_id):
+    node = TextNode(text='chunk')
+    node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=source_id)
+    return SourceDocument(nodes=[node])
+
+
+def guard(store):
+    return SourceIdWidthGuard(graph_store=store, tenant_id=TenantId())
+
+
+class TestSourceIdWidthGuard:
+
+    def _run(self, store, *source_ids):
+        return list(guard(store)([source_document(s) for s in source_ids]))
+
+    def test_documents_at_the_graph_width_pass_through(self):
+        docs = self._run(graph_store(record=8), LEGACY_ID, LEGACY_ID)
+
+        assert [d.source_id() for d in docs] == [LEGACY_ID, LEGACY_ID]
+
+    def test_a_document_at_another_width_stops_the_build(self):
+        # The case where an S3 collection extracted at one width is built into
+        # a graph written at another.
+        with pytest.raises(SourceIdWidthMismatchError):
+            self._run(graph_store(record=8), FULL_ID)
+
+    def test_the_first_document_into_an_empty_graph_records_its_width(self):
+        store = graph_store()
+
+        self._run(store, FULL_ID)
+
+        assert store.recorded['width'] == 32
+
+    def test_a_graph_that_already_has_a_record_is_not_rewritten(self):
+        store = graph_store(record=32)
+
+        self._run(store, FULL_ID)
+
+        queries = [call[0][0] for call in store.execute_query.call_args_list]
+        assert not any('MERGE' in q for q in queries)
+
+    def test_the_error_names_the_document_and_both_widths(self):
+        with pytest.raises(SourceIdWidthMismatchError) as raised:
+            self._run(graph_store(record=8), FULL_ID)
+
+        assert FULL_ID in str(raised.value)
+        assert 'SOURCE_ID_WIDTH=LEGACY' in str(raised.value)
+
+    def test_mixed_widths_in_one_build_stop_it(self):
+        with pytest.raises(SourceIdWidthMismatchError):
+            self._run(graph_store(), FULL_ID, LEGACY_ID)
+
+    def test_documents_with_foreign_source_ids_pass_through(self):
+        docs = self._run(graph_store(record=8), 'aws:custom-id', '0f8fad5b-d9cb-469f-a165-70867728950e')
+
+        assert len(docs) == 2
+
+    def test_text_nodes_are_checked_and_passed_through_unchanged(self):
+        nodes = [source_document(LEGACY_ID).nodes[0], source_document(LEGACY_ID).nodes[0]]
+
+        out = guard(graph_store(record=8))(nodes)
+
+        assert out == nodes
+
+    def test_a_text_node_at_another_width_stops_the_build(self):
+        nodes = [source_document(FULL_ID).nodes[0]]
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            guard(graph_store(record=8))(nodes)
+
+    def test_a_sized_input_stays_sized(self):
+        # BuildPipeline reads len(inputs) to report batch totals.
+        out = guard(graph_store(record=8))(
+            [source_document(LEGACY_ID)] * 3)
+
+        assert len(out) == 3
+
+    def test_an_unsized_input_stays_lazy(self):
+        docs = iter([source_document(LEGACY_ID)])
+
+        out = guard(graph_store(record=8))(docs)
+
+        assert not hasattr(out, '__len__')
+
+
+class TestConfiguredWidth:
+
+    def test_the_default_is_the_full_digest(self):
+        assert GraphRAGConfig.source_id_width is FULL
+
+    def test_an_unset_width_is_not_an_explicit_setting(self):
+        assert GraphRAGConfig.source_id_width_setting is None
+
+    def test_the_environment_is_an_explicit_setting(self, monkeypatch):
+        monkeypatch.setenv('SOURCE_ID_WIDTH', 'legacy')
+
+        assert GraphRAGConfig.source_id_width_setting is LEGACY
+        assert GraphRAGConfig.source_id_width is LEGACY
+
+    def test_the_setter_is_an_explicit_setting(self):
+        GraphRAGConfig.source_id_width = LEGACY
+
+        assert GraphRAGConfig.source_id_width_setting is LEGACY
+
+
+class TestLexicalGraphIndexWiring:
+    """The index resolves the width before extraction and guards the build."""
+
+    @staticmethod
+    def _index(store):
+        from graphrag_toolkit.lexical_graph.lexical_graph_index import LexicalGraphIndex
+
+        module = 'graphrag_toolkit.lexical_graph.lexical_graph_index'
+        with (
+            patch(f'{module}.GraphStoreFactory.for_graph_store', return_value=store),
+            patch(f'{module}.MultiTenantGraphStore.wrap', return_value=store),
+            patch(f'{module}.VectorStoreFactory.for_vector_store', return_value=Mock()),
+            patch(f'{module}.MultiTenantVectorStore.wrap', return_value=Mock()),
+            patch.object(LexicalGraphIndex, '_configure_extraction_pipeline', return_value=([], [])),
+        ):
+            return LexicalGraphIndex(graph_store='dummy://', vector_store='dummy://')
+
+    def test_extraction_uses_the_width_the_graph_was_written_at(self):
+        index = self._index(graph_store(source_id=LEGACY_ID))
+        module = 'graphrag_toolkit.lexical_graph.lexical_graph_index'
+
+        with patch(f'{module}.ExtractionPipeline.create') as create, \
+             patch(f'{module}.BuildPipeline.create'):
+            index.extract([])
+
+        assert create.call_args.kwargs['source_id_width'] is LEGACY
+
+    def test_building_documents_at_another_width_raises(self):
+        from pipe import Pipe
+        index = self._index(graph_store(record=8))
+        module = 'graphrag_toolkit.lexical_graph.lexical_graph_index'
+
+        with patch(f'{module}.BuildPipeline.create', return_value=Pipe(list)), \
+             patch(f'{module}.GraphConstruction.for_graph_store'), \
+             patch(f'{module}.VectorIndexing.for_vector_store'):
+            with pytest.raises(SourceIdWidthMismatchError):
+                index.build([source_document(FULL_ID)])

--- a/lexical-graph/tests/unit/indexing/test_source_id_width.py
+++ b/lexical-graph/tests/unit/indexing/test_source_id_width.py
@@ -23,6 +23,8 @@ from graphrag_toolkit.lexical_graph.indexing.source_id_width import (
     SourceIdWidthMismatchError,
     SourceIdWidthGuard,
     graph_source_id_width,
+    recorded_source_id_width,
+    sampled_source_id_width,
     record_graph_source_id_width,
     resolve_source_id_width,
 )
@@ -143,14 +145,14 @@ def source_document(source_id):
     return SourceDocument(nodes=[node])
 
 
-def guard(store):
-    return SourceIdWidthGuard(graph_store=store, tenant_id=TenantId())
+def guard(store, configured=None):
+    return SourceIdWidthGuard(graph_store=store, tenant_id=TenantId(), configured=configured)
 
 
 class TestSourceIdWidthGuard:
 
-    def _run(self, store, *source_ids):
-        return list(guard(store)([source_document(s) for s in source_ids]))
+    def _run(self, store, *source_ids, configured=None):
+        return list(guard(store, configured)([source_document(s) for s in source_ids]))
 
     def test_documents_at_the_graph_width_pass_through(self):
         docs = self._run(graph_store(record=8), LEGACY_ID, LEGACY_ID)
@@ -279,3 +281,97 @@ class TestLexicalGraphIndexWiring:
              patch(f'{module}.VectorIndexing.for_vector_store'):
             with pytest.raises(SourceIdWidthMismatchError):
                 index.build([source_document(FULL_ID)])
+
+
+class TestASampledWidthIsRecorded:
+    """
+    A collection written before the record existed is sampled once, then read
+    from its record. Leaving it unrecorded makes the sampling window permanent
+    for exactly the collections the window was a concession to.
+    """
+
+    def test_a_sampled_width_is_written_to_the_record(self):
+        store = graph_store(source_id=LEGACY_ID)
+
+        list(guard(store)([source_document(LEGACY_ID)]))
+
+        assert store.recorded['width'] == LEGACY.value
+
+    def test_the_record_is_written_once_for_a_batch(self):
+        store = graph_store(source_id=LEGACY_ID)
+
+        list(guard(store)([source_document(LEGACY_ID) for _ in range(3)]))
+
+        merges = [c for c in store.execute_query.call_args_list if 'MERGE' in c.args[0]]
+        assert len(merges) == 1
+
+    def test_a_collection_that_already_has_a_record_is_not_rewritten(self):
+        store = graph_store(record=8, source_id=LEGACY_ID)
+
+        list(guard(store)([source_document(LEGACY_ID)]))
+
+        assert not [c for c in store.execute_query.call_args_list if 'MERGE' in c.args[0]]
+
+
+class TestTheGuardHonoursAnExplicitWidth:
+    """
+    A build takes documents it did not extract, so an empty collection would
+    otherwise be stamped with whatever width they carry, and the next run would
+    then fail against the setting the operator never changed.
+    """
+
+    def test_documents_contradicting_the_setting_stop_an_empty_collection(self):
+        with pytest.raises(SourceIdWidthMismatchError) as e:
+            list(guard(graph_store(), configured=FULL)([source_document(LEGACY_ID)]))
+
+        assert 'SOURCE_ID_WIDTH' in str(e.value)
+
+    def test_nothing_is_recorded_when_the_documents_are_refused(self):
+        store = graph_store()
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            list(guard(store, configured=FULL)([source_document(LEGACY_ID)]))
+
+        assert not [c for c in store.execute_query.call_args_list if 'MERGE' in c.args[0]]
+
+    def test_documents_matching_the_setting_are_recorded(self):
+        store = graph_store()
+
+        list(guard(store, configured=LEGACY)([source_document(LEGACY_ID)]))
+
+        assert store.recorded['width'] == LEGACY.value
+
+    def test_an_unset_setting_leaves_the_documents_to_decide(self):
+        store = graph_store()
+
+        list(guard(store, configured=None)([source_document(LEGACY_ID)]))
+
+        assert store.recorded['width'] == LEGACY.value
+
+
+class TestReadingTheRecord:
+
+    def test_every_record_is_read_not_just_the_first(self):
+        store = Mock()
+        store.node_id = Mock(side_effect=lambda name: name)
+        store.execute_query = Mock(return_value=[{'width': 8}, {'width': 32}])
+
+        with pytest.raises(SourceIdWidthMismatchError):
+            recorded_source_id_width(store)
+
+    def test_records_that_agree_resolve(self):
+        store = Mock()
+        store.node_id = Mock(side_effect=lambda name: name)
+        store.execute_query = Mock(return_value=[{'width': 8}, {'width': 8}])
+
+        assert recorded_source_id_width(store) is LEGACY
+
+    def test_a_null_source_id_in_the_sample_is_skipped(self):
+        assert sampled_source_id_width(
+            graph_store(source_ids=[None, LEGACY_ID])) is LEGACY
+
+    def test_a_sample_of_only_null_ids_has_no_width(self):
+        assert sampled_source_id_width(graph_store(source_ids=[None])) is None
+
+    def test_a_record_column_that_comes_back_null_does_not_block_recording(self):
+        record_graph_source_id_width(graph_store(written=None), TenantId(), FULL)


### PR DESCRIPTION
## Description

A source id keeps the first 8 characters of the document's text digest, so a corpus loaded without metadata discriminates on 32 bits and two different documents are given one id after about 30,000 of them. They then share an S3 prefix and merge into one `__Source__` node, with nothing logged or raised. This changes the default to the whole digest, and gives each graph a width it keeps, so an existing graph is not handed a second set of ids for documents it already holds.

A graph records its source id width the first time it is written to, and every run reads that record. A graph written before the record existed has its width read from a sample of stored source ids and then recorded. A document arriving at any other width stops the build with an error naming the document and both widths.

The first two commits are the collision reproducer from #536, which this builds on: the fix removes the `xfail` marker those tests carry.

## Changes

- `IdGenerator` builds source ids from named constants and gains `width_of_source_id`, so the id format is written and read in one place. An id the generator did not write has no width and is left alone.
- New `indexing/source_id_width.py`: resolves the width a run must use, reads and records the width on a graph, and guards a build against documents at another width.
- `LexicalGraphIndex` resolves the width before extraction and runs the guard before the build pipeline.
- `ExtractionPipeline` takes the resolved width instead of reading the configured one.
- `SOURCE_ID_WIDTH` defaults to `FULL`, and a value set explicitly must match the width of the graph being written to.
- `__SYS_Config__` added to the lexical graph labels, so the record is rewritten per tenant like every other node.
- The `xfail` marker is removed from `tests/unit/indexing/test_source_id_collision.py`.

## Problem

Two documents that share a truncated source id are indistinguishable downstream: the S3 prefix is the source id, the graph MERGEs on it, and every chunk, topic and statement id is derived from it. Measured on the current width, 127 pairs collide at 1M documents and 11,762 at 10M.

Related issue (if any): #533

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

Unit tests cover the parser, the resolver, the graph read and record, the guard, and the wiring into `LexicalGraphIndex`. The full unit suite passes at 2,201.

`tests/integration/indexing/test_source_id_width_live.py` runs the same ten checks against a real graph and skips unless `NEO4J_TEST_URI` or `NEPTUNE_GRAPH_TEST_ID` is set. Both stores were run: 10 passed against Neo4j 5 in a container, and 10 passed against a Neptune Analytics graph, which exercises `~id` rather than a property. Each run uses its own tenant and deletes what it wrote.

Multi-tenant behaviour was checked by hand on Neptune: two tenants hold separate records at different widths, and the graph ends up with `__SYS_Config__` and `__SYS_Config__<tenant>__` as separate labels.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [x] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented)

The default width changes, which is a behaviour change, documented here and in the configuration docs. An existing graph keeps its own width, so ingesting into one is unaffected. Two cases do change:

- An extract run that cannot read the target graph, which means a dummy graph store or `ExtractionPipeline` used directly, takes the new default. Building that output into a graph written at the old width stops with the mismatch error. Set `SOURCE_ID_WIDTH=LEGACY` to extract for such a graph.
- Deleting every source leaves the width record in place, so starting again at a different width means deleting that record too.

## Still open

- Code calling `ExtractionPipeline` or `BuildPipeline` directly does not go through the guard, which is wired into `LexicalGraphIndex`.
- The width of a graph with no record is read from the first 100 source ids the store returns, so a graph whose widths already diverge past that window reads as whichever width the sample holds. Every graph written from here on records its width, and the record is read in full.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
