### PR TITLE
[FIX] Run a single-worker pipeline in-process instead of spawning a pool per batch

### DIFF
--- a/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
+++ b/lexical-graph/src/graphrag_toolkit/lexical_graph/indexing/utils/pipeline_utils.py
@@ -53,6 +53,16 @@ def run_pipeline(
         **kwargs
     )
 
+    # One worker has nothing to run in parallel, and a spawned worker costs a
+    # full interpreter start and package import on every call. The build stage
+    # behind extract() calls this once per batch of four documents, so on a
+    # 500-document run that was 125 spawns and about 1.4 s per document.
+    if num_workers == 1:
+        for node_batch in node_batches:
+            for processed_node in transform(node_batch):
+                yield processed_node
+        return
+
     # Use "spawn": a forked worker can inherit a held lock (e.g. a logging
     # thread's) and deadlock. Spawn starts workers from a clean interpreter,
     # which also drops the GraphRAGConfig singleton's programmatically-set

--- a/lexical-graph/tests/unit/indexing/utils/test_pipeline_utils.py
+++ b/lexical-graph/tests/unit/indexing/utils/test_pipeline_utils.py
@@ -161,31 +161,89 @@ class TestRunPipeline:
                 assert results[3].text == "Node 4"
     
     def test_run_pipeline_with_single_worker(self):
-        """Verify run_pipeline works with single worker."""
+        """One worker runs in the calling process: no pool, so no spawn."""
         mock_pipeline = Mock(spec=IngestionPipeline)
         mock_pipeline.transformations = []
         mock_pipeline.cache = None
         mock_pipeline.disable_cache = True
-        
+
         batch = [TextNode(text="Node 1", id_="1")]
         node_batches = [batch]
-        
+
         with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.run_transformations') as mock_transform:
             mock_transform.return_value = batch
-            
+
+            with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.ProcessPoolExecutor') as mock_executor:
+                results = list(run_pipeline(mock_pipeline, node_batches, num_workers=1))
+
+                assert len(results) == 1
+                mock_executor.assert_not_called()
+                mock_transform.assert_called_once()
+                assert mock_transform.call_args.args[0] == batch
+
+    def test_single_worker_passes_cache_and_kwargs_like_the_pool(self):
+        """The in-process path must hand run_transformations the same arguments
+        the pooled transform gets, or one worker would behave differently from two."""
+        mock_cache = Mock()
+        mock_pipeline = Mock(spec=IngestionPipeline)
+        mock_pipeline.transformations = ['t']
+        mock_pipeline.cache = mock_cache
+        mock_pipeline.disable_cache = False
+        batch = [TextNode(text="Node 1", id_="1")]
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.run_transformations') as mock_transform:
+            mock_transform.return_value = batch
+
+            list(run_pipeline(mock_pipeline, [batch], cache_collection="c", num_workers=1, in_place=False, extra="x"))
+
+        kwargs = mock_transform.call_args.kwargs
+        assert kwargs['transformations'] == ['t']
+        assert kwargs['cache'] is mock_cache
+        assert kwargs['cache_collection'] == "c"
+        assert kwargs['in_place'] is False
+        assert kwargs['extra'] == "x"
+
+    def test_single_worker_runs_a_real_transformation_in_process(self):
+        """End to end without mocks: a real transformation, real nodes, and the
+        result, with no process start behind it."""
+        from llama_index.core.schema import TransformComponent
+
+        class Upper(TransformComponent):
+            def __call__(self, nodes, **kwargs):
+                for n in nodes:
+                    n.set_content(n.get_content().upper())
+                return nodes
+
+        pipeline = IngestionPipeline(transformations=[Upper()])
+        batches = [[TextNode(text="a", id_="1")], [TextNode(text="b", id_="2")]]
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.ProcessPoolExecutor') as mock_executor:
+            results = list(run_pipeline(pipeline, batches, num_workers=1))
+
+        assert [n.get_content() for n in results] == ["A", "B"]
+        mock_executor.assert_not_called()
+
+    def test_more_than_one_worker_still_uses_a_spawn_pool(self):
+        """The fork deadlock fix stays in place for the parallel path."""
+        mock_pipeline = Mock(spec=IngestionPipeline)
+        mock_pipeline.transformations = []
+        mock_pipeline.cache = None
+        mock_pipeline.disable_cache = True
+        batch = [TextNode(text="Node 1", id_="1")]
+
+        with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.run_transformations'):
             with patch('graphrag_toolkit.lexical_graph.indexing.utils.pipeline_utils.ProcessPoolExecutor') as mock_executor:
                 mock_pool = MagicMock()
                 mock_pool.__enter__.return_value = mock_pool
                 mock_pool.map.return_value = [batch]
                 mock_executor.return_value = mock_pool
-                
-                results = list(run_pipeline(mock_pipeline, node_batches, num_workers=1))
 
-                assert len(results) == 1
-                mock_executor.assert_called_once()
-                _, call_kwargs = mock_executor.call_args
-                assert call_kwargs['max_workers'] == 1
-                assert call_kwargs['mp_context'].get_start_method() == 'spawn'
+                list(run_pipeline(mock_pipeline, [batch], num_workers=2))
+
+        mock_executor.assert_called_once()
+        _, call_kwargs = mock_executor.call_args
+        assert call_kwargs['max_workers'] == 2
+        assert call_kwargs['mp_context'].get_start_method() == 'spawn'
     
     def test_run_pipeline_passes_config_snapshot_to_workers(self, monkeypatch):
         """run_pipeline must wire the config snapshot into the pool initializer,


### PR DESCRIPTION
## Description

`run_pipeline` builds a fresh spawn-context `ProcessPoolExecutor` on every call, even when `num_workers` is 1. The build stage behind `LexicalGraphIndex.extract()` calls it once per batch of four documents to run a `NullBuilder`, so a 500-document extraction starts 125 interpreters, each importing the package, to pass nodes through unchanged. That is the single-threaded drain measured in #493: about 1.4 s per document that did not move with thread count, worker count, model or storage backend. This runs a single-worker pipeline in the calling process instead. Two or more workers still use the spawn pool, so the fork deadlock fix from #419 stays in place.

## Changes

- `pipeline_utils.run_pipeline`: when `num_workers == 1`, apply the transform to each batch in-process and yield, with no executor.
- Tests: the single-worker test now asserts no pool is created and the transform receives the batch; new tests cover cache and kwargs being passed exactly as the pooled path passes them, a real transformation end to end, and the multi-worker path still using a spawn pool.

## Problem

Every drain measurement in #493 fits one process start per build batch. Measured here, one `run_pipeline` call with nothing to do costs 2.2 to 2.3 s regardless of node count or worker count, and one pool round trip is 0.005 s under fork against 2.27 s under spawn. #419 switched the pool to spawn on 2026-07-23; every drain measurement we have is from after that. On the instance, 11.43 min of drain over 125 batches is 5.5 s per batch, and the other four runs land between 5.6 and 6.8 s per batch.

Per-stage timing of the exact `extract()` pipe, 120 documents, chunker in place of the LLM, on a laptop:

| Stage | Before | After |
|---|---|---|
| extraction pipeline | 2.74 s | 2.69 s |
| handler.accept | 0.10 s | 0.07 s |
| build pipeline | 67.66 s | 0.00 s |
| whole run | 70.49 s | 2.76 s |

Handler output is byte-identical between the two runs (sha256 over every written file).

Related issue (if any): #493

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added (as appropriate)
- [x] Existing tests pass (`pytest`)
- [x] Tested manually (describe below)

The three single-worker tests fail on `main` and pass with the change. Full unit suite: 2,138 passed. The per-stage harness above was run on the change itself, not only with the patch simulated.

Re-run on the instance (2026-09-12, stack `drain-1789186485`): WikiHow, all 5,000 documents, 1 worker, 32 threads, on-demand `us.amazon.nova-2-lite-v1:0`, `ml.m5.4xlarge` + `db.r8g.2xlarge`, S3 doc store, this branch packaged by `build-tests.sh`. Extraction phase 04:25:21 to 04:56:10 (30.8 min). Everything after it, the S3 upload of 5,000 documents and 1,250 build batches, ran from 04:56:10 to 04:56:33: 23 seconds, about 0.005 s per document, against 1.4 s per document before. On the previous code the same 1,250 batches would have been roughly 115 minutes of spawns. Whole run 31.7 min for 5,000 documents on one worker, 158 docs/min, against the 33 docs/min ceiling #493 measured across multiple workers. The 5,000 was unintended: `BENCHMARK_EXTRACT_DOC_LIMIT` is read by the `batch_extract.py` tests, not by `benchmark_extract.py`.

## Checklist

- [x] Code follows existing style and conventions
- [x] License headers present on new files
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented)

Behaviour differences on the single-worker path: exceptions from a transformation now raise where the pipeline runs rather than after the pool shuts down, and with `in_place=True` the transform mutates the caller's node objects instead of pickled copies. Neither caller reads the input nodes after `run_pipeline` returns.

## Not in this PR

`build()` and `extract_and_build()` with real builders still spawn `build_num_workers` processes per batch of four documents. That wants a pool reused across batches and is a separate change.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
